### PR TITLE
Handle CHANNELS, CHARACTERISTICS, BIT-DEPTH, SAMPLE-RATE and VIDEO-RANGE playlist attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,11 +345,11 @@ most of them are not needed for playback):
   - [x] LANGUAGE: In audio track selection API
   - [x] ASSOC-LANGUAGE: In audio track selection API
   - [x] NAME: In audio track selection API
-  - [ ] CHANNELS: Not so hard to implement, but I've been too lazy to parse that
+  - [x] CHANNELS: Not so hard to implement, but I've been too lazy to parse that
         specific format from the Multivariant Playlist for now
-  - [ ] CHARACTERISTICS: Soon...
-  - [ ] BIT-DEPTH
-  - [ ] SAMPLE-RATE
+  - [x] CHARACTERISTICS: Soon...
+  - [x] BIT-DEPTH
+  - [x] SAMPLE-RATE
   - [ ] FORCED: As the SUBTITLES TYPE is not handled yet, we don't have to use
         this one
   - [ ] INSTREAM-ID: As the CLOSED-CAPTIONS TYPE is not handled yet, we don't
@@ -367,7 +367,7 @@ most of them are not needed for playback):
   - [x] FRAME-RATE: Used to describe variant in variant selection API
   - [x] SCORE: Considered both to select a variant and to determine if a quality
         is better when "fast-switching".
-  - [ ] VIDEO-RANGE
+  - [x] VIDEO-RANGE
   - [ ] REQ-VIDEO-LAYOUT
   - [ ] STABLE-VARIANT-ID: Not really needed for now (only for content steering?)
   - [ ] AVERAGE-BANDWIDTH: Not used yet. I don't know if it's useful yet for us.

