### PR TITLE
[WIP] Port MPEG-TS + Packed Audio AAC transmuxer from TypeScript to Rust (and thus from JS to WebAssembly)

### DIFF
--- a/src/rs-core/lib.rs
+++ b/src/rs-core/lib.rs
@@ -10,6 +10,7 @@ mod parser;
 mod playlist_store;
 mod requester;
 mod segment_selector;
+mod transmux;
 mod utils;
 
 #[unsafe(no_mangle)]

--- a/src/rs-core/transmux/elementary_packet_parser.rs
+++ b/src/rs-core/transmux/elementary_packet_parser.rs
@@ -1,0 +1,352 @@
+// NOTE/TODO: this is a work in progress to re-implement the TypeScript transmuxing logic into Rust,
+// it is being done, from the beginning of the pipeline to its end.
+//
+// None of those files are ready, nor optimized, nor used for the moment. You're very welcome to
+// improve it.
+
+use super::transport_packet_parser::{ParsedTsPacket, PesPacketInfo, Pid, ProgramMapTable};
+
+const H264_STREAM_TYPE: u8 = 0x1b;
+const ADTS_STREAM_TYPE: u8 = 0x0f;
+const METADATA_STREAM_TYPE: u8 = 0x15;
+
+struct MetadataElementaryPacket {
+    tracks: Vec<MetadataElementaryPacketTrack>,
+}
+
+struct MediaElementaryPacket {
+    media_type: ElementaryMediaType,
+    track_id: Pid,
+    data: Vec<u8>,
+    packet_length: Option<u32>,
+    data_alignment_indicator: Option<bool>,
+    pts: Option<u32>,
+    dts: Option<u32>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ElementaryMediaType {
+    Video,
+    Audio,
+    TimedMetadata,
+}
+
+struct MetadataElementaryPacketTrack {
+    base_media_decode_time: u64,
+    id: Pid,
+    codec: &'static str,
+    media_type: ElementaryMediaType,
+}
+
+enum ElementaryPacket {
+    Metadata(MetadataElementaryPacket),
+    Media(MediaElementaryPacket),
+}
+
+#[derive(Clone, Debug, Default)]
+struct ElementaryTrackInfo {
+    data: Vec<PesPacketInfo>,
+    size: u32,
+}
+
+struct ElementaryPacketParser {
+    segment_had_pmt: bool,
+    audio: ElementaryTrackInfo,
+    video: ElementaryTrackInfo,
+    timed_metadata: ElementaryTrackInfo,
+    program_map_table: Option<ProgramMapTable>,
+}
+
+impl ElementaryPacketParser {
+    pub(super) fn new() -> Self {
+        Self {
+            segment_had_pmt: false,
+            audio: ElementaryTrackInfo::default(),
+            video: ElementaryTrackInfo::default(),
+            timed_metadata: ElementaryTrackInfo::default(),
+            program_map_table: None,
+        }
+    }
+
+    /// Identifies M2TS packet types and parses PES packets using metadata
+    /// parsed from the PMT
+    pub(super) fn read_next_packet(&mut self, data: ParsedTsPacket) -> Option<ElementaryPacket> {
+        match data {
+            ParsedTsPacket::Pat(_) => {
+                // we have to wait for the PMT to arrive as well before we
+                // have any meaningful metadata
+            }
+            ParsedTsPacket::Pes(ref info) => {
+                let stream_type = match info.stream_type() {
+                    Some(H264_STREAM_TYPE) => ElementaryMediaType::Video,
+                    Some(ADTS_STREAM_TYPE) => ElementaryMediaType::Audio,
+                    Some(METADATA_STREAM_TYPE) => ElementaryMediaType::TimedMetadata,
+                    _ => {
+                        // ignore unknown stream types
+                        return None;
+                    }
+                };
+
+                // if a new packet is starting, we can flush the completed
+                // packet
+                let mut res: Option<ElementaryPacket> = None;
+                if info.payload_unit_start_indicator() {
+                    res = self.flush_stream(stream_type, true);
+                }
+
+                let stream = match stream_type {
+                    ElementaryMediaType::Video => &mut self.video,
+                    ElementaryMediaType::Audio => &mut self.audio,
+                    ElementaryMediaType::TimedMetadata => &mut self.timed_metadata,
+                };
+
+                // buffer this fragment until we are sure we've received the
+                // complete payload
+                // TODO no need to clone here, we should take back ownership
+                stream.data.push(info.clone());
+                stream.size += info.data().len() as u32;
+                return res;
+            }
+            ParsedTsPacket::Pmt(info) => {
+                let mut packet = MetadataElementaryPacket { tracks: vec![] };
+
+                let program_map_table = info.program_map_table();
+                self.program_map_table = Some(program_map_table.clone());
+
+                // translate audio and video streams to tracks
+                if let Some(pid) = program_map_table.video() {
+                    packet.tracks.push({
+                        MetadataElementaryPacketTrack {
+                            base_media_decode_time: 0,
+                            id: pid,
+                            codec: "avc",
+                            media_type: ElementaryMediaType::Video,
+                        }
+                    });
+                }
+                if let Some(pid) = program_map_table.audio() {
+                    packet.tracks.push({
+                        MetadataElementaryPacketTrack {
+                            base_media_decode_time: 0,
+                            id: pid,
+                            codec: "atds",
+                            media_type: ElementaryMediaType::Audio,
+                        }
+                    });
+                }
+
+                self.segment_had_pmt = true;
+
+                return Some(ElementaryPacket::Metadata(packet));
+            }
+        }
+        None
+    }
+
+    pub(super) fn reset(&mut self) {
+        self.video.size = 0;
+        self.video.data = vec![];
+        self.audio.size = 0;
+        self.audio.data = vec![];
+    }
+
+    fn parse_pes(&mut self, payload: Vec<u8>, pes: &mut MediaElementaryPacket) {
+        if payload.len() < 9 {
+            return;
+        }
+        let start_prefix =
+            ((payload[0] as u32) << 16) | ((payload[1] as u32) << 8) | payload[2] as u32;
+        // In certain live streams, the start of a TS fragment has ts packets
+        // that are frame data that is continuing from the previous fragment. This
+        // is to check that the pes data is the start of a new pes payload
+        if start_prefix != 1 {
+            return;
+        }
+        // get the packet length, this will be 0 for video
+        pes.packet_length = Some(6 + (((payload[4] as u32) << 8) | payload[5] as u32));
+
+        // find out if this packets starts a new keyframe
+        pes.data_alignment_indicator = Some((payload[6] & 0x04) != 0);
+
+        // PES packets may be annotated with a PTS value, or a PTS value
+        // and a DTS value. Determine what combination of values is
+        // available to work with.
+        let pts_dts_flags = payload[7];
+
+        // PTS and DTS are normally stored as a 33-bit number.  Javascript
+        // performs all bitwise operations on 32-bit integers but javascript
+        // supports a much greater range (52-bits) of integer using standard
+        // mathematical operations.
+        // We construct a 31-bit value using bitwise operators over the 31
+        // most significant bits and then multiply by 4 (equal to a left-shift
+        // of 2) before we add the final 2 least significant bits of the
+        // timestamp (equal to an OR.)
+        if pts_dts_flags & 0xc0 != 0 && payload.len() >= 13 {
+            // the PTS and DTS are not written out directly. For information
+            // on how they are encoded, see
+            // http://dvd.sourceforge.net/dvdinfo/pes-hdr.html
+            let mut pts = (((payload[9] & 0x0e) as u32) << 27)
+                | ((payload[10] as u32) << 20)
+                | (((payload[11] & 0xfe) as u32) << 12)
+                | ((payload[12] as u32) << 5)
+                | (((payload[13] & 0xfe) as u32) >> 3);
+            pts *= 4; // Left shift by 2
+            pts += ((payload[13] & 0x06) as u32) >> 1; // OR by the two LSBs
+            pes.pts = Some(pts);
+            pes.dts = pes.pts;
+            if pts_dts_flags & 0x40 != 0 && payload.len() >= 18 {
+                let mut dts = (((payload[14] & 0x0e) as u32) << 27)
+                    | ((payload[15] as u32) << 20)
+                    | (((payload[16] & 0xfe) as u32) << 12)
+                    | ((payload[17] as u32) << 5)
+                    | (((payload[18] & 0xfe) as u32) >> 3);
+                dts *= 4; // Left shift by 2
+                dts += ((payload[18] & 0x06) as u32) >> 1; // OR by the two LSBs
+                pes.dts = Some(dts)
+            }
+        }
+
+        // the data section starts immediately after the PES header.
+        // pes_header_data_length specifies the number of header bytes
+        // that follow the last byte of the field.
+        pes.data = payload[9 + (payload[8] as usize)..].to_owned();
+    }
+
+    /// Pass completely parsed PES packets.
+    fn flush_stream(
+        &mut self,
+        media_type: ElementaryMediaType,
+        force_flush: bool,
+    ) -> Option<ElementaryPacket> {
+        let mut packet_flushable = false;
+
+        let stream = self.track_info_mut(media_type);
+
+        // do nothing if there is not enough buffered data for a complete
+        // PES header
+        if stream.data.is_empty() || stream.size < 9 {
+            return None;
+        }
+        let mut packet = MediaElementaryPacket {
+            media_type,
+            data: vec![],
+            track_id: stream.data[0].pid(),
+            packet_length: None,
+            data_alignment_indicator: None,
+            pts: None,
+            dts: None,
+        };
+
+        // reassemble the packet
+        let mut packet_data = Vec::with_capacity(stream.size as usize);
+        stream.data.iter().for_each(|fragment| {
+            packet_data.extend(fragment.data());
+        });
+
+        // parse assembled packet's PES header
+        self.parse_pes(packet_data, &mut packet);
+
+        let stream = self.track_info_mut(media_type);
+
+        // non-video PES packets MUST have a non-zero PES_packet_length
+        // check that there is enough stream data to fill the packet
+        if media_type == ElementaryMediaType::Video {
+            packet_flushable = packet
+                .packet_length
+                .map(|l| l <= stream.size)
+                .unwrap_or(false);
+        }
+
+        // flush pending packets if the conditions are right
+        if force_flush || packet_flushable {
+            stream.size = 0;
+            stream.data = vec![];
+        }
+
+        // only emit packets that are complete. this is to avoid assembling
+        // incomplete PES packets due to poor segmentation
+        if packet_flushable {
+            Some(ElementaryPacket::Media(packet))
+        } else {
+            None
+        }
+    }
+
+    /**
+     * Flush any remaining input. Video PES packets may be of variable
+     * length. Normally, the start of a new video packet can trigger the
+     * finalization of the previous packet. That is not possible if no
+     * more video is forthcoming, however. In that case, some other
+     * mechanism (like the end of the file) has to be employed. When it is
+     * clear that no additional data is forthcoming, calling this method
+     * will flush the buffered packets.
+     */
+    pub fn flush_streams(&mut self) -> Vec<ElementaryPacket> {
+        let mut res = vec![];
+        if let Some(vid) = self.flush_stream(ElementaryMediaType::Video, false) {
+            res.push(vid);
+        }
+        if let Some(aud) = self.flush_stream(ElementaryMediaType::Audio, false) {
+            res.push(aud);
+        }
+        if let Some(tm) = self.flush_stream(ElementaryMediaType::TimedMetadata, false) {
+            res.push(tm);
+        }
+        res
+    }
+
+    pub fn flush(&mut self) -> Vec<ElementaryPacket> {
+        let mut pmt_packet: Option<MetadataElementaryPacket> = None;
+        // if on flush we haven't had a pmt emitted and we have a
+        // pmt to emit. emit the pmt so that we trigger a trackinfo downstream.
+        if !self.segment_had_pmt {
+            if let Some(ref program_map_table) = self.program_map_table {
+                let mut pmt = MetadataElementaryPacket { tracks: vec![] };
+                // translate audio and video streams to tracks
+                if let Some(vid) = program_map_table.video() {
+                    pmt.tracks.push(MetadataElementaryPacketTrack {
+                        base_media_decode_time: 0,
+                        id: vid,
+                        codec: "avc",
+                        media_type: ElementaryMediaType::Video,
+                    });
+                }
+
+                if let Some(aud) = program_map_table.audio() {
+                    pmt.tracks.push(MetadataElementaryPacketTrack {
+                        base_media_decode_time: 0,
+                        id: aud,
+                        codec: "adts",
+                        media_type: ElementaryMediaType::Audio,
+                    });
+                }
+                pmt_packet = Some(pmt);
+            }
+        }
+
+        self.segment_had_pmt = false;
+        if let Some(pmt) = pmt_packet {
+            let mut res = vec![ElementaryPacket::Metadata(pmt)];
+            res.extend(self.flush_streams());
+            res
+        } else {
+            self.flush_streams()
+        }
+    }
+
+    fn track_info(&mut self, media_type: ElementaryMediaType) -> &ElementaryTrackInfo {
+        match media_type {
+            ElementaryMediaType::Video => &self.video,
+            ElementaryMediaType::Audio => &self.audio,
+            ElementaryMediaType::TimedMetadata => &self.timed_metadata,
+        }
+    }
+
+    fn track_info_mut(&mut self, media_type: ElementaryMediaType) -> &mut ElementaryTrackInfo {
+        match media_type {
+            ElementaryMediaType::Video => &mut self.video,
+            ElementaryMediaType::Audio => &mut self.audio,
+            ElementaryMediaType::TimedMetadata => &mut self.timed_metadata,
+        }
+    }
+}

--- a/src/rs-core/transmux/exp_golomb.rs
+++ b/src/rs-core/transmux/exp_golomb.rs
@@ -1,0 +1,154 @@
+// NOTE/TODO: this is a work in progress to re-implement the TypeScript transmuxing logic into Rust,
+// it is being done, from the beginning of the pipeline to its end.
+//
+// None of those files are ready, nor optimized, nor used for the moment. You're very welcome to
+// improve it.
+
+/// Parser for exponential Golomb codes, a variable-bitwidth number encoding
+/// scheme used by h264.
+///
+/// It is a very simple number encoding:
+///   1. Write down x+1 in binary
+///   2. Count the bits written, subtract one, and write that number of starting zero bits preceding
+///     the previous bit string.
+struct ExpGolomb<'a> {
+    /// The current data that is being read
+    working_data: &'a [u8],
+    /// The number of bytes left to examine in `working_data`
+    /// TODO needed? Why not just "sliding" the `working_data` slice?
+    working_bytes_available: usize,
+    /// The current word being examined. 32 bits maximum here.
+    working_word: u32,
+    /// The number of bits left to examine in the current word
+    working_bits_available: u64,
+}
+
+impl<'a> ExpGolomb<'a> {
+    pub(super) fn new(working_data: &'a [u8]) -> Self {
+        Self {
+            working_data,
+            working_bytes_available: working_data.len(),
+            working_word: 0,
+            working_bits_available: 0,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        8 * self.working_bytes_available
+    }
+
+    pub fn bits_available(&self) -> u64 {
+        8 * (self.working_bytes_available as u64) + self.working_bits_available
+    }
+
+    pub fn load_word(&mut self) {
+        let position = self.working_data.len() - self.working_bytes_available;
+        let available_bytes = usize::min(4, self.working_bytes_available);
+
+        if available_bytes == 0 {
+            self.working_word = 0;
+            return;
+        }
+
+        self.working_word = match available_bytes {
+            4 => {
+                (self.working_data[position] as u32) << 24
+                    | (self.working_data[position + 1] as u32) << 16
+                    | (self.working_data[position + 2] as u32) << 8
+                    | (self.working_data[position + 3] as u32)
+            }
+            3 => {
+                (self.working_data[position] as u32) << 16
+                    | (self.working_data[position + 1] as u32) << 8
+                    | self.working_data[position + 2] as u32
+            }
+            2 => (self.working_data[position] as u32) << 8 | self.working_data[position + 1] as u32,
+            _ => self.working_data[0] as u32,
+        };
+
+        // track the amount of workingData that has been processed
+        self.working_bits_available = (available_bytes as u64) * 8;
+        self.working_bytes_available -= available_bytes;
+    }
+
+    pub fn skip_bits(&mut self, count: u64) {
+        if self.working_bits_available > count {
+            self.working_word <<= count;
+            self.working_bits_available -= count;
+        } else {
+            let mut used_count = count;
+            used_count -= self.working_bits_available;
+            let skip_bytes = used_count / 8;
+            used_count -= skip_bytes * 8;
+            self.working_bytes_available -= skip_bytes as usize;
+            self.load_word();
+            self.working_word <<= used_count;
+            self.working_bits_available -= used_count;
+        }
+    }
+
+    pub fn read_bits(&mut self, size: u64) -> u32 {
+        let mut bits = u64::min(self.working_bits_available, size);
+        let valu = self.working_word >> (32 - bits);
+        self.working_bits_available -= bits;
+        if self.working_bits_available > 0 {
+            self.working_word <<= bits;
+        } else if self.working_bytes_available > 0 {
+            self.load_word();
+        }
+
+        bits = size - bits;
+        if bits > 0 {
+            return (valu << bits) | self.read_bits(bits);
+        }
+        valu
+    }
+
+    pub fn skip_leading_zeros(&mut self) -> u64 {
+        for leading_zero_count in 0..self.working_bits_available {
+            if (self.working_word & (0x80000000 >> leading_zero_count)) != 0 {
+                // the first bit of working word is 1
+                self.working_word <<= leading_zero_count;
+                self.working_bits_available -= leading_zero_count;
+                return leading_zero_count;
+            }
+        }
+
+        // we exhausted workingWord and still have not found a 1
+        let working_bits = self.working_bits_available;
+        self.load_word();
+        working_bits + self.skip_leading_zeros()
+    }
+
+    pub fn skip_unsigned(&mut self) {
+        let skipped = self.skip_leading_zeros();
+        self.skip_bits(1 + skipped);
+    }
+
+    pub fn skip_signed(&mut self) {
+        self.skip_unsigned();
+    }
+
+    pub fn read_unsigned(&mut self) -> u32 {
+        let clz = self.skip_leading_zeros();
+        self.read_bits(clz + 1) - 1
+    }
+
+    pub fn read_signed(&mut self) -> i32 {
+        let valu = self.read_unsigned() as i32; // :int
+        if 0x01 & valu != 0 {
+            // the number is odd if the low order bit is set
+            (1 + valu) >> 1 // add 1 to make it even, and divide by 2
+        } else {
+            -(valu >> 1) // divide by two then make it negative
+        }
+    }
+
+    pub fn read_boolean(&mut self) -> bool {
+        self.read_bits(1) == 1
+    }
+
+    pub fn read_unsigned_byte(&mut self) -> u8 {
+        self.read_bits(8) as u8
+    }
+}

--- a/src/rs-core/transmux/mod.rs
+++ b/src/rs-core/transmux/mod.rs
@@ -1,0 +1,10 @@
+// NOTE/TODO: this is a work in progress to re-implement the TypeScript transmuxing logic into Rust,
+// it is being done, from the beginning of the pipeline to its end.
+//
+// None of those files are ready, nor optimized, nor used for the moment. You're very welcome to
+// improve it.
+
+mod elementary_packet_parser;
+mod exp_golomb;
+mod transport_packet_parser;
+mod transport_stream_splitter;

--- a/src/rs-core/transmux/transport_packet_parser.rs
+++ b/src/rs-core/transmux/transport_packet_parser.rs
@@ -1,0 +1,345 @@
+// NOTE/TODO: this is a work in progress to re-implement the TypeScript transmuxing logic into Rust,
+// it is being done, from the beginning of the pipeline to its end.
+//
+// None of those files are ready, nor optimized, nor used for the moment. You're very welcome to
+// improve it.
+
+const H264_STREAM_TYPE: u8 = 0x1b;
+const ADTS_STREAM_TYPE: u8 = 0x0f;
+const METADATA_STREAM_TYPE: u8 = 0x15;
+
+// PIDs are 13 bits
+pub(super) type Pid = u16;
+
+#[derive(Clone, Debug)]
+pub(super) struct PatPacketInfo {
+    section_number: u8,
+    last_section_number: u8,
+    pmt_pid: Pid,
+    pid: Pid,
+    payload_unit_start_indicator: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct PmtPacketInfo {
+    program_map_table: ProgramMapTable,
+    pid: Pid,
+    payload_unit_start_indicator: bool,
+}
+
+impl PmtPacketInfo {
+    pub(super) fn pid(&self) -> Pid {
+        self.pid
+    }
+    pub(super) fn program_map_table(&self) -> &ProgramMapTable {
+        &self.program_map_table
+    }
+    pub(super) fn payload_unit_start_indicator(&self) -> bool {
+        self.payload_unit_start_indicator
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct PesPacketInfo {
+    stream_type: Option<u8>,
+    data: Vec<u8>,
+    pid: Pid,
+    payload_unit_start_indicator: bool,
+}
+
+impl PesPacketInfo {
+    pub(super) fn pid(&self) -> Pid {
+        self.pid
+    }
+    pub(super) fn data(&self) -> &[u8] {
+        &self.data
+    }
+    pub(super) fn stream_type(&self) -> Option<u8> {
+        self.stream_type
+    }
+    pub(super) fn payload_unit_start_indicator(&self) -> bool {
+        self.payload_unit_start_indicator
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ProgramMapTable {
+    /// PID for audio streams
+    audio: Option<Pid>,
+    /// PID for video streams
+    video: Option<Pid>,
+    /// map pid to stream type for metadata streams
+    timed_metadata: Vec<(Pid, u8)>,
+}
+
+impl ProgramMapTable {
+    pub(super) fn audio(&self) -> Option<Pid> {
+        self.audio
+    }
+    pub(super) fn video(&self) -> Option<Pid> {
+        self.video
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum ParsedTsPacket {
+    Pat(PatPacketInfo),
+    Pmt(PmtPacketInfo),
+    Pes(PesPacketInfo),
+}
+
+/// Accepts an MP2T Transport packet and parses it into legible
+/// information.
+pub(super) struct TransportPacketParser {
+    packets_waiting_for_pmt: Vec<(Vec<u8>, usize, Pid, bool)>,
+    program_map_table: Option<ProgramMapTable>,
+    pmt_pid: Option<Pid>,
+}
+
+impl TransportPacketParser {
+    pub(super) fn new() -> Self {
+        Self {
+            packets_waiting_for_pmt: vec![],
+            program_map_table: None,
+            pmt_pid: None,
+        }
+    }
+
+    /// Parse a new MP2T Transport packet.
+    pub(super) fn parse(&mut self, packet: &[u8]) -> Vec<ParsedTsPacket> {
+        if packet.len() < 4 {
+            return vec![];
+        }
+
+        let mut offset: usize = 4;
+        let payload_unit_start_indicator = packet[1] & 0x40 != 0;
+
+        // pid is a 13-bit field starting at the last bit of packet[1]
+        let mut pid = (packet[1] & 0x1f) as u16;
+        pid <<= 8;
+        pid |= packet[2] as u16;
+
+        // if an adaption field is present, its length is specified by the
+        // fifth byte of the TS packet header. The adaptation field is
+        // used to add stuffing to PES packets that don't fill a complete
+        // TS packet, and to specify some forms of timing and control data
+        // that we do not currently use.
+        if (packet[3] & 0x30) >> 4 > 0x01 {
+            offset += packet[offset] as usize + 1;
+        }
+
+        if offset >= packet.len() {
+            return vec![];
+        }
+
+        // parse the rest of the packet based on the type
+        if pid == 0 {
+            if let Some(packet) =
+                self.parse_psi(&packet[offset..], pid, payload_unit_start_indicator)
+            {
+                vec![packet]
+            } else {
+                vec![]
+            }
+        } else if Some(pid) == self.pmt_pid {
+            let result = if let Some(packet) =
+                self.parse_psi(&packet[offset..], pid, payload_unit_start_indicator)
+            {
+                packet
+            } else {
+                return vec![];
+            };
+            let mut ret = vec![result];
+
+            // if there are any packets waiting for a PMT to be found, process them now
+            while !self.packets_waiting_for_pmt.is_empty() {
+                let waiting = self.packets_waiting_for_pmt.remove(0);
+                ret.push(self.process_pes(&waiting.0, waiting.1, waiting.2, waiting.3));
+            }
+            ret
+        } else if self.program_map_table.is_none() {
+            // When we have not seen a PMT yet, defer further processing of PES packets until one
+            // has been parsed
+            self.packets_waiting_for_pmt.push((
+                packet.to_owned(),
+                offset,
+                pid,
+                payload_unit_start_indicator,
+            ));
+            vec![]
+        } else {
+            vec![self.process_pes(packet, offset, pid, payload_unit_start_indicator)]
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.packets_waiting_for_pmt.clear();
+        self.program_map_table = None;
+    }
+
+    fn parse_psi(
+        &mut self,
+        payload: &[u8],
+        pid: Pid,
+        payload_unit_start_indicator: bool,
+    ) -> Option<ParsedTsPacket> {
+        if payload.is_empty() {
+            return None;
+        }
+        let mut offset = 0;
+
+        // PSI packets may be split into multiple sections and those
+        // sections may be split into multiple packets. If a PSI
+        // section starts in this packet, the payload_unit_start_indicator
+        // will be true and the first byte of the payload will indicate
+        // the offset from the current position to the start of the
+        // section.
+        if payload_unit_start_indicator {
+            offset += (payload[0] as usize) + 1;
+        }
+
+        if offset >= payload.len() {
+            None
+        } else if pid == 0 {
+            self.parse_pat(&payload[offset..], payload_unit_start_indicator)
+        } else {
+            self.parse_pmt(&payload[offset..], pid, payload_unit_start_indicator)
+        }
+    }
+
+    fn parse_pat(
+        &mut self,
+        payload: &[u8],
+        payload_unit_start_indicator: bool,
+    ) -> Option<ParsedTsPacket> {
+        if payload.len() < 12 {
+            return None;
+        }
+        let pat_info = PatPacketInfo {
+            pid: 0,
+            payload_unit_start_indicator,
+            section_number: payload[7],
+            last_section_number: payload[8],
+
+            // skip the PSI header and parse the first PMT entry
+            pmt_pid: (((payload[10] & 0x1f) as u16) << 8) | payload[11] as u16,
+        };
+        self.pmt_pid = Some(pat_info.pmt_pid);
+        Some(ParsedTsPacket::Pat(pat_info))
+    }
+
+    /// Parses out the relevant fields of a Program Map Table (PMT).
+    ///
+    /// - payload - The PMT-specific portion of an MP2T
+    /// packet. The first byte in this array should be the table_id
+    /// field.
+    fn parse_pmt(
+        &mut self,
+        payload: &[u8],
+        pid: Pid,
+        payload_unit_start_indicator: bool,
+    ) -> Option<ParsedTsPacket> {
+        // PMTs can be sent ahead of the time when they should actually
+        // take effect. We don't believe this should ever be the case
+        // for HLS but we'll ignore "forward" PMT declarations if we see
+        // them. Future PMT declarations have the current_next_indicator
+        // set to zero.
+        if payload.len() < 12 || payload[5] & 0x01 == 0 {
+            return None;
+        }
+
+        // overwrite any existing program map table
+        self.program_map_table = Some(ProgramMapTable {
+            audio: None,
+            video: None,
+            timed_metadata: vec![],
+        });
+
+        // the mapping table ends at the end of the current section
+        let section_len = (((payload[1] & 0x0f) as u16) << 8) | payload[2] as u16;
+        let table_end = 3 + section_len as usize - 4;
+
+        // to determine where the table is, we have to figure out how
+        // long the program info descriptors are
+        let program_info_len = (((payload[10] & 0x0f) as u16) << 8) | payload[11] as u16;
+
+        // advance the offset to the first entry in the mapping table
+        let mut offset = 12 + program_info_len as usize;
+        while offset < table_end && offset + 2 < payload.len() {
+            let stream_type = payload[offset];
+            let inner_pid =
+                (((payload[offset + 1] & 0x1f) as u16) << 8) | payload[offset + 2] as u16;
+
+            // only map a single elementary_pid for audio and video stream types
+            // TODO: should this be done for metadata too? for now maintain behavior of
+            //       multiple metadata streams
+            if stream_type == H264_STREAM_TYPE {
+                let pmt = self.program_map_table.as_mut().unwrap();
+                if pmt.video.is_none() {
+                    pmt.video = Some(inner_pid);
+                }
+            } else if stream_type == ADTS_STREAM_TYPE {
+                let pmt = self.program_map_table.as_mut().unwrap();
+                if pmt.audio.is_none() {
+                    pmt.audio = Some(inner_pid);
+                }
+            } else if stream_type == METADATA_STREAM_TYPE {
+                let pmt = self.program_map_table.as_mut().unwrap();
+                // map inner_pid to stream type for metadata streams
+                pmt.timed_metadata.push((inner_pid, stream_type));
+            }
+
+            if offset + 4 >= payload.len() {
+                break;
+            }
+
+            // move to the next table entry
+            // skip past the elementary stream descriptors, if present
+            offset += ((((payload[offset + 3] & 0x0f) as usize) << 8)
+                | (payload[offset + 4]) as usize)
+                + 5;
+        }
+
+        let pmt_info = PmtPacketInfo {
+            pid,
+            payload_unit_start_indicator,
+            program_map_table: self.program_map_table.as_ref().unwrap().clone(),
+        };
+        Some(ParsedTsPacket::Pmt(pmt_info))
+    }
+
+    fn process_pes(
+        &mut self,
+        packet: &[u8],
+        offset: usize,
+        pid: Pid,
+        payload_unit_start_indicator: bool,
+    ) -> ParsedTsPacket {
+        // set the appropriate stream type
+        let stream_type;
+        if Some(pid) == self.program_map_table.as_ref().unwrap().video {
+            stream_type = Some(H264_STREAM_TYPE);
+        } else if Some(pid) == self.program_map_table.as_ref().unwrap().audio {
+            stream_type = Some(ADTS_STREAM_TYPE);
+        } else {
+            // if not video or audio, it is timed-metadata or unknown
+            // if unknown, stream_type will be undefined
+            stream_type = self
+                .program_map_table
+                .as_ref()
+                .unwrap()
+                .timed_metadata
+                .iter()
+                .find(|t| t.0 == pid)
+                .map(|t| t.1);
+        }
+
+        let info = PesPacketInfo {
+            pid,
+            payload_unit_start_indicator,
+            stream_type,
+            data: packet[offset..].to_owned(),
+        };
+        ParsedTsPacket::Pes(info)
+    }
+}

--- a/src/rs-core/transmux/transport_stream_splitter.rs
+++ b/src/rs-core/transmux/transport_stream_splitter.rs
@@ -1,0 +1,106 @@
+// NOTE/TODO: this is a work in progress to re-implement the TypeScript transmuxing logic into Rust,
+// it is being done, from the beginning of the pipeline to its end.
+//
+// None of those files are ready, nor optimized, nor used for the moment. You're very welcome to
+// improve it.
+
+const MP2T_PACKET_LENGTH: usize = 188;
+const SYNC_BYTE: u8 = 0x47;
+
+/// Splits an incoming stream of binary data into single MPEG-2 Transport
+/// Stream packets.
+struct TransportStreamSplitter {
+    input: Vec<u8>,
+    incomplete_packet_buffer: Vec<u8>,
+    bytes_in_incomplete_packet_buffer: usize,
+    start_index: usize,
+    end_index: usize,
+}
+
+impl TransportStreamSplitter {
+    pub(super) fn new() -> Self {
+        Self {
+            input: vec![],
+            incomplete_packet_buffer: Vec::with_capacity(MP2T_PACKET_LENGTH),
+            bytes_in_incomplete_packet_buffer: 0,
+            start_index: 0,
+            end_index: MP2T_PACKET_LENGTH,
+        }
+    }
+
+    pub(super) fn feed(&mut self, bytes: Vec<u8>) {
+        // If there are bytes remaining from the last segment, prepend them to the
+        // bytes that were pushed in
+        if self.bytes_in_incomplete_packet_buffer > 0 {
+            let mut new_input =
+                Vec::with_capacity(bytes.len() + self.bytes_in_incomplete_packet_buffer);
+            new_input.extend(
+                self.incomplete_packet_buffer[0..self.bytes_in_incomplete_packet_buffer].iter(),
+            );
+            new_input.extend(bytes);
+            self.input = new_input;
+            self.bytes_in_incomplete_packet_buffer = 0;
+        } else {
+            self.input = bytes;
+        }
+
+        self.start_index = 0;
+        self.end_index = MP2T_PACKET_LENGTH;
+    }
+
+    pub fn read_next_packet(&mut self) -> (Option<&[u8]>, bool) {
+        if self.input.is_empty() {
+            return (None, true);
+        }
+
+        // While we have enough data for a packet
+        while self.end_index < self.input.len() {
+            // Look for a pair of start and end sync bytes in the data..
+            if self.input[self.start_index] == SYNC_BYTE && self.input[self.end_index] == SYNC_BYTE
+            {
+                // We found a packet so emit it and jump one whole packet forward
+                let data = &self.input[self.start_index..self.end_index];
+                self.start_index += MP2T_PACKET_LENGTH;
+                self.end_index += MP2T_PACKET_LENGTH;
+                let is_ended = self.start_index >= self.input.len();
+                return (Some(data), is_ended);
+            }
+            // If we get here, we have somehow become de-synchronized and we need to step
+            // forward one byte at a time until we find a pair of sync bytes that denote
+            // a packet
+            self.start_index += 1;
+            self.end_index += 1;
+        }
+
+        // If there was some data left over at the end of the segment that couldn't
+        // possibly be a whole packet, keep it because it might be the start of a packet
+        // that continues in the next segment
+        if self.start_index < self.input.len() {
+            // self.incompletePacketBuffer.set(
+            //     self.input.subarray(self.start_index),
+            //     0
+            // );
+            self.bytes_in_incomplete_packet_buffer = self.input.len() - self.start_index;
+        } else {
+            self.bytes_in_incomplete_packet_buffer = 0;
+        }
+        // If the buffer contains a whole packet when we are being flushed, emit it
+        // and empty the buffer. Otherwise hold onto the data because it may be
+        // important for decoding the next segment
+        if self.bytes_in_incomplete_packet_buffer == MP2T_PACKET_LENGTH
+            && self.input[0] == SYNC_BYTE
+        {
+            self.bytes_in_incomplete_packet_buffer = 0;
+            (Some(&self.input[self.start_index..]), true)
+        } else {
+            (None, true)
+        }
+    }
+
+    pub(super) fn reset(&mut self) {
+        self.input.clear();
+        self.bytes_in_incomplete_packet_buffer = 0;
+        self.start_index = 0;
+        self.end_index = MP2T_PACKET_LENGTH;
+    }
+}

--- a/src/ts-main/api.ts
+++ b/src/ts-main/api.ts
@@ -356,14 +356,24 @@ export default class WaspHlsPlayer extends EventEmitter<WaspHlsPlayerEvents> {
     if (this.__worker__ === null) {
       throw new Error("The Player is not initialized or is disposed.");
     }
-    for (const [key, value] of Object.entries(overwrite)) {
+    for (const [key, value] of Object.entries(
+      overwrite as Record<string, unknown>,
+    )) {
       if (value !== undefined) {
-        this.__config__[key as keyof WaspHlsPlayerConfig] = value;
+        if (key in this.__config__) {
+          const typedKey = key as keyof WaspHlsPlayerConfig;
+          (
+            this.__config__ as Record<
+              keyof WaspHlsPlayerConfig,
+              WaspHlsPlayerConfig[keyof WaspHlsPlayerConfig]
+            >
+          )[typedKey] = value as WaspHlsPlayerConfig[keyof WaspHlsPlayerConfig];
+        }
       }
     }
     postMessageToWorker(this.__worker__, {
       type: MainMessageType.UpdateConfig,
-      value: this.__config__,
+      value: overwrite,
     });
   }
 

--- a/src/ts-worker/bindings.ts
+++ b/src/ts-worker/bindings.ts
@@ -61,6 +61,7 @@ import {
   getIsobmfTimeInfo,
 } from "./isobmff-utils.js";
 import postMessageToMain from "./postMessage.js";
+import { recordTransmuxProfile } from "./transmux-profiling.js";
 import {
   createTransmuxer,
   getFmp4Type,
@@ -829,11 +830,12 @@ export function addSourceBuffer(
       if (shouldTransmux(typ)) {
         mimeType = getTransmuxedType(typ, mediaType);
       }
+      const transmuxer = mimeType === typ ? null : createTransmuxer();
       const sourceBufferId = nextSourceBufferId;
       sourceBuffers.push({
         lastInitTrackInfoByTrackId: undefined,
         id: sourceBufferId,
-        transmuxer: mimeType === typ ? null : createTransmuxer(),
+        transmuxer,
         sourceBuffer: null,
         mediaType,
       });
@@ -876,13 +878,14 @@ export function addSourceBuffer(
         mimeType = getTransmuxedType(typ, mediaType);
       }
       const sourceBuffer = mediaSource.addSourceBuffer(mimeType);
+      const transmuxer = mimeType === typ ? null : createTransmuxer();
       const sourceBufferId = nextSourceBufferId;
       const queuedSourceBuffer = new QueuedSourceBuffer(sourceBuffer);
       sourceBuffers.push({
         lastInitTrackInfoByTrackId: undefined,
         id: sourceBufferId,
         sourceBuffer: queuedSourceBuffer,
-        transmuxer: mimeType === typ ? null : createTransmuxer(),
+        transmuxer,
         mediaType,
       });
       contentInfo.mediaSourceObj.nextSourceBufferId++;
@@ -968,6 +971,8 @@ export function appendBuffer(
   const sourceBufferObj = mediaSourceObj.sourceBuffers[sourceBufferObjIdx];
   if (sourceBufferObj.transmuxer !== null) {
     try {
+      const inputBytes = segment.byteLength;
+      const startTime = monotonicNow();
       const dtsHint = combineSafeTimeValue(
         segmentHints.baseDecodeTimeStartHi,
         segmentHints.baseDecodeTimeStartLo,
@@ -982,8 +987,15 @@ export function appendBuffer(
           },
         },
       );
+      const durationMs = monotonicNow() - startTime;
       if (transmuxedData !== null) {
         segment = transmuxedData.data;
+        recordTransmuxProfile({
+          durationMs,
+          inputBytes,
+          outputBytes: transmuxedData.data.byteLength,
+          mediaType: sourceBufferObj.mediaType,
+        });
         if (transmuxedData.timingInfo !== undefined) {
           if (logger.hasLevel(LogLevel.Debug)) {
             const startString = (

--- a/src/ts-worker/globals.ts
+++ b/src/ts-worker/globals.ts
@@ -7,6 +7,11 @@ import type {
 } from "../ts-common/types.ts";
 import type Transmuxer from "../ts-transmux/index.ts";
 import { Dispatcher, type InitOutput, type MediaType } from "../wasm/index.js";
+import {
+  type HiddenTransmuxProfilingConfig,
+  resetTransmuxProfiling,
+  updateTransmuxProfilingConfig,
+} from "./transmux-profiling.ts";
 
 export interface WorkerInitializationOptions {
   hasMseInWorker: boolean;
@@ -36,6 +41,7 @@ class PlayerInstance {
     wasm.wasp_set_logger_level(logLevel);
     const dispatcher = new Dispatcher(opts.initialBandwidth);
     updateDispatcherConfig(dispatcher, config);
+    resetTransmuxProfiling();
     this._instanceInfo = {
       wasm,
       dispatcher,
@@ -50,6 +56,7 @@ class PlayerInstance {
     requestsStore.freeEverything((request) => {
       request.abortController.abort();
     });
+    resetTransmuxProfiling();
   }
 
   public changeContent(content: ContentInfo) {
@@ -59,6 +66,7 @@ class PlayerInstance {
       );
       return;
     }
+    resetTransmuxProfiling();
     this._instanceInfo.content = content;
   }
 
@@ -175,8 +183,9 @@ const I32_MAX_VALUE = 2147483647;
 
 export function updateDispatcherConfig(
   dispatcher: Dispatcher,
-  config: Partial<WaspHlsPlayerConfig>,
+  config: Partial<WaspHlsPlayerConfig> & HiddenTransmuxProfilingConfig,
 ): void {
+  updateTransmuxProfilingConfig(config);
   if (config.bufferGoal !== undefined) {
     dispatcher.set_buffer_goal(config.bufferGoal);
   }

--- a/src/ts-worker/transmux-profiling.ts
+++ b/src/ts-worker/transmux-profiling.ts
@@ -1,0 +1,170 @@
+import { MediaType } from "../ts-common/generatedWasmEnums.ts";
+import logger, { LoggerLevel } from "../ts-common/logger.ts";
+
+export interface HiddenTransmuxProfilingConfig {
+  transmuxProfiling?: boolean;
+  transmuxProfilingSampleSize?: number;
+  transmuxProfilingSlowThreshold?: number;
+}
+
+interface TransmuxProfilingConfig {
+  enabled: boolean;
+  sampleSize: number;
+  slowThreshold: number;
+}
+
+interface TransmuxProfilingTotals {
+  count: number;
+  totalDurationMs: number;
+  maxDurationMs: number;
+  totalInputBytes: number;
+  totalOutputBytes: number;
+}
+
+const DEFAULT_CONFIG: TransmuxProfilingConfig = {
+  enabled: false,
+  sampleSize: 20,
+  slowThreshold: 12,
+};
+
+const currentConfig: TransmuxProfilingConfig = { ...DEFAULT_CONFIG };
+let totals = createEmptyTotals();
+
+function createEmptyTotals(): TransmuxProfilingTotals {
+  return {
+    count: 0,
+    totalDurationMs: 0,
+    maxDurationMs: 0,
+    totalInputBytes: 0,
+    totalOutputBytes: 0,
+  };
+}
+
+function clampPositiveInteger(value: number, fallback: number): number {
+  if (!Number.isFinite(value) || value < 1) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+function clampNonNegativeNumber(value: number, fallback: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function formatBytesPerMs(bytes: number, durationMs: number): string {
+  if (durationMs <= 0) {
+    return "n/a";
+  }
+  return (bytes / durationMs).toFixed(1);
+}
+
+function mediaTypeToString(mediaType: MediaType): string {
+  switch (mediaType) {
+    case MediaType.Audio:
+      return "audio";
+    case MediaType.Video:
+      return "video";
+    default:
+      return "unknown";
+  }
+}
+
+export function updateTransmuxProfilingConfig(
+  config: HiddenTransmuxProfilingConfig,
+): void {
+  const previousEnabled = currentConfig.enabled;
+  if (config.transmuxProfiling !== undefined) {
+    currentConfig.enabled = config.transmuxProfiling;
+  }
+  if (config.transmuxProfilingSampleSize !== undefined) {
+    currentConfig.sampleSize = clampPositiveInteger(
+      config.transmuxProfilingSampleSize,
+      DEFAULT_CONFIG.sampleSize,
+    );
+  }
+  if (config.transmuxProfilingSlowThreshold !== undefined) {
+    currentConfig.slowThreshold = clampNonNegativeNumber(
+      config.transmuxProfilingSlowThreshold,
+      DEFAULT_CONFIG.slowThreshold,
+    );
+  }
+
+  if (currentConfig.enabled !== previousEnabled || !currentConfig.enabled) {
+    resetTransmuxProfiling();
+  }
+
+  if (
+    currentConfig.enabled &&
+    !previousEnabled &&
+    logger.hasLevel(LoggerLevel.Info)
+  ) {
+    logger.info(
+      "[transmux-profile] enabled sampleSize=",
+      currentConfig.sampleSize,
+      "slowThresholdMs=",
+      currentConfig.slowThreshold,
+    );
+  }
+}
+
+export function resetTransmuxProfiling(): void {
+  totals = createEmptyTotals();
+}
+
+export function recordTransmuxProfile(args: {
+  durationMs: number;
+  inputBytes: number;
+  outputBytes: number;
+  mediaType: MediaType;
+}): void {
+  if (!currentConfig.enabled) {
+    return;
+  }
+
+  totals.count += 1;
+  totals.totalDurationMs += args.durationMs;
+  totals.maxDurationMs = Math.max(totals.maxDurationMs, args.durationMs);
+  totals.totalInputBytes += args.inputBytes;
+  totals.totalOutputBytes += args.outputBytes;
+
+  if (
+    args.durationMs >= currentConfig.slowThreshold &&
+    logger.hasLevel(LoggerLevel.Info)
+  ) {
+    logger.info(
+      "[transmux-profile] slow-segment mediaType=",
+      mediaTypeToString(args.mediaType),
+      "durationMs=",
+      args.durationMs.toFixed(2),
+      "inputBytes=",
+      args.inputBytes,
+      "outputBytes=",
+      args.outputBytes,
+    );
+  }
+
+  if (
+    totals.count % currentConfig.sampleSize === 0 &&
+    logger.hasLevel(LoggerLevel.Info)
+  ) {
+    logger.info(
+      "[transmux-profile] summary segments=",
+      totals.count,
+      "avgMs=",
+      (totals.totalDurationMs / totals.count).toFixed(2),
+      "maxMs=",
+      totals.maxDurationMs.toFixed(2),
+      "avgInputBytes=",
+      Math.round(totals.totalInputBytes / totals.count),
+      "avgOutputBytes=",
+      Math.round(totals.totalOutputBytes / totals.count),
+      "avgInputBytesPerMs=",
+      formatBytesPerMs(totals.totalInputBytes, totals.totalDurationMs),
+      "avgOutputBytesPerMs=",
+      formatBytesPerMs(totals.totalOutputBytes, totals.totalDurationMs),
+    );
+  }
+}


### PR DESCRIPTION
__NOTE__: This PR is a work-in-progress still at the very beginning. Most of the code has been almost directly converted manually from TypeScript to Rust so some code may not look idiomatic yet (nor performant at all for that matter).

## Transmuxing and the need for it

The HLS specification defines several allowed formats for media and initialization segments.

Among them,  the `WaspHlsPlayer` supports the three most frequent ones: fmp4, mpeg2-ts and packed audio AAC.

The first one (fmp4) is very well supported amongst browser so may be pushed directly to the browser's `SourceBuffer` for later decoding. However, support is very poor for the other two, leading us to need to transform that data before communicating it to the browser.

That's where the "transmuxer" comes into play. In the `WaspHlsPlayer` it takes either an mpeg2-ts or AAC formatted segment, and basically repackage it into an fmp4 segment for the browser.

This is called transmuxing, an operation generally more performance-sensitive than others in an HLS web player and which also may handle huge chunks of memory - both areas where WebAssembly might be a better tool than JavaScript.

## Previous state

For now, `WaspHlsPlayer`'s transmuxer is written in TypeScript.

This is because it's a fork of [mux.js](https://github.com/videojs/mux.js/)'s own transmuxer for reasons explained [in the corresponding Pull Request](https://github.com/peaBerberian/wasp-hls/pull/4).

On some segments (for example the content with 10 seconds segments found in the demo page), this transmuxer may take several hundreds of milliseconds to parse a single segment on the laptop I tested it on (Its performance is indistinguishable from the original transmuxer's one on that part).
This doesn't block the UI as transmuxing is performed in a WebWorker and thus concurrently, yet it may still be annoying, for example when playing low-latency contents (though when playing low-latency contents we do parse much shorter chunks of data) or when doing an operation - like a seek - where the faster the response, the better (here we might both block the seek operation due to a segment already being parsed, and postpone the next segment pushing)

Moreover, transmuxing is an operation handling huge chunks of data where I would prefer to have a better control on memory management.

## This PR

Consequently, this PR tries to port our TypeScript transmuxer (from the `src/ts-transmux` directory) to Rust (in the `src/rs-core/transmux` directory).

This is a very long ongoing effort, and there's no guarantee that it will actually perform better than the previous one, but still seems like a logical next-step in theory.

As this project is mainly for fun anyway, I decided to go on with it.