### PR TITLE
Handle QuotaExceededError when pushing segments to the SourceBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,15 +280,14 @@ MSE API and buffer handling:
       segments if they are needed again.
 - [x] Discontinuity handling: Automatically skip "holes" in the buffer where
       it is known that no segment will be pushed to fill them.
-- [ ] Freezing handling: Detect when the browser is not making progress in the
-      content despite having media data to play and try to unstuck it.
-      _Priority: average_
-- [ ] Proper handling of `QuotaExceededError` after pushing segments (when low
+- [x] Proper handling of `QuotaExceededError` after pushing segments (when low
       on memory).
       This is generally not needed as the browser should already handle some kind of
       garbage collection but some platforms still may have issues when memory is
       constrained.
-      _Priority: low_
+- [ ] Freezing handling: Detect when the browser is not making progress in the
+      content despite having media data to play and try to unstuck it.
+      _Priority: average_
 
 Tracks:
 

--- a/src/rs-core/bindings/js_functions.rs
+++ b/src/rs-core/bindings/js_functions.rs
@@ -308,7 +308,7 @@ extern "C" {
 
     /// Function to call to indicate that an error arised when removing data from a
     /// `SourceBuffer`.
-    pub fn jsSendRemovedBufferError(fatal: bool, media_type: MediaType, message: &str);
+    pub fn jsSendRemoveBufferError(fatal: bool, media_type: MediaType, message: &str);
 
     /// Function to call to indicate that an uncategorized error happened.
     pub fn jsSendOtherError(fatal: bool, code: OtherErrorCode, message: &str);
@@ -899,6 +899,7 @@ impl From<PushSegmentError> for SegmentParsingErrorCode {
 
 /// Errors that can arise after a SourceBuffer's `appendBuffer` call.
 #[wasm_bindgen]
+#[derive(Eq, PartialEq, Clone, Copy, Debug)]
 pub enum PushedSegmentErrorCode {
     /// We could not push the segment because the `SourceBuffer`'s buffer seems full.
     BufferFull,

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         jsAnnounceVariantUpdate, jsClearTimer, jsSendMediaPlaylistParsingError,
         jsSendMediaPlaylistRequestError, jsSendMultivariantPlaylistParsingError,
         jsSendMultivariantPlaylistRequestError, jsSendOtherError, jsSendPushedSegmentError,
-        jsSendRemovedBufferError, jsSendSegmentParsingError, jsSendSegmentRequestError,
+        jsSendRemoveBufferError, jsSendSegmentParsingError, jsSendSegmentRequestError,
         jsSendSourceBufferCreationError, jsSetMediaSourceDuration, jsStartObservingPlayback,
         jsStopObservingPlayback, jsTimer, jsUpdateContentInfo, AddSourceBufferErrorCode, MediaType,
         MultivariantPlaylistParsingErrorCode, OtherErrorCode, PlaylistNature,
@@ -312,7 +312,7 @@ impl Dispatcher {
         buffered: JsTimeRanges,
     ) {
         self.media_element_ref
-            .on_source_buffer_update(source_buffer_id, buffered);
+            .on_source_buffer_update(source_buffer_id, buffered, true);
     }
 
     /// Method to call when a `SourceBuffer`'s `appendBuffer` call led to an `error` event.
@@ -320,9 +320,45 @@ impl Dispatcher {
         &mut self,
         source_buffer_id: SourceBufferId,
         code: PushedSegmentErrorCode,
+        buffered: JsTimeRanges,
     ) {
+        self.media_element_ref
+            .on_source_buffer_update(source_buffer_id, buffered, false);
+
         match self.media_element_ref.media_type_for(source_buffer_id) {
             Some(mt) => {
+                if code == PushedSegmentErrorCode::BufferFull {
+                    let wanted_pos = self.media_element_ref.wanted_position();
+                    let min_pos = if wanted_pos < 10. {
+                        0.
+                    } else {
+                        wanted_pos - 10.
+                    };
+                    let max_pos = wanted_pos + self.buffer_goal + 10.;
+
+                    let has_segments_to_delete =
+                        self.media_element_ref.inventory(mt).iter().any(|x| {
+                            x.last_buffered_start() < min_pos || x.last_buffered_end() > max_pos
+                        });
+                    if has_segments_to_delete {
+                        Logger::warn(&format!(
+                            "BufferFull error received for {}. Cleaning < {}, > {}.",
+                            mt, min_pos, max_pos
+                        ));
+                        if let (Ok(_), Ok(_)) = (
+                            self.media_element_ref.remove_data(mt, 0., min_pos),
+                            self.media_element_ref.remove_data(mt, max_pos, f64::MAX),
+                        ) {
+                            self.segment_selectors
+                                .restart_from_position(wanted_pos - 0.2);
+                            return;
+                        }
+                    }
+
+                    // TODO Dynamically reduce the buffer goal after repeated
+                    // BufferFull errors?
+                }
+
                 let message = match code {
                     PushedSegmentErrorCode::BufferFull => format!(
                         "The {mt} `SourceBuffer` was full and could not accept anymore segment"
@@ -343,12 +379,18 @@ impl Dispatcher {
     }
 
     /// Method to call when a `SourceBuffer`'s `remove` call led to an `error` event.
-    pub(super) fn on_remove_buffer_error_core(&mut self, source_buffer_id: SourceBufferId) {
+    pub(super) fn on_remove_buffer_error_core(
+        &mut self,
+        source_buffer_id: SourceBufferId,
+        buffered: JsTimeRanges,
+    ) {
+        self.media_element_ref
+            .on_source_buffer_update(source_buffer_id, buffered, false);
         match self.media_element_ref.media_type_for(source_buffer_id) {
             Some(mt) => {
                 let message =
                     &format!("An error happened while calling `remove` on the {mt} `SourceBuffer`");
-                jsSendRemovedBufferError(true, mt, message);
+                jsSendRemoveBufferError(true, mt, message);
             }
             None => jsSendOtherError(
                 true,

--- a/src/rs-core/dispatcher/event_listeners/mod.rs
+++ b/src/rs-core/dispatcher/event_listeners/mod.rs
@@ -134,8 +134,9 @@ impl Dispatcher {
         &mut self,
         source_buffer_id: SourceBufferId,
         code: PushedSegmentErrorCode,
+        buffered: JsTimeRanges,
     ) {
-        self.on_append_buffer_error_core(source_buffer_id, code);
+        self.on_append_buffer_error_core(source_buffer_id, code, buffered);
     }
 
     /// The JS code should call this method when a SourceBuffer emits an `error`
@@ -146,8 +147,12 @@ impl Dispatcher {
     /// * `source_buffer_id` - The identifier given generated when the
     ///   SourceBuffer was created. This allows the `Dispatcher` to identify
     ///   which SourceBuffer actually emitted this event.
-    pub fn on_remove_buffer_error(&mut self, source_buffer_id: SourceBufferId) {
-        self.on_remove_buffer_error_core(source_buffer_id);
+    pub fn on_remove_buffer_error(
+        &mut self,
+        source_buffer_id: SourceBufferId,
+        buffered: JsTimeRanges,
+    ) {
+        self.on_remove_buffer_error_core(source_buffer_id, buffered);
     }
 
     /// The JS code should call this method once regular playback "tick" are enabled

--- a/src/rs-core/media_element/mod.rs
+++ b/src/rs-core/media_element/mod.rs
@@ -523,23 +523,34 @@ impl MediaElementReference {
         &mut self,
         source_buffer_id: SourceBufferId,
         buffered: JsTimeRanges,
+        success: bool,
     ) {
         if let Some(ref mut sb) = self.audio_buffer {
             if sb.id() == source_buffer_id {
-                if let Some(SourceBufferQueueElement::PushMedia((_, id))) = sb.on_operation_end() {
+                let queue_elt = if success {
+                    sb.on_operation_end()
+                } else {
+                    sb.cancel_current_operations()
+                };
+                if let Some(SourceBufferQueueElement::PushMedia((_, id))) = queue_elt {
                     if let Some(media_offset) = self.media_offset {
                         self.audio_inventory
-                            .validate_segment(id, &buffered, media_offset);
+                            .reconcile_push_result(id, &buffered, media_offset, success);
                     }
                 }
             }
         }
         if let Some(ref mut sb) = self.video_buffer {
             if sb.id() == source_buffer_id {
-                if let Some(SourceBufferQueueElement::PushMedia((_, id))) = sb.on_operation_end() {
+                let queue_elt = if success {
+                    sb.on_operation_end()
+                } else {
+                    sb.cancel_current_operations()
+                };
+                if let Some(SourceBufferQueueElement::PushMedia((_, id))) = queue_elt {
                     if let Some(media_offset) = self.media_offset {
                         self.video_inventory
-                            .validate_segment(id, &buffered, media_offset);
+                            .reconcile_push_result(id, &buffered, media_offset, success);
                     }
                 }
             }

--- a/src/rs-core/media_element/segment_inventory.rs
+++ b/src/rs-core/media_element/segment_inventory.rs
@@ -230,19 +230,24 @@ impl SegmentInventory {
         self.inventory = vec![];
     }
 
-    /// Once a segment has been succesfully pushed, you should call `validate_segment` with the
-    /// current `TimeRanges` object from the corresponding MSE `SourceBuffer` and the
-    /// `id` of the segment that has been pushed as arguments, to allow the `SegmentInventory` to
-    /// check the initial place of that segment in the buffer.
+    /// Once a segment push operation has finished, call this method with the
+    /// current `TimeRanges` object from the corresponding MSE `SourceBuffer`
+    /// and the `id` of the segment that had been announced before the push.
     ///
-    /// We talk here about a "correction" because the expected start and end of the segment can be
-    /// a little different from what the lower-level buffer advertise, this is what we're computing
-    /// here.
-    pub(super) fn validate_segment(
+    /// This allows the `SegmentInventory` to reconcile that announced segment
+    /// with the buffered ranges actually reported by the browser, whether the
+    /// push operation succeeded entirely or failed after partially appending
+    /// media data.
+    ///
+    /// We talk here about a "correction" because the expected start and end of
+    /// the segment can be a little different from what the lower-level buffer
+    /// advertises, this is what we're computing here.
+    pub(super) fn reconcile_push_result(
         &mut self,
         seg_id: u64,
         buffered: &JsTimeRanges,
         media_offset: f64,
+        success: bool,
     ) {
         self.synchronize(buffered, media_offset);
         let seg_idx = self
@@ -279,12 +284,21 @@ impl SegmentInventory {
                 });
 
         if media_range.is_none() {
-            let seg = self.inventory.get_mut(seg_idx).unwrap();
-            Logger::warn(&format!(
-                "SI: Buffered range of pushed segment not found (s:{}, e:{})",
-                seg.start, seg.end
-            ));
-            seg.validated = true;
+            let seg = self.inventory.get(seg_idx).unwrap();
+            if success {
+                Logger::warn(&format!(
+                    "SI: Buffered range of pushed segment not found (s:{}, e:{})",
+                    seg.start, seg.end
+                ));
+                let seg = self.inventory.get_mut(seg_idx).unwrap();
+                seg.validated = true;
+            } else {
+                Logger::info(&format!(
+                    "SI: Failed pushed {} segment not found in buffered ranges, removing it from inventory (s:{}, e:{})",
+                    self.media_type, seg.start, seg.end
+                ));
+                self.inventory.remove(seg_idx);
+            }
             return;
         }
         let (media_range_start, media_range_end) = media_range.unwrap();
@@ -393,15 +407,34 @@ impl SegmentInventory {
         let seg = self.inventory.get_mut(seg_idx).unwrap();
         seg.start += start_correction;
         seg.end += end_correction;
-        seg.last_buffered_start = seg.start;
-        seg.last_buffered_end = seg.end;
-        seg.validated = true;
 
         if f64::abs(start_correction) >= 0.05 || f64::abs(end_correction) >= 0.05 {
             Logger::debug(&format!(
                 "SI: corrected {} segment (s:{}, e:{}, cs:{}, ce:{})",
                 self.media_type, seg.start, seg.end, start_correction, end_correction
             ));
+        }
+
+        seg.validated = true;
+        seg.last_buffered_start = seg.start;
+        seg.last_buffered_end = seg.end;
+        if !success {
+            // Push operation failed, let's base ourselves on the current
+            // announced buffered time ranges here.
+            //
+            // In cases where the push operation succeeded, we don't synchronize
+            // right at validation time because there's a very small risk that
+            // the buffered time range is not up-to-date, in which case we might
+            // falsely consider it as garbage-collected by the browser.
+            // Having the same problem when the push operation failed is less
+            // problematic: reloading the segment in such rare conditions is not
+            // that much of an issue - and we would consequently prefer having
+            // the real buffered range sooner.
+            //
+            // TODO This might maybe be improved, as we still want the
+            // `SegmentInventory` to reflect as much as possible the real
+            // buffered time ranges, even when the operation failed.
+            self.synchronize(buffered, media_offset);
         }
     }
 
@@ -710,6 +743,7 @@ impl SegmentInventory {
 
                 if range_end <= curr_seg.last_buffered_start {
                     // That range is before the current segment
+                    // Go to the next range directly
                     return;
                 }
 

--- a/src/rs-core/media_element/source_buffers.rs
+++ b/src/rs-core/media_element/source_buffers.rs
@@ -186,6 +186,33 @@ impl SourceBuffer {
         jsRemoveBuffer(self.id, 0., f64::INFINITY);
     }
 
+    /// SourceBuffers maintain a queue of planned operations such as push and remove to media
+    /// buffers.
+    ///
+    /// In some rare scenarios, we could be left in a situation where all previously scheduled
+    /// operations are cancelled, such as when one of them fails.
+    /// This method allows to empty that SourceBuffer's queue in such situations.
+    pub(super) fn clear_queue(&mut self) {
+        Logger::info(&format!(
+            "Buffer {} ({}): clearing queue.",
+            self.id, self.typ
+        ));
+        self.queue.clear();
+    }
+
+    /// Cancel the current operation and every remaining queued operation.
+    ///
+    /// This should be used when the underlying `SourceBuffer` has failed one
+    /// operation, making the rest of the planned queue unreliable.
+    ///
+    /// Contrary to `on_operation_end`, this intentionally does not trigger any
+    /// success-oriented side effects such as reflushes.
+    pub(super) fn cancel_current_operations(&mut self) -> Option<SourceBufferQueueElement> {
+        let current = self.queue.pop_front();
+        self.clear_queue();
+        current
+    }
+
     /// Indicate to this `SourceBuffer` that the last chronological segment has been pushed.
     pub(super) fn announce_last_segment_pushed(&mut self) {
         self.last_segment_pushed = true;

--- a/src/ts-common/QueuedSourceBuffer.ts
+++ b/src/ts-common/QueuedSourceBuffer.ts
@@ -1,6 +1,19 @@
 import assertNever from "./assertNever";
 import logger from "./logger";
 
+/**
+ * Error raised for queued SourceBuffer operations that were never attempted
+ * because a previous SourceBuffer operation already failed.
+ */
+export class SourceBufferOperationCancelledError extends Error {
+  constructor() {
+    super(
+      "Queued SourceBuffer operation cancelled because a previous operation failed",
+    );
+    this.name = "SourceBufferOperationCancelledError";
+  }
+}
+
 /** List the "operations" a `QueuedSourceBuffer` might perform. */
 export enum SourceBufferOperation {
   /** Pushing new data to the `SourceBuffer`. */
@@ -226,6 +239,12 @@ export default class QueuedSourceBuffer {
 
     if (this._pendingTask !== null) {
       this._pendingTask.reject(error);
+    }
+    this._pendingTask = null;
+    const cancellationError = new SourceBufferOperationCancelledError();
+    while (this._queue.length > 0) {
+      const nextElement = this._queue.shift();
+      nextElement?.reject(cancellationError);
     }
   }
 

--- a/src/ts-common/timeRangesToFloat64Array.ts
+++ b/src/ts-common/timeRangesToFloat64Array.ts
@@ -8,7 +8,7 @@
  */
 export default function timeRangesToFloat64Array(
   timeRanges: TimeRanges,
-): Float64Array {
+): Float64Array<ArrayBuffer> {
   const buffered = new Float64Array(timeRanges.length * 2);
   for (let i = 0; i < timeRanges.length; i++) {
     const offset = i * 2;

--- a/src/ts-common/types.ts
+++ b/src/ts-common/types.ts
@@ -1127,6 +1127,10 @@ export interface SourceBufferOperationSuccessMainMessage {
      * `CreateSourceBufferWorkerMessage`.
      */
     sourceBufferId: SourceBufferId;
+    /**
+     * Buffered TimeRanges at the time of the error once that operation was
+     * validated.
+     */
     buffered: Float64Array;
   };
 }
@@ -1153,6 +1157,11 @@ export interface SourceBufferOperationErrorMainMessage {
     operation: SourceBufferOperation;
     /** If `true` the error is due to the fact that the buffer is full. */
     isBufferFull: boolean;
+    /**
+     * Buffered TimeRanges at the time of the error.
+     * Empty Float64Array if that data cannot be retrieved due to the error.
+     */
+    buffered: Float64Array;
   };
 }
 

--- a/src/ts-main/worker-message-handlers.ts
+++ b/src/ts-main/worker-message-handlers.ts
@@ -2,6 +2,7 @@ import assertNever from "../ts-common/assertNever";
 import logger from "../ts-common/logger";
 import QueuedSourceBuffer, {
   SourceBufferOperation,
+  SourceBufferOperationCancelledError,
 } from "../ts-common/QueuedSourceBuffer";
 import timeRangesToFloat64Array from "../ts-common/timeRangesToFloat64Array";
 import type {
@@ -420,10 +421,24 @@ export function onAppendBufferMessage(
       handleAppendBufferError(err);
     }
     function handleAppendBufferError(err: unknown): void {
+      if (err instanceof SourceBufferOperationCancelledError) {
+        logger.info("API: Ignoring cancelled appendBuffer operation");
+        return;
+      }
       const { message } = getErrorInformation(
         err,
         "Unknown error when appending data to the SourceBuffer",
       );
+      let buffered = new Float64Array([]);
+      try {
+        if (sbObject !== undefined) {
+          buffered = timeRangesToFloat64Array(
+            sbObject.queuedSourceBuffer.getBufferedRanges(),
+          );
+        }
+      } catch (_) {
+        /* ignore error here */
+      }
       postMessageToWorker(worker, {
         type: MainMessageType.SourceBufferOperationError,
         value: {
@@ -433,6 +448,7 @@ export function onAppendBufferMessage(
           operation: SourceBufferOperation.Push,
           isBufferFull:
             err instanceof Error && err.name === "QuotaExceededError",
+          buffered,
         },
       });
     }
@@ -483,10 +499,24 @@ export function onRemoveBufferMessage(
       handleRemoveBufferError(err);
     }
     function handleRemoveBufferError(err: unknown): void {
+      if (err instanceof SourceBufferOperationCancelledError) {
+        logger.info("API: Ignoring cancelled removeBuffer operation");
+        return;
+      }
       const { message } = getErrorInformation(
         err,
         "Unknown error when removing data to the SourceBuffer",
       );
+      let buffered = new Float64Array([]);
+      try {
+        if (sbObject !== undefined) {
+          buffered = timeRangesToFloat64Array(
+            sbObject.queuedSourceBuffer.getBufferedRanges(),
+          );
+        }
+      } catch (_) {
+        /* ignore error here */
+      }
       postMessageToWorker(worker, {
         type: MainMessageType.SourceBufferOperationError,
         value: {
@@ -495,6 +525,7 @@ export function onRemoveBufferMessage(
           message,
           operation: SourceBufferOperation.Remove,
           isBufferFull: false,
+          buffered,
         },
       });
     }

--- a/src/ts-worker/MessageReceiver.ts
+++ b/src/ts-worker/MessageReceiver.ts
@@ -394,17 +394,23 @@ export default function MessageReceiver() {
           ) {
             return;
           }
+          const buffered = new JsTimeRanges(data.value.buffered);
           if (data.value.operation === SourceBufferOperation.Remove) {
-            dispatcher.on_remove_buffer_error(data.value.sourceBufferId);
+            dispatcher.on_remove_buffer_error(
+              data.value.sourceBufferId,
+              buffered,
+            );
           } else if (data.value.isBufferFull) {
             dispatcher.on_append_buffer_error(
               data.value.sourceBufferId,
               PushedSegmentErrorCode.BufferFull,
+              buffered,
             );
           } else {
             dispatcher.on_append_buffer_error(
               data.value.sourceBufferId,
               PushedSegmentErrorCode.UnknownError,
+              buffered,
             );
           }
         }

--- a/src/ts-worker/bindings.ts
+++ b/src/ts-worker/bindings.ts
@@ -1,6 +1,8 @@
 import idGenerator from "../ts-common/idGenerator";
 import logger from "../ts-common/logger";
-import QueuedSourceBuffer from "../ts-common/QueuedSourceBuffer";
+import QueuedSourceBuffer, {
+  SourceBufferOperationCancelledError,
+} from "../ts-common/QueuedSourceBuffer";
 import timeRangesToFloat64Array from "../ts-common/timeRangesToFloat64Array";
 import type {
   AudioTrackInfo,
@@ -961,13 +963,26 @@ export function appendBuffer(
           }
         })
         .catch((err) => {
+          if (err instanceof SourceBufferOperationCancelledError) {
+            logger.info("Worker: Ignoring cancelled appendBuffer operation");
+            return;
+          }
           try {
+            let buffered;
+            try {
+              const timeRange =
+                sourceBufferObj.sourceBuffer.getBufferedRanges();
+              buffered = new JsTimeRanges(timeRangesToFloat64Array(timeRange));
+            } catch (_) {
+              buffered = new JsTimeRanges(new Float64Array([]));
+            }
             if (err instanceof Error && err.name === "QuotaExceededError") {
               playerInstance
                 .getDispatcher()
                 ?.on_append_buffer_error(
                   sourceBufferId,
                   PushedSegmentErrorCode.BufferFull,
+                  buffered,
                 );
             } else {
               playerInstance
@@ -975,6 +990,7 @@ export function appendBuffer(
                 ?.on_append_buffer_error(
                   sourceBufferId,
                   PushedSegmentErrorCode.UnknownError,
+                  buffered,
                 );
             }
           } catch (err2) {
@@ -1048,13 +1064,24 @@ export function removeBuffer(
             logger.error("Error when calling `on_source_buffer_update`", error);
           }
         })
-        .catch(() => {
+        .catch((err) => {
+          if (err instanceof SourceBufferOperationCancelledError) {
+            logger.info("Worker: Ignoring cancelled removeBuffer operation");
+            return;
+          }
+          let buffered;
+          try {
+            const timeRange = sourceBufferObj.sourceBuffer.getBufferedRanges();
+            buffered = new JsTimeRanges(timeRangesToFloat64Array(timeRange));
+          } catch (_) {
+            buffered = new JsTimeRanges(new Float64Array([]));
+          }
           try {
             playerInstance
               .getDispatcher()
-              ?.on_remove_buffer_error(sourceBufferId);
-          } catch (err) {
-            const error = err instanceof Error ? err : "Unknown Error";
+              ?.on_remove_buffer_error(sourceBufferId, buffered);
+          } catch (err2) {
+            const error = err2 instanceof Error ? err2 : "Unknown Error";
             logger.error("Error when calling `on_remove_buffer_error`", error);
           }
         });


### PR DESCRIPTION
`SourceBuffer.prototype.appendBuffer` can optionally throw a `QuotaExceededError` if it has no space left for supplementary segments for the time.

Those errors are relatively rarely encountered, yet possible. To handle it, the general work-around is to wait for a small amount of time before trying again.