--- a/doc/API/Audio_Track_Selection/getAudioTrackList.md
+++ b/doc/API/Audio_Track_Selection/getAudioTrackList.md
@@ -40,6 +40,30 @@ Each of those objects should contain the following keys (same than for the
 
   For example, an AC-3 5.1 Rendition would have a `channels` attribute set to `6`.
 
+- `characteristics` (`Array.<string> | undefined`): Semantic characteristics
+  linked to that audio track, generally expressed as Uniform Type Identifiers
+  such as accessibility-related metadata or commentary flags.
+
+  `undefined` if unknown or if no such characteristics are announced.
+
+- `bitDepth` (`number | undefined`): If set, the bit depth in bits of the audio
+  samples for every rendition grouped into that audio track.
+
+  `undefined` if unknown or if grouped renditions do not all share the same bit
+  depth.
+
+- `sampleRate` (`number | undefined`): If set, the sample rate in hertz of the
+  audio samples for every rendition grouped into that audio track.
+
+  `undefined` if unknown or if grouped renditions do not all share the same
+  sample rate.
+
+- `bitDepths` (`Array.<number> | undefined`): Distinct bit depths in bits found
+  among the renditions grouped into that audio track.
+
+- `sampleRates` (`Array.<number> | undefined`): Distinct sample rates in hertz
+  found among the renditions grouped into that audio track.
+
 That list of audio tracks is known once the `audioTrackListUpdate`
 [event](../Player_Events.md) is sent for the currently-loaded content, which
 should happen at least once before the content is in the `"Loaded"`

--- a/doc/API/Audio_Track_Selection/getCurrentAudioTrack.md
+++ b/doc/API/Audio_Track_Selection/getCurrentAudioTrack.md
@@ -35,6 +35,22 @@ When set, the returned object has the following properties (same than for a
 
   For example, an AC-3 5.1 Rendition would have a `channels` attribute set to `6`.
 
+- `characteristics` (`Array.<string> | undefined`): Semantic characteristics
+  linked to that audio track, generally expressed as Uniform Type Identifiers
+  such as accessibility-related metadata or commentary flags.
+
+- `bitDepth` (`number | undefined`): If set, the bit depth in bits of the audio
+  samples for every rendition grouped into that audio track.
+
+- `sampleRate` (`number | undefined`): If set, the sample rate in hertz of the
+  audio samples for every rendition grouped into that audio track.
+
+- `bitDepths` (`Array.<number> | undefined`): Distinct bit depths in bits found
+  among the renditions grouped into that audio track.
+
+- `sampleRates` (`Array.<number> | undefined`): Distinct sample rates in hertz
+  found among the renditions grouped into that audio track.
+
 The current audio track should be known once the `audioTrackUpdate`
 [event](../Player_Events.md) is sent for the currently-loaded content, which
 should happen at least once before the content is in the `"Loaded"`

--- a/doc/API/Player_Events.md
+++ b/doc/API/Player_Events.md
@@ -300,6 +300,11 @@ When set to an object, it should contain the following keys:
 
   `undefined` if unknown,
 
+- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
+  range announced for the video data linked to that variant.
+
+  `undefined` if there's no video data.
+
 You can also know at any time the same characteristics of the current variant
 by calling the [`getCurrentVariant`](./Variant_Selection/getCurrentVariant.md)
 method.
@@ -352,6 +357,11 @@ for the `variantUpdate` event):
 
   `undefined` if unknown,
 
+- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
+  range announced for the video data linked to that variant.
+
+  `undefined` if there's no video data.
+
 If that change of lock status led to a change of currently-loaded variant,
 you'll also receive a `variantUpdate` event.
 
@@ -392,6 +402,11 @@ Each object should contain the following keys (same than for the
   combination in that variant, in bits per second.
 
   `undefined` if unknown,
+
+- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
+  range announced for the video data linked to that variant.
+
+  `undefined` if there's no video data.
 
 You can also know at any time the list of available variants by calling the
 [`getVariantList`](./Variant_Selection/getVariantList.md) method.
@@ -437,6 +452,22 @@ When set to an object, it should contain the following keys:
 
   For example, an AC-3 5.1 Rendition would have a `channels` attribute set to `6`.
 
+- `characteristics` (`Array.<string> | undefined`): Semantic characteristics
+  linked to that audio track, generally expressed as Uniform Type Identifiers
+  such as accessibility-related metadata or commentary flags.
+
+- `bitDepth` (`number | undefined`): If set, the bit depth in bits of the audio
+  samples for every rendition grouped into that audio track.
+
+- `sampleRate` (`number | undefined`): If set, the sample rate in hertz of the
+  audio samples for every rendition grouped into that audio track.
+
+- `bitDepths` (`Array.<number> | undefined`): Distinct bit depths in bits found
+  among the renditions grouped into that audio track.
+
+- `sampleRates` (`Array.<number> | undefined`): Distinct sample rates in hertz
+  found among the renditions grouped into that audio track.
+
 You can also know at any time the same characteristics of the current audio
 track by calling the [`getCurrentAudioTrack`](./Audio_Track_Selection/getCurrentAudioTrack.md)
 method.
@@ -477,6 +508,22 @@ Each object should contain the following keys (same than for the
   present in any media data in that audio track.
 
   For example, an AC-3 5.1 Rendition would have a `channels` attribute set to `6`.
+
+- `characteristics` (`Array.<string> | undefined`): Semantic characteristics
+  linked to that audio track, generally expressed as Uniform Type Identifiers
+  such as accessibility-related metadata or commentary flags.
+
+- `bitDepth` (`number | undefined`): If set, the bit depth in bits of the audio
+  samples for every rendition grouped into that audio track.
+
+- `sampleRate` (`number | undefined`): If set, the sample rate in hertz of the
+  audio samples for every rendition grouped into that audio track.
+
+- `bitDepths` (`Array.<number> | undefined`): Distinct bit depths in bits found
+  among the renditions grouped into that audio track.
+
+- `sampleRates` (`Array.<number> | undefined`): Distinct sample rates in hertz
+  found among the renditions grouped into that audio track.
 
 You can also know at any time the list of available audio tracks by calling the
 [`getAudioTrackList`](./Audio_Track_Selection/getAudioTrackList.md) method.

--- a/doc/API/Player_Events.md
+++ b/doc/API/Player_Events.md
@@ -300,10 +300,11 @@ When set to an object, it should contain the following keys:
 
   `undefined` if unknown,
 
-- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
-  range announced for the video data linked to that variant.
+- `videoRange` (`string | undefined`): The dynamic range announced for the
+  video data linked to that variant, as directly signaled through the HLS
+  `VIDEO-RANGE` attribute.
 
-  `undefined` if there's no video data.
+  `undefined` if there's no video data or if that property is not specified.
 
 You can also know at any time the same characteristics of the current variant
 by calling the [`getCurrentVariant`](./Variant_Selection/getCurrentVariant.md)
@@ -357,10 +358,11 @@ for the `variantUpdate` event):
 
   `undefined` if unknown,
 
-- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
-  range announced for the video data linked to that variant.
+- `videoRange` (`string | undefined`): The dynamic range announced for the
+  video data linked to that variant, as directly signaled through the HLS
+  `VIDEO-RANGE` attribute.
 
-  `undefined` if there's no video data.
+  `undefined` if there's no video data or if that property is not specified.
 
 If that change of lock status led to a change of currently-loaded variant,
 you'll also receive a `variantUpdate` event.
@@ -403,10 +405,11 @@ Each object should contain the following keys (same than for the
 
   `undefined` if unknown,
 
-- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
-  range announced for the video data linked to that variant.
+- `videoRange` (`string | undefined`): The dynamic range announced for the
+  video data linked to that variant, as directly signaled through the HLS
+  `VIDEO-RANGE` attribute.
 
-  `undefined` if there's no video data.
+  `undefined` if there's no video data or if that property is not specified.
 
 You can also know at any time the list of available variants by calling the
 [`getVariantList`](./Variant_Selection/getVariantList.md) method.

--- a/doc/API/Variant_Selection/getCurrentVariant.md
+++ b/doc/API/Variant_Selection/getCurrentVariant.md
@@ -36,10 +36,11 @@ When set, the returned object has the following properties (same than for a
 
   `undefined` if unknown,
 
-- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
-  range announced for the video data linked to that variant.
+- `videoRange` (`string | undefined`): The dynamic range announced for the
+  video data linked to that variant, as directly signaled through the HLS
+  `VIDEO-RANGE` attribute.
 
-  `undefined` if there's no video data.
+  `undefined` if there's no video data or if that property is not specified.
 
 The current variant should be known once the `variantUpdate`
 [event](../Player_Events.md) is sent for the currently-loaded content, which

--- a/doc/API/Variant_Selection/getCurrentVariant.md
+++ b/doc/API/Variant_Selection/getCurrentVariant.md
@@ -36,6 +36,11 @@ When set, the returned object has the following properties (same than for a
 
   `undefined` if unknown,
 
+- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
+  range announced for the video data linked to that variant.
+
+  `undefined` if there's no video data.
+
 The current variant should be known once the `variantUpdate`
 [event](../Player_Events.md) is sent for the currently-loaded content, which
 should happen at least once before the content is in the `"Loaded"`

--- a/doc/API/Variant_Selection/getLockedVariant.md
+++ b/doc/API/Variant_Selection/getLockedVariant.md
@@ -38,6 +38,11 @@ Those characteristics are the same than for most other variant API, namely:
 
   `undefined` if unknown,
 
+- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
+  range announced for the video data linked to that variant.
+
+  `undefined` if there's no video data.
+
 Note that `getLockedVariant` won't return its new value synchronously after a
 `lockVariant` call as it is is first processed by the `WaspHlsPlayer`'s
 WebWorker, an inherently asynchronous process. If you want to know when and if

--- a/doc/API/Variant_Selection/getLockedVariant.md
+++ b/doc/API/Variant_Selection/getLockedVariant.md
@@ -38,10 +38,11 @@ Those characteristics are the same than for most other variant API, namely:
 
   `undefined` if unknown,
 
-- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
-  range announced for the video data linked to that variant.
+- `videoRange` (`string | undefined`): The dynamic range announced for the
+  video data linked to that variant, as directly signaled through the HLS
+  `VIDEO-RANGE` attribute.
 
-  `undefined` if there's no video data.
+  `undefined` if there's no video data or if that property is not specified.
 
 Note that `getLockedVariant` won't return its new value synchronously after a
 `lockVariant` call as it is is first processed by the `WaspHlsPlayer`'s

--- a/doc/API/Variant_Selection/getVariantList.md
+++ b/doc/API/Variant_Selection/getVariantList.md
@@ -37,6 +37,11 @@ Each of those objects should contain the following keys:
 
   `undefined` if unknown,
 
+- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
+  range announced for the video data linked to that variant.
+
+  `undefined` if there is no video data linked to that variant.
+
 That list of variants is known once the `variantListUpdate`
 [event](../Player_Events.md) is sent for the currently-loaded content, which
 should happen at least once before the content is in the `"Loaded"`

--- a/doc/API/Variant_Selection/getVariantList.md
+++ b/doc/API/Variant_Selection/getVariantList.md
@@ -37,10 +37,12 @@ Each of those objects should contain the following keys:
 
   `undefined` if unknown,
 
-- `videoRange` (`"SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined`): The dynamic
-  range announced for the video data linked to that variant.
+- `videoRange` (`string | undefined`): The dynamic range announced for the
+  video data linked to that variant, as directly signaled through the HLS
+  `VIDEO-RANGE` attribute.
 
-  `undefined` if there is no video data linked to that variant.
+  `undefined` if there is no video data linked to that variant or if that
+  property is not specified.
 
 That list of variants is known once the `variantListUpdate`
 [event](../Player_Events.md) is sent for the currently-loaded content, which

--- a/src/rs-core/bindings/formatters.rs
+++ b/src/rs-core/bindings/formatters.rs
@@ -1,6 +1,6 @@
 use crate::{
     media_element::SourceBufferCreationError,
-    parser::{AudioTrack, ByteRange, VariantStream, VideoDynamicRange, VideoResolution},
+    parser::{AudioTrack, ByteRange, VariantStream, VideoResolution},
 };
 
 static NULL_RESOLUTION: VideoResolution = VideoResolution::new(0, 0);
@@ -15,16 +15,13 @@ pub(crate) unsafe fn format_variants_info_for_js(variants: &[&VariantStream]) ->
         ret.push(resolution.width());
         ret.push(v.frame_rate().unwrap_or(0.) as u32);
         ret.push(v.bandwidth() as u32);
-        ret.push(if v.has_type(crate::bindings::MediaType::Video) {
-            match v.video_range() {
-                VideoDynamicRange::Sdr => 1,
-                VideoDynamicRange::Hlg => 2,
-                VideoDynamicRange::Pq => 3,
-                VideoDynamicRange::Unknown => 4,
-            }
+        let video_range = if v.has_type(crate::bindings::MediaType::Video) {
+            v.video_range().unwrap_or("")
         } else {
-            0
-        });
+            ""
+        };
+        ret.push(video_range.len() as u32);
+        ret.push(video_range.as_ptr() as u32);
     });
     ret
 }

--- a/src/rs-core/bindings/formatters.rs
+++ b/src/rs-core/bindings/formatters.rs
@@ -1,6 +1,6 @@
 use crate::{
     media_element::SourceBufferCreationError,
-    parser::{AudioTrack, ByteRange, VariantStream, VideoResolution},
+    parser::{AudioTrack, ByteRange, VariantStream, VideoDynamicRange, VideoResolution},
 };
 
 static NULL_RESOLUTION: VideoResolution = VideoResolution::new(0, 0);
@@ -15,6 +15,16 @@ pub(crate) unsafe fn format_variants_info_for_js(variants: &[&VariantStream]) ->
         ret.push(resolution.width());
         ret.push(v.frame_rate().unwrap_or(0.) as u32);
         ret.push(v.bandwidth() as u32);
+        ret.push(if v.has_type(crate::bindings::MediaType::Video) {
+            match v.video_range() {
+                VideoDynamicRange::Sdr => 1,
+                VideoDynamicRange::Hlg => 2,
+                VideoDynamicRange::Pq => 3,
+                VideoDynamicRange::Unknown => 4,
+            }
+        } else {
+            0
+        });
     });
     ret
 }
@@ -83,6 +93,26 @@ pub(crate) unsafe fn format_audio_tracks_for_js(tracks: &[AudioTrack]) -> Vec<u3
         ret.push(name.len() as u32);
         ret.push(name.as_ptr() as u32);
         ret.push(t.channels().unwrap_or(0));
+
+        let characteristics = t.characteristics();
+        ret.push(characteristics.len() as u32);
+        characteristics.iter().for_each(|characteristic| {
+            ret.push(characteristic.len() as u32);
+            ret.push(characteristic.as_ptr() as u32);
+        });
+
+        ret.push(t.bit_depth().unwrap_or(0));
+        ret.push(t.sample_rate().unwrap_or(0));
+
+        let bit_depths = t.bit_depths();
+        ret.push(bit_depths.len() as u32);
+        bit_depths.iter().for_each(|bit_depth| ret.push(*bit_depth));
+
+        let sample_rates = t.sample_rates();
+        ret.push(sample_rates.len() as u32);
+        sample_rates
+            .iter()
+            .for_each(|sample_rate| ret.push(*sample_rate));
     });
     ret
 }

--- a/src/rs-core/parser/audio_track_list.rs
+++ b/src/rs-core/parser/audio_track_list.rs
@@ -1,4 +1,5 @@
 use super::MediaTag;
+use std::collections::BTreeSet;
 use std::ops::{Deref, DerefMut};
 
 /// Allows to translate various `EXT-X-MEDIA` tag found inside a Multivariant Playlist into well
@@ -19,14 +20,15 @@ impl AudioTrackList {
             let language = media.language();
             let assoc_language = media.assoc_language();
             let channels = media.channels();
+            let characteristics = media.characteristics();
 
             // Check if the track already exist in another encoding quality
-            // TODO also check characteristics
             let pos_compat = available_audio_tracks.iter().position(|t| {
                 t.name() == name
                     && t.language() == language
                     && t.assoc_language() == assoc_language
                     && t.channels() == channels
+                    && t.characteristics() == characteristics
             });
 
             if let Some(pos) = pos_compat {
@@ -141,6 +143,60 @@ impl AudioTrack {
     /// Returns the number of channels that audio track outputs
     pub fn channels(&self) -> Option<u32> {
         self.media_tags.first().and_then(|t| t.channels())
+    }
+
+    /// Returns semantic characteristics linked to that audio track.
+    pub fn characteristics(&self) -> &[String] {
+        self.media_tags
+            .first()
+            .map(|t| t.characteristics())
+            .unwrap_or(&[])
+    }
+
+    /// Returns the uniform bit depth linked to that audio track when all
+    /// backing renditions agree on it.
+    pub fn bit_depth(&self) -> Option<u32> {
+        let first = self.media_tags.first()?.bit_depth()?;
+        if self.media_tags.iter().all(|t| t.bit_depth() == Some(first)) {
+            Some(first)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the uniform sample rate linked to that audio track when all
+    /// backing renditions agree on it.
+    pub fn sample_rate(&self) -> Option<u32> {
+        let first = self.media_tags.first()?.sample_rate()?;
+        if self
+            .media_tags
+            .iter()
+            .all(|t| t.sample_rate() == Some(first))
+        {
+            Some(first)
+        } else {
+            None
+        }
+    }
+
+    /// Returns all distinct bit depths seen on backing renditions.
+    pub fn bit_depths(&self) -> Vec<u32> {
+        self.media_tags
+            .iter()
+            .filter_map(|t| t.bit_depth())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    /// Returns all distinct sample rates seen on backing renditions.
+    pub fn sample_rates(&self) -> Vec<u32> {
+        self.media_tags
+            .iter()
+            .filter_map(|t| t.sample_rate())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
     }
 
     /// Returns slice of the various `MediaTag` objects that audio track is associated with.

--- a/src/rs-core/parser/media_tag.rs
+++ b/src/rs-core/parser/media_tag.rs
@@ -1,7 +1,10 @@
 use super::{
     media_playlist::MediaPlaylistParsingError,
     multi_variant_playlist::MediaPlaylistContext,
-    utils::{parse_enumerated_string, parse_quoted_string, skip_attribute_list_value},
+    utils::{
+        parse_comma_separated_list, parse_enumerated_string, parse_quoted_string,
+        skip_attribute_list_value,
+    },
     MediaPlaylist,
 };
 use crate::{utils::url::Url, Logger};
@@ -86,9 +89,18 @@ pub struct MediaTag {
     /// then the `channels` attribute is REQUIRED; otherwise, it is
     /// OPTIONAL.
     channels: Option<u32>,
+
+    /// List of Uniform Type Identifiers describing semantic characteristics of
+    /// the rendition, such as accessibility or commentary-related metadata.
+    characteristics: Vec<String>,
+
+    /// Audio sample bit depth, in bits, when known.
+    bit_depth: Option<u32>,
+
+    /// Audio sample rate, in hertz, when known.
+    sample_rate: Option<u32>,
     // TODO
     // instream_id
-    // characteristics
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -126,7 +138,10 @@ impl MediaTag {
         let mut autoselect = false;
         let mut forced = false;
 
-        let channels: Option<u32> = None;
+        let mut channels: Option<u32> = None;
+        let mut characteristics: Vec<String> = vec![];
+        let mut bit_depth: Option<u32> = None;
+        let mut sample_rate: Option<u32> = None;
 
         let mut offset = "#EXT-X-MEDIA:".len();
         loop {
@@ -138,108 +153,142 @@ impl MediaTag {
                     Logger::warn("Attribute Name not followed by equal sign");
                     break;
                 }
-                Some(idx) => {
-                    match &media_line[offset..offset + idx] {
-                        "TYPE" => {
-                            let (parsed, end_offset) =
-                                parse_enumerated_string(media_line, offset + idx + 1);
-                            offset = end_offset + 1;
-                            match parsed {
-                                "AUDIO" => typ = Some(MediaTagType::Audio),
-                                "VIDEO" => typ = Some(MediaTagType::Video),
-                                "SUBTITLES" => typ = Some(MediaTagType::Subtitles),
-                                "CLOSED-CAPTIONS" => typ = Some(MediaTagType::ClosedCaptions),
-                                x => {
-                                    Logger::warn(&format!("Unrecognized media type: {}", x));
-                                    typ = Some(MediaTagType::Other);
-                                }
-                            };
-                        }
-                        "URI" => {
-                            let (parsed, end_offset) =
-                                parse_quoted_string(media_line, offset + idx + 1);
-                            offset = end_offset + 1;
-                            if let Ok(parsed) = parsed {
-                                url = Some(Url::new(parsed.to_owned()));
-                            } else {
-                                Logger::warn("Unparsable URI value");
+                Some(idx) => match &media_line[offset..offset + idx] {
+                    "TYPE" => {
+                        let (parsed, end_offset) =
+                            parse_enumerated_string(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        match parsed {
+                            "AUDIO" => typ = Some(MediaTagType::Audio),
+                            "VIDEO" => typ = Some(MediaTagType::Video),
+                            "SUBTITLES" => typ = Some(MediaTagType::Subtitles),
+                            "CLOSED-CAPTIONS" => typ = Some(MediaTagType::ClosedCaptions),
+                            x => {
+                                Logger::warn(&format!("Unrecognized media type: {}", x));
+                                typ = Some(MediaTagType::Other);
                             }
-                        }
-                        "GROUP-ID" => {
-                            let (parsed, end_offset) =
-                                parse_quoted_string(media_line, offset + idx + 1);
-                            offset = end_offset + 1;
-                            if let Ok(val) = parsed {
-                                group_id = Some(val.to_owned());
-                            } else {
-                                Logger::warn("Unparsable GROUP-ID value");
-                            }
-                        }
-                        "LANGUAGE" => {
-                            let (parsed, end_offset) =
-                                parse_quoted_string(media_line, offset + idx + 1);
-                            offset = end_offset + 1;
-                            if let Ok(val) = parsed {
-                                language = Some(val.to_owned());
-                            } else {
-                                Logger::warn("Unparsable LANGUAGE value");
-                            }
-                        }
-                        "ASSOC-LANGUAGE" => {
-                            let (parsed, end_offset) =
-                                parse_quoted_string(media_line, offset + idx + 1);
-                            offset = end_offset + 1;
-                            if let Ok(val) = parsed {
-                                assoc_language = Some(val.to_owned());
-                            } else {
-                                Logger::warn("Unparsable ASSOC-LANGUAGE value");
-                            }
-                        }
-                        "NAME" => {
-                            let (parsed, end_offset) =
-                                parse_quoted_string(media_line, offset + idx + 1);
-                            offset = end_offset + 1;
-                            if let Ok(val) = parsed {
-                                name = Some(val.to_owned());
-                            } else {
-                                Logger::warn("Unparsable NAME value");
-                            }
-                        }
-                        "STABLE-RENDITION-ID" => {
-                            let (parsed, end_offset) =
-                                parse_quoted_string(media_line, offset + idx + 1);
-                            offset = end_offset + 1;
-                            if let Ok(val) = parsed {
-                                stable_rendition_id = Some(val.to_owned());
-                            } else {
-                                Logger::warn("Unparsable STABLE-RENDITION-ID value");
-                            }
-                        }
-                        "DEFAULT" => {
-                            let end_offset =
-                                skip_attribute_list_value(media_line, offset + idx + 1);
-                            offset = end_offset + 1;
-                            default = true;
-                        }
-                        "AUTOSELECT" => {
-                            let end_offset =
-                                skip_attribute_list_value(media_line, offset + idx + 1);
-                            offset = end_offset + 1;
-                            autoselect = true;
-                        }
-                        "FORCED" => {
-                            let end_offset =
-                                skip_attribute_list_value(media_line, offset + idx + 1);
-                            offset = end_offset + 1;
-                            forced = true;
-                        }
-                        "CHANNELS" => {
-                            // TODO
-                            offset = skip_attribute_list_value(media_line, offset + idx + 1) + 1;
-                        }
-                        _ => offset = skip_attribute_list_value(media_line, offset + idx + 1) + 1,
+                        };
                     }
-                }
+                    "URI" => {
+                        let (parsed, end_offset) =
+                            parse_quoted_string(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        if let Ok(parsed) = parsed {
+                            url = Some(Url::new(parsed.to_owned()));
+                        } else {
+                            Logger::warn("Unparsable URI value");
+                        }
+                    }
+                    "GROUP-ID" => {
+                        let (parsed, end_offset) =
+                            parse_quoted_string(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        if let Ok(val) = parsed {
+                            group_id = Some(val.to_owned());
+                        } else {
+                            Logger::warn("Unparsable GROUP-ID value");
+                        }
+                    }
+                    "LANGUAGE" => {
+                        let (parsed, end_offset) =
+                            parse_quoted_string(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        if let Ok(val) = parsed {
+                            language = Some(val.to_owned());
+                        } else {
+                            Logger::warn("Unparsable LANGUAGE value");
+                        }
+                    }
+                    "ASSOC-LANGUAGE" => {
+                        let (parsed, end_offset) =
+                            parse_quoted_string(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        if let Ok(val) = parsed {
+                            assoc_language = Some(val.to_owned());
+                        } else {
+                            Logger::warn("Unparsable ASSOC-LANGUAGE value");
+                        }
+                    }
+                    "NAME" => {
+                        let (parsed, end_offset) =
+                            parse_quoted_string(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        if let Ok(val) = parsed {
+                            name = Some(val.to_owned());
+                        } else {
+                            Logger::warn("Unparsable NAME value");
+                        }
+                    }
+                    "STABLE-RENDITION-ID" => {
+                        let (parsed, end_offset) =
+                            parse_quoted_string(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        if let Ok(val) = parsed {
+                            stable_rendition_id = Some(val.to_owned());
+                        } else {
+                            Logger::warn("Unparsable STABLE-RENDITION-ID value");
+                        }
+                    }
+                    "DEFAULT" => {
+                        let end_offset = skip_attribute_list_value(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        default = true;
+                    }
+                    "AUTOSELECT" => {
+                        let end_offset = skip_attribute_list_value(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        autoselect = true;
+                    }
+                    "FORCED" => {
+                        let end_offset = skip_attribute_list_value(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        forced = true;
+                    }
+                    "CHANNELS" => {
+                        let (parsed, end_offset) =
+                            parse_quoted_string(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        if let Ok(val) = parsed {
+                            match val.split('/').next().unwrap_or("").parse::<u32>() {
+                                Ok(parsed_channels) => channels = Some(parsed_channels),
+                                Err(_) => Logger::warn("Unparsable CHANNELS value"),
+                            }
+                        } else {
+                            Logger::warn("Unparsable CHANNELS value");
+                        }
+                    }
+                    "CHARACTERISTICS" => {
+                        let (parsed, end_offset) =
+                            parse_comma_separated_list(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        if let Ok(vals) = parsed {
+                            characteristics = vals.iter().map(|v| (*v).to_owned()).collect();
+                            characteristics.sort();
+                            characteristics.dedup();
+                        } else {
+                            Logger::warn("Unparsable CHARACTERISTICS value");
+                        }
+                    }
+                    "BIT-DEPTH" => {
+                        let (parsed, end_offset) =
+                            parse_enumerated_string(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        match parsed.parse::<u32>() {
+                            Ok(val) => bit_depth = Some(val),
+                            Err(_) => Logger::warn("Unparsable BIT-DEPTH value"),
+                        }
+                    }
+                    "SAMPLE-RATE" => {
+                        let (parsed, end_offset) =
+                            parse_enumerated_string(media_line, offset + idx + 1);
+                        offset = end_offset + 1;
+                        match parsed.parse::<u32>() {
+                            Ok(val) => sample_rate = Some(val),
+                            Err(_) => Logger::warn("Unparsable SAMPLE-RATE value"),
+                        }
+                    }
+                    _ => offset = skip_attribute_list_value(media_line, offset + idx + 1) + 1,
+                },
             }
         }
 
@@ -280,6 +329,9 @@ impl MediaTag {
             autoselect,
             forced,
             channels,
+            characteristics,
+            bit_depth,
+            sample_rate,
         })
     }
 
@@ -342,5 +394,17 @@ impl MediaTag {
 
     pub(crate) fn channels(&self) -> Option<u32> {
         self.channels
+    }
+
+    pub(crate) fn characteristics(&self) -> &[String] {
+        self.characteristics.as_slice()
+    }
+
+    pub(crate) fn bit_depth(&self) -> Option<u32> {
+        self.bit_depth
+    }
+
+    pub(crate) fn sample_rate(&self) -> Option<u32> {
+        self.sample_rate
     }
 }

--- a/src/rs-core/parser/mod.rs
+++ b/src/rs-core/parser/mod.rs
@@ -15,4 +15,4 @@ pub(crate) use multi_variant_playlist::{
     MediaPlaylistPermanentId, MediaPlaylistUpdateError, MultivariantPlaylist,
     MultivariantPlaylistParsingError,
 };
-pub(crate) use variant_stream::{VariantStream, VideoResolution};
+pub(crate) use variant_stream::{VariantStream, VideoDynamicRange, VideoResolution};

--- a/src/rs-core/parser/mod.rs
+++ b/src/rs-core/parser/mod.rs
@@ -15,4 +15,4 @@ pub(crate) use multi_variant_playlist::{
     MediaPlaylistPermanentId, MediaPlaylistUpdateError, MultivariantPlaylist,
     MultivariantPlaylistParsingError,
 };
-pub(crate) use variant_stream::{VariantStream, VideoDynamicRange, VideoResolution};
+pub(crate) use variant_stream::{VariantStream, VideoResolution};

--- a/src/rs-core/parser/variant_stream.rs
+++ b/src/rs-core/parser/variant_stream.rs
@@ -74,10 +74,9 @@ pub struct VariantStream {
     /// Stream with an hdcp_level attribute unless its value is `None`.
     hdcp_level: HdcpLevel,
 
-    /// The dynamic range of the video of this variant stream.
-    /// Clients that do not recognize the attribute value SHOULD NOT select the
-    /// Variant Stream.
-    video_range: VideoDynamicRange,
+    /// The dynamic range of the video of this variant stream, as signaled
+    /// through the HLS `VIDEO-RANGE` attribute.
+    video_range: Option<String>,
 
     /// The value is a list of formats, each associated to a `MediaType`, where
     /// each format specifies a media sample type that is present in one or
@@ -217,33 +216,6 @@ enum HdcpLevel {
     Unknown,
 }
 
-/// Indicate the dynamic range of the video track(s) of the concerned content.
-#[derive(Copy, Clone, Debug)]
-pub(crate) enum VideoDynamicRange {
-    /// The video in the corresponding content is encoded using one of the
-    /// following reference opto-electronic transfer characteristic functions
-    /// specified by the TransferCharacteristics code point: [CICP] 1, 6, 13,
-    /// 14, 15.
-    /// Note that different TransferCharacteristics code points can use the
-    /// same transfer function.
-    Sdr,
-
-    /// The video in the corresponding content is encoded using a reference
-    /// opto-electronic transfer characteristic function specified by the
-    /// TransferCharacteristics code point 18, or consists of such video mixed
-    /// with video qualifying as `Sdr` (see above).
-    Hlg,
-
-    /// The video in the corresponding content is encoded using a reference
-    /// opto-electronic transfer characteristic function specified by the
-    /// TransferCharacteristics code point 16, or consists of such video mixed
-    /// with video qualifying as Sdr or Hlg (see above).
-    Pq,
-
-    /// The video dynamic range of the current content is any other.
-    Unknown,
-}
-
 #[derive(Debug)]
 pub enum VariantParsingError {
     MissingBandwidth,
@@ -291,8 +263,8 @@ impl VariantStream {
         self.frame_rate
     }
 
-    pub(crate) fn video_range(&self) -> VideoDynamicRange {
-        self.video_range
+    pub(crate) fn video_range(&self) -> Option<&str> {
+        self.video_range.as_deref()
     }
 
     pub(crate) fn id(&self) -> u32 {
@@ -349,7 +321,7 @@ impl VariantStream {
         let mut average_bandwitdh: Option<u64> = None;
         let mut codecs: Vec<(Option<MediaType>, String)> = vec![];
         let mut hdcp_level: HdcpLevel = HdcpLevel::None;
-        let mut video_range: VideoDynamicRange = VideoDynamicRange::Sdr;
+        let mut video_range: Option<String> = None;
         let mut program_id: Option<u64> = None;
         let mut score: Option<f64> = None;
         let mut frame_rate: Option<f64> = None;
@@ -516,12 +488,7 @@ impl VariantStream {
                         let (parsed, end_offset) =
                             parse_enumerated_string(variant_line, offset + idx + 1);
                         offset = end_offset + 1;
-                        video_range = match parsed {
-                            "SDR" => VideoDynamicRange::Sdr,
-                            "HLG" => VideoDynamicRange::Hlg,
-                            "PQ" => VideoDynamicRange::Pq,
-                            _ => VideoDynamicRange::Unknown,
-                        };
+                        video_range = Some(parsed.to_owned());
                     }
                     "PATHWAY-ID" => {
                         let (parsed, end_offset) =

--- a/src/rs-core/parser/variant_stream.rs
+++ b/src/rs-core/parser/variant_stream.rs
@@ -219,7 +219,7 @@ enum HdcpLevel {
 
 /// Indicate the dynamic range of the video track(s) of the concerned content.
 #[derive(Copy, Clone, Debug)]
-enum VideoDynamicRange {
+pub(crate) enum VideoDynamicRange {
     /// The video in the corresponding content is encoded using one of the
     /// following reference opto-electronic transfer characteristic functions
     /// specified by the TransferCharacteristics code point: [CICP] 1, 6, 13,
@@ -289,6 +289,10 @@ impl VariantStream {
 
     pub(crate) fn frame_rate(&self) -> Option<f64> {
         self.frame_rate
+    }
+
+    pub(crate) fn video_range(&self) -> VideoDynamicRange {
+        self.video_range
     }
 
     pub(crate) fn id(&self) -> u32 {

--- a/src/ts-common/types.ts
+++ b/src/ts-common/types.ts
@@ -459,6 +459,7 @@ export interface VariantInfo {
   height: number | undefined;
   frameRate: number | undefined;
   bandwidth: number | undefined;
+  videoRange?: "SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined;
 }
 
 export interface AudioTrackInfo {
@@ -467,6 +468,11 @@ export interface AudioTrackInfo {
   assocLanguage?: string | undefined;
   name: string;
   channels?: number | undefined;
+  characteristics?: string[] | undefined;
+  bitDepth?: number | undefined;
+  sampleRate?: number | undefined;
+  bitDepths?: number[] | undefined;
+  sampleRates?: number[] | undefined;
 }
 
 /**

--- a/src/ts-common/types.ts
+++ b/src/ts-common/types.ts
@@ -459,7 +459,7 @@ export interface VariantInfo {
   height: number | undefined;
   frameRate: number | undefined;
   bandwidth: number | undefined;
-  videoRange?: "SDR" | "HLG" | "PQ" | "UNKNOWN" | undefined;
+  videoRange?: string | undefined;
 }
 
 export interface AudioTrackInfo {

--- a/src/ts-worker/bindings.ts
+++ b/src/ts-worker/bindings.ts
@@ -1225,22 +1225,6 @@ export function announceFetchedContent(
   }
   const variantInfoObj: VariantInfo[] = [];
   {
-    const toVideoRange = (
-      videoRangeCode: number,
-    ): VariantInfo["videoRange"] => {
-      switch (videoRangeCode) {
-        case 1:
-          return "SDR";
-        case 2:
-          return "HLG";
-        case 3:
-          return "PQ";
-        case 4:
-          return "UNKNOWN";
-        default:
-          return undefined;
-      }
-    };
     let i = 0;
     i++; // Skip number of variants
     while (i < variantInfo.length) {
@@ -1259,8 +1243,15 @@ export function announceFetchedContent(
       const bandwidth = variantInfo[i];
       i++;
 
-      const videoRangeCode = variantInfo[i];
+      const videoRangeLen = variantInfo[i];
       i++;
+      const videoRangeU8 = new Uint8Array(
+        memory.buffer,
+        variantInfo[i],
+        videoRangeLen,
+      );
+      i++;
+      const videoRange = cachedTextDecoder.decode(videoRangeU8);
 
       variantInfoObj.push({
         id,
@@ -1268,7 +1259,7 @@ export function announceFetchedContent(
         width: width === 0 ? undefined : width,
         frameRate: frameRate === 0 ? undefined : frameRate,
         bandwidth: bandwidth === 0 ? undefined : bandwidth,
-        videoRange: toVideoRange(videoRangeCode),
+        videoRange: videoRange === "" ? undefined : videoRange,
       });
     }
   }

--- a/src/ts-worker/bindings.ts
+++ b/src/ts-worker/bindings.ts
@@ -1225,6 +1225,22 @@ export function announceFetchedContent(
   }
   const variantInfoObj: VariantInfo[] = [];
   {
+    const toVideoRange = (
+      videoRangeCode: number,
+    ): VariantInfo["videoRange"] => {
+      switch (videoRangeCode) {
+        case 1:
+          return "SDR";
+        case 2:
+          return "HLG";
+        case 3:
+          return "PQ";
+        case 4:
+          return "UNKNOWN";
+        default:
+          return undefined;
+      }
+    };
     let i = 0;
     i++; // Skip number of variants
     while (i < variantInfo.length) {
@@ -1243,12 +1259,16 @@ export function announceFetchedContent(
       const bandwidth = variantInfo[i];
       i++;
 
+      const videoRangeCode = variantInfo[i];
+      i++;
+
       variantInfoObj.push({
         id,
         height: height === 0 ? undefined : height,
         width: width === 0 ? undefined : width,
         frameRate: frameRate === 0 ? undefined : frameRate,
         bandwidth: bandwidth === 0 ? undefined : bandwidth,
+        videoRange: toVideoRange(videoRangeCode),
       });
     }
   }
@@ -1289,12 +1309,55 @@ export function announceFetchedContent(
       const channels = audioTracksInfo[i];
       i++;
 
+      const characteristicsCount = audioTracksInfo[i];
+      i++;
+      const characteristics: string[] = [];
+      for (let j = 0; j < characteristicsCount; j++) {
+        const characteristicLen = audioTracksInfo[i];
+        i++;
+        const characteristicU8 = new Uint8Array(
+          memory.buffer,
+          audioTracksInfo[i],
+          characteristicLen,
+        );
+        i++;
+        characteristics.push(cachedTextDecoder.decode(characteristicU8));
+      }
+
+      const bitDepth = audioTracksInfo[i];
+      i++;
+
+      const sampleRate = audioTracksInfo[i];
+      i++;
+
+      const bitDepthCount = audioTracksInfo[i];
+      i++;
+      const bitDepths: number[] = [];
+      for (let j = 0; j < bitDepthCount; j++) {
+        bitDepths.push(audioTracksInfo[i]);
+        i++;
+      }
+
+      const sampleRateCount = audioTracksInfo[i];
+      i++;
+      const sampleRates: number[] = [];
+      for (let j = 0; j < sampleRateCount; j++) {
+        sampleRates.push(audioTracksInfo[i]);
+        i++;
+      }
+
       audioTracksObj.push({
         id,
         language: language === "" ? undefined : language,
         assocLanguage: assocLanguage === "" ? undefined : assocLanguage,
         name,
-        channels,
+        channels: channels === 0 ? undefined : channels,
+        characteristics:
+          characteristics.length === 0 ? undefined : characteristics,
+        bitDepth: bitDepth === 0 ? undefined : bitDepth,
+        sampleRate: sampleRate === 0 ? undefined : sampleRate,
+        bitDepths: bitDepths.length === 0 ? undefined : bitDepths,
+        sampleRates: sampleRates.length === 0 ? undefined : sampleRates,
       });
     }
   }


### PR DESCRIPTION
This adds what effectively is more signaling to the API.
It is relatively straightforward (parse from the playlist, then find a way to associate it to one of the API concepts).

Only complexity that I'm not sure about is API shape.
In particular:
- Here the corresponding individual items from the `characteristics` attribute from an audio track keep the same semantics than in the HLS spec. E.g. audio description can become `["public.accessibility.transcribes-spoken-dialog", "public.accessibility.describes-music-and-sound"]`
 
   The pro is that we don't lose anything from the source, and as the player is HLS-only here, there's no real need to find a sort of "consensus concept", re-using HLS concepts directly is oK.

   The con is that it may be awkward to handle for applications, which are generally not avid readers of RFCs (even one as readable as HLS', as opposed to... the specs for the other big one)

- I just put `bitDepths` and `sampleRates`, that presumably most application won't care at all about, in an array in that audio track (in case where an "audio track" - which is not an HLS concept - is linked here with media/renditions with different bit depth and/or sample rate)  .

  This seems to me a little awkward also but an application may like the info, so maybe good enough? (To see in the future for API specific to audio renditions, but that seems to me extremely niche, not sure if really needed)