### PR TITLE
[WIP] Begin trying consideration of sequence number tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@
 ### Features
 
 - It is now possible to play media playlists directly instead of always going through a multivariant playlist URL
-- Add parsing of `#EXT-X-DEFINE` tags
-- Add `NotAPlaylist` error code: a new `WaspOtherError` for when the given resource URL does not seem to be a valid HLS playlist URL
-- Add `MultivariantPlaylistVariableDefinitionError` and `MediaPlaylistVariableDefinitionError` error codes for when an `#EXT-X-DEFINE` tag or usage is not compliant to the HLS specification respectively on the MultiVariant Playlist or the Media Playlist.
-- Add `SourceBufferEmptyMimeType`, `SourceBufferMediaSourceIsClosed`, `SourceBufferNoMediaSourceAttached` and `SourceBufferQuotaExceededError` error codes on a `WaspSourceBufferCreationError` error type.
 - Add optional `bitDepth` and `sampleRate` properties to `getAudioTrackList`, `getCurrentAudioTrack`methods plus `audioTrackUpdate` and `audioTrackListUpdate` events reflecting respectively the bit depth of audio samples and the audio audio sample rate for the corresponding audio tracks if they're invariant for all renditions of that track.
 - Add optional `bitDephs` and `sampleRates` array properties to `getAudioTrackList`, `getCurrentAudioTrack`methods plus `audioTrackUpdate` and `audioTrackListUpdate` events listing respectively the known various bit depts and rates of audio samples in all renditions of that track.
 - Add `characteristics` property to `getAudioTrackList`, `getCurrentAudioTrack`methods plus `audioTrackUpdate` and `audioTrackListUpdate` events reflecting the `CHARACTERISTICS` of the original playlist, e.g. for audio-description audio tracks.
 - Add optional `videoRange` property to `getVariantList`, `getLockedVariant`, `getCurrentVariant` as well as `variantUpdate`, `variantLockUpdate` and `variantListUpdate` events to reflect its video's dynamic range
+- Add `NotAPlaylist` error code: a new `WaspOtherError` for when the given resource URL does not seem to be a valid HLS playlist URL
+- Add `MultivariantPlaylistVariableDefinitionError` and `MediaPlaylistVariableDefinitionError` error codes for when an `#EXT-X-DEFINE` tag or usage is not compliant to the HLS specification respectively on the MultiVariant Playlist or the Media Playlist.
+- Add `SourceBufferEmptyMimeType`, `SourceBufferMediaSourceIsClosed`, `SourceBufferNoMediaSourceAttached` and `SourceBufferQuotaExceededError` error codes on a `WaspSourceBufferCreationError` error type.
 - Light handling of QuotaExceededError by removing data from buffers if/when it happens. More advanced handling would be to reduce buffer goal adaptively (not done yet)
+- Add parsing of `#EXT-X-DEFINE` tags
+- Handle `#EXT-X-MEDIA-SEQUENCE` tags and use it for segment staleness detection
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ most of them are not needed for playback):
       anything like that.
 - [x] EXT-X-DEFINE (Used in variable substitutions)
 - [x] EXT-X-START: Used to determine a default start time in the content.
+- [x] EXT-X-MEDIA-SEQUENCE
 - EXT-X-MAP:
   - [x] URI: Used to fetch the initialization segment if one is present
   - [x] BYTERANGE: To perform a range request for the initialization segment
@@ -380,8 +381,6 @@ most of them are not needed for playback):
       handled until now had compatible behaviors from version to version
 - [ ] EXT-X-INDEPENDENT-SEGMENTS: Might needs to be considered once we're
       doing some manual cleaning?
-- [ ] EXT-X-MEDIA-SEQUENCE: For now, playlist are refreshed without needing
-      to identify the media sequence.
 - [ ] EXT-X-I-FRAMES-ONLY: To handle one day, perhaps (very low priority)
 - [ ] EXT-X-PART: low-latency related
 - [ ] EXT-X-PART-INF: low-latency related

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -205,13 +205,26 @@ impl Dispatcher {
                 reason,
                 status,
             } => {
-                if self
-                    .segment_request_contexts
-                    .take(s.id())
-                    .is_some_and(|ctxt| ctxt.is_probe())
+                let req_ctxt = self.segment_request_contexts.take(s.id());
+                if req_ctxt
+                    .as_ref()
+                    .is_some_and(PendingSegmentRequest::is_probe)
                 {
                     self.ready_probe_segment = None;
                 }
+
+                if status.is_some_and(|s| s == 404 || s == 410)
+                    && req_ctxt.as_ref().is_some_and(|ctxt| {
+                        is_stale_media_segment_context(self.playlist_store.as_ref(), ctxt)
+                    })
+                {
+                    Logger::info(
+                        "Core: Ignoring terminal 404/410 for segment no longer in the live window",
+                    );
+                    self.check_segments_to_request();
+                    return;
+                }
+
                 let time_info = s.time_info();
                 jsSendSegmentRequestError(
                     true,
@@ -719,7 +732,6 @@ impl Dispatcher {
     ) {
         self.playlist_refresh_timers
             .set_timer(playlist_id.clone(), refresh_interval);
-        self.check_stale_segment_requests(&playlist_id);
 
         let Some(playlist_store) = self.playlist_store.as_ref() else {
             return;
@@ -1160,40 +1172,6 @@ impl Dispatcher {
         }
     }
 
-    /// After a media playlist update, we may have requests pending for segment that do
-    /// not exist anymore. Abort them if that's the case.
-    ///
-    /// XXX TODO: Is that what we want to do? Maybe HLS put a delay in place before
-    /// segment eviction server-side? To check.
-    fn check_stale_segment_requests(&mut self, playlist_id: &MediaPlaylistPermanentId) {
-        let Some(playlist_store) = self.playlist_store.as_ref() else {
-            return; // no content loaded
-        };
-        let Some(media_type) = playlist_store.curr_media_type_for(playlist_id) else {
-            return; // No active media playlist found with that id
-        };
-        let Some(playlist) = playlist_store.curr_media_playlist(media_type) else {
-            return; // No active playlist for the given media type, should not happen
-        };
-
-        // Now select segment requests with stale ids
-        let stale_request_ids = self.segment_request_contexts.ids_matching(|context| {
-            matches!(
-                context,
-                PendingSegmentRequest::Media {
-                    media_type: req_media_type,
-                    sequence,
-                    ..
-                } if *req_media_type == media_type
-                    && !playlist.contains_sequence(*sequence)
-            )
-        });
-        self.requester.abort_segments(&stale_request_ids); // and abort them
-        for req_id in stale_request_ids {
-            self.segment_request_contexts.take(req_id);
-        }
-    }
-
     /// Try to progress `ready_state` when in the `AwaitingPlaylistInfo` state
     fn inner_advance_awaiting_playlist_info_state(&mut self) {
         let (starting_position, playlist_store) =
@@ -1421,4 +1399,23 @@ fn get_initial_position(
     } else {
         playlist_store.expected_start_time()
     }
+}
+
+fn is_stale_media_segment_context(
+    playlist_store: Option<&PlaylistStore>,
+    context: &PendingSegmentRequest,
+) -> bool {
+    let PendingSegmentRequest::Media {
+        media_type,
+        sequence,
+        ..
+    } = context
+    else {
+        return false;
+    };
+
+    playlist_store
+        .as_ref()
+        .and_then(|pl_store| pl_store.curr_media_playlist(*media_type))
+        .is_some_and(|playlist| !playlist.contains_sequence(*sequence))
 }

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -215,13 +215,20 @@ impl Dispatcher {
 
                 if status.is_some_and(|s| s == 404 || s == 410)
                     && req_ctxt.as_ref().is_some_and(|ctxt| {
-                        is_stale_media_segment_context(self.playlist_store.as_ref(), ctxt)
+                        is_stale_segment_request_context(self.playlist_store.as_ref(), ctxt)
                     })
                 {
                     Logger::info(
                         "Core: Ignoring terminal 404/410 for segment no longer in the live window",
                     );
-                    self.check_segments_to_request();
+                    if req_ctxt
+                        .as_ref()
+                        .is_some_and(PendingSegmentRequest::is_probe)
+                    {
+                        self.recheck_player_state();
+                    } else {
+                        self.check_segments_to_request();
+                    }
                     return;
                 }
 
@@ -500,13 +507,15 @@ impl Dispatcher {
                 None,
                 req_id,
             ),
-            ProbeSegmentContext::Media { time_info } => self.requester.request_segment_unlocked(
-                RequestLaneTag::Probe,
-                &probe_segment.url,
-                probe_segment.byte_range.as_ref(),
-                Some(time_info.clone()),
-                req_id,
-            ),
+            ProbeSegmentContext::Media { time_info, .. } => {
+                self.requester.request_segment_unlocked(
+                    RequestLaneTag::Probe,
+                    &probe_segment.url,
+                    probe_segment.byte_range.as_ref(),
+                    Some(time_info.clone()),
+                    req_id,
+                )
+            }
         }
         true
     }
@@ -612,7 +621,7 @@ impl Dispatcher {
             ProbeSegmentContext::Init { id } => {
                 self.on_init_segment_loaded(data, media_type, id);
             }
-            ProbeSegmentContext::Media { time_info } => {
+            ProbeSegmentContext::Media { time_info, .. } => {
                 let Some((_, context)) = self
                     .playlist_store
                     .as_ref()
@@ -1401,21 +1410,30 @@ fn get_initial_position(
     }
 }
 
-fn is_stale_media_segment_context(
+fn is_stale_segment_request_context(
     playlist_store: Option<&PlaylistStore>,
     context: &PendingSegmentRequest,
 ) -> bool {
-    let PendingSegmentRequest::Media {
-        media_type,
-        sequence,
-        ..
-    } = context
-    else {
-        return false;
-    };
+    match context {
+        PendingSegmentRequest::Media {
+            media_type,
+            sequence,
+            ..
+        } => playlist_store
+            .as_ref()
+            .and_then(|pl_store| pl_store.curr_media_playlist(*media_type))
+            .is_some_and(|playlist| !playlist.contains_sequence(*sequence)),
 
-    playlist_store
-        .as_ref()
-        .and_then(|pl_store| pl_store.curr_media_playlist(*media_type))
-        .is_some_and(|playlist| !playlist.contains_sequence(*sequence))
+        PendingSegmentRequest::Probe {
+            probe_segment:
+                ProbeSegmentMetadata {
+                    context: ProbeSegmentContext::Media { sequence, .. },
+                    ..
+                },
+        } => playlist_store
+            .as_ref()
+            .and_then(|pl_store| pl_store.direct_media_playlist())
+            .is_some_and(|(_, playlist)| !playlist.contains_sequence(*sequence)),
+        _ => false,
+    }
 }

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -722,6 +722,33 @@ impl Dispatcher {
         };
         self.playlist_refresh_timers
             .set_timer(playlist_id.clone(), refresh_interval);
+        if let Some(media_type) = playlist_store.curr_media_type_for(&playlist_id) {
+            if let Some(playlist) = playlist_store.curr_media_playlist(media_type) {
+                if let Some(summary) = playlist.update_summary() {
+                    Logger::debug(&format!(
+                        "Core: Media playlist refresh seq {} -> {} (prev_count: {}, dropped: {}, retained: {}, appended: {})",
+                        summary.previous_first_sequence(),
+                        playlist.media_sequence(),
+                        summary.previous_segment_count(),
+                        summary.dropped_segments(),
+                        summary.retained_segments(),
+                        summary.appended_segments(),
+                    ));
+                }
+                let stale_request_ids = self.segment_request_contexts.ids_matching(|context| {
+                    matches!(
+                        context,
+                        PendingSegmentRequest::Media {
+                            media_type: req_media_type,
+                            sequence,
+                            ..
+                        } if *req_media_type == media_type
+                            && !playlist.contains_sequence(*sequence)
+                    )
+                });
+                self.requester.abort_segments(&stale_request_ids);
+            }
+        }
 
         if let Some(duration) = playlist_store.segment_target_duration() {
             let mut min_buffer_time = f64::max(3., duration - 1.);
@@ -933,7 +960,7 @@ impl Dispatcher {
                             .insert(PendingSegmentRequest::Media {
                                 media_type,
                                 time_info: seg.time_info().clone(),
-
+                                sequence: seg.sequence(),
                                 quality_context: seg_info.1,
                             });
                     self.requester
@@ -1048,6 +1075,7 @@ impl Dispatcher {
                 media_type: req_media_type,
                 time_info,
                 quality_context,
+                ..
             } => {
                 if Some(req_media_type) != media_type {
                     Logger::warn("Loaded media segment with mismatched media type context.");

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -724,17 +724,6 @@ impl Dispatcher {
             .set_timer(playlist_id.clone(), refresh_interval);
         if let Some(media_type) = playlist_store.curr_media_type_for(&playlist_id) {
             if let Some(playlist) = playlist_store.curr_media_playlist(media_type) {
-                if let Some(summary) = playlist.update_summary() {
-                    Logger::debug(&format!(
-                        "Core: Media playlist refresh seq {} -> {} (prev_count: {}, dropped: {}, retained: {}, appended: {})",
-                        summary.previous_first_sequence(),
-                        playlist.media_sequence(),
-                        summary.previous_segment_count(),
-                        summary.dropped_segments(),
-                        summary.retained_segments(),
-                        summary.appended_segments(),
-                    ));
-                }
                 let stale_request_ids = self.segment_request_contexts.ids_matching(|context| {
                     matches!(
                         context,

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -717,28 +717,13 @@ impl Dispatcher {
         playlist_id: MediaPlaylistPermanentId,
         refresh_interval: Option<f64>,
     ) {
+        self.playlist_refresh_timers
+            .set_timer(playlist_id.clone(), refresh_interval);
+        self.check_stale_segment_requests(&playlist_id);
+
         let Some(playlist_store) = self.playlist_store.as_ref() else {
             return;
         };
-        self.playlist_refresh_timers
-            .set_timer(playlist_id.clone(), refresh_interval);
-        if let Some(media_type) = playlist_store.curr_media_type_for(&playlist_id) {
-            if let Some(playlist) = playlist_store.curr_media_playlist(media_type) {
-                let stale_request_ids = self.segment_request_contexts.ids_matching(|context| {
-                    matches!(
-                        context,
-                        PendingSegmentRequest::Media {
-                            media_type: req_media_type,
-                            sequence,
-                            ..
-                        } if *req_media_type == media_type
-                            && !playlist.contains_sequence(*sequence)
-                    )
-                });
-                self.requester.abort_segments(&stale_request_ids);
-            }
-        }
-
         if let Some(duration) = playlist_store.segment_target_duration() {
             let mut min_buffer_time = f64::max(3., duration - 1.);
             min_buffer_time = f64::min(8., min_buffer_time);
@@ -1172,6 +1157,40 @@ impl Dispatcher {
                 .retain(|id| pl_store.is_curr_media_playlist(id))
         } else {
             self.playlist_refresh_timers.clear_all_timers();
+        }
+    }
+
+    /// After a media playlist update, we may have requests pending for segment that do
+    /// not exist anymore. Abort them if that's the case.
+    ///
+    /// XXX TODO: Is that what we want to do? Maybe HLS put a delay in place before
+    /// segment eviction server-side? To check.
+    fn check_stale_segment_requests(&mut self, playlist_id: &MediaPlaylistPermanentId) {
+        let Some(playlist_store) = self.playlist_store.as_ref() else {
+            return; // no content loaded
+        };
+        let Some(media_type) = playlist_store.curr_media_type_for(playlist_id) else {
+            return; // No active media playlist found with that id
+        };
+        let Some(playlist) = playlist_store.curr_media_playlist(media_type) else {
+            return; // No active playlist for the given media type, should not happen
+        };
+
+        // Now select segment requests with stale ids
+        let stale_request_ids = self.segment_request_contexts.ids_matching(|context| {
+            matches!(
+                context,
+                PendingSegmentRequest::Media {
+                    media_type: req_media_type,
+                    sequence,
+                    ..
+                } if *req_media_type == media_type
+                    && !playlist.contains_sequence(*sequence)
+            )
+        });
+        self.requester.abort_segments(&stale_request_ids); // and abort them
+        for req_id in stale_request_ids {
+            self.segment_request_contexts.take(req_id);
         }
     }
 

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -1,7 +1,6 @@
 use super::{
-    event_listeners::JsTimeRanges, Dispatcher, JsMemoryBlob, MediaObservation,
+    event_listeners::JsTimeRanges, utils, Dispatcher, JsMemoryBlob, MediaObservation,
     MediaSourceReadyState, PlaybackTickReason, PlayerReadyState, ReadyProbeSegment,
-    StartingPositionType,
 };
 use crate::{
     bindings::{
@@ -20,7 +19,7 @@ use crate::{
         MultivariantPlaylistParsingErrorCode, OtherErrorCode, PlaylistNature, PlaylistType,
         PushedSegmentErrorCode, RequestId, SourceBufferId, TimerId,
     },
-    dispatcher::{segment_request_contexts::PendingSegmentRequest, StartingPosition},
+    dispatcher::segment_request_contexts::PendingSegmentRequest,
     media_element::{SegmentQualityContext, SourceBufferCreationError},
     parser::{SegmentTimeInfo, TopLevelPlaylist, TopLevelPlaylistParsingError},
     playlist_store::{
@@ -215,7 +214,7 @@ impl Dispatcher {
 
                 if status.is_some_and(|s| s == 404 || s == 410)
                     && req_ctxt.as_ref().is_some_and(|ctxt| {
-                        is_stale_segment_request_context(self.playlist_store.as_ref(), ctxt)
+                        utils::is_stale_segment_request_context(self.playlist_store.as_ref(), ctxt)
                     })
                 {
                     Logger::info(
@@ -607,7 +606,8 @@ impl Dispatcher {
         let Some(ReadyProbeSegment { request, data }) = self.ready_probe_segment.take() else {
             return; // No stored probe segment
         };
-        let Some(media_type) = has_playlist_store_media_type(self.playlist_store.as_ref()) else {
+        let Some(media_type) = utils::has_playlist_store_media_type(self.playlist_store.as_ref())
+        else {
             jsSendOtherError(
                 true,
                 OtherErrorCode::Unknown,
@@ -1128,7 +1128,8 @@ impl Dispatcher {
                 self.stop_current_content();
             }
             Ok(()) => {
-                if was_last_segment(self.playlist_store.as_ref(), media_type, segment_start) {
+                if utils::was_last_segment(self.playlist_store.as_ref(), media_type, segment_start)
+                {
                     Logger::info(&format!(
                         "Last {} segment request finished, declaring its buffer's end",
                         media_type
@@ -1195,7 +1196,7 @@ impl Dispatcher {
             };
 
         // Progress through the "startup steps" of the linked `PlaylistStore`, returning `true`
-        let wanted_position = get_initial_position(playlist_store, starting_position);
+        let wanted_position = utils::get_initial_position(playlist_store, starting_position);
         match playlist_store.startup_status(wanted_position) {
             Ok(StartupStatus::Ready) => false,
             Ok(StartupStatus::AwaitingSupportCheck) => true,
@@ -1327,7 +1328,7 @@ impl Dispatcher {
             return;
         };
 
-        let wanted_start = get_initial_position(playlist_store, starting_pos);
+        let wanted_start = utils::get_initial_position(playlist_store, starting_pos);
         if wanted_start > 0. {
             self.media_element_ref.seek(wanted_start);
         }
@@ -1355,85 +1356,5 @@ impl Dispatcher {
         }
         jsStartObservingPlayback();
         self.consume_probe_segment();
-    }
-}
-
-fn was_last_segment(
-    playlist_store: Option<&PlaylistStore>,
-    media_type: MediaType,
-    seg_start: f64,
-) -> bool {
-    playlist_store
-        .and_then(|c| c.curr_media_playlist(media_type))
-        .map(|pl| {
-            pl.is_ended()
-                && pl
-                    .segment_list()
-                    .media()
-                    .last()
-                    .map(|x| x.start() == seg_start)
-                    .unwrap_or(false)
-        })
-        .unwrap_or(false)
-}
-
-fn has_playlist_store_media_type(playlist_store: Option<&PlaylistStore>) -> Option<MediaType> {
-    let playlist_store = playlist_store?;
-    if playlist_store.has_media_type(MediaType::Video) {
-        Some(MediaType::Video)
-    } else if playlist_store.has_media_type(MediaType::Audio) {
-        Some(MediaType::Audio)
-    } else {
-        None
-    }
-}
-
-/// Returns the expected position at which we want to start playback, in seconds, according to
-/// both configuration and playlist metadata.
-fn get_initial_position(
-    playlist_store: &PlaylistStore,
-    starting_position: Option<StartingPosition>,
-) -> f64 {
-    if let Some(starting_pos) = starting_position {
-        match starting_pos.start_type {
-            StartingPositionType::Absolute => starting_pos.position,
-            StartingPositionType::FromBeginning => {
-                playlist_store.curr_min_position().unwrap_or(0.) + starting_pos.position
-            }
-            StartingPositionType::FromEnd => playlist_store
-                .curr_max_position()
-                .map(|max| max - starting_pos.position)
-                .unwrap_or(playlist_store.expected_start_time()),
-        }
-    } else {
-        playlist_store.expected_start_time()
-    }
-}
-
-fn is_stale_segment_request_context(
-    playlist_store: Option<&PlaylistStore>,
-    context: &PendingSegmentRequest,
-) -> bool {
-    match context {
-        PendingSegmentRequest::Media {
-            media_type,
-            sequence,
-            ..
-        } => playlist_store
-            .as_ref()
-            .and_then(|pl_store| pl_store.curr_media_playlist(*media_type))
-            .is_some_and(|playlist| !playlist.contains_sequence(*sequence)),
-
-        PendingSegmentRequest::Probe {
-            probe_segment:
-                ProbeSegmentMetadata {
-                    context: ProbeSegmentContext::Media { sequence, .. },
-                    ..
-                },
-        } => playlist_store
-            .as_ref()
-            .and_then(|pl_store| pl_store.direct_media_playlist())
-            .is_some_and(|(_, playlist)| !playlist.contains_sequence(*sequence)),
-        _ => false,
     }
 }

--- a/src/rs-core/dispatcher/mod.rs
+++ b/src/rs-core/dispatcher/mod.rs
@@ -12,6 +12,7 @@ mod core;
 mod event_listeners;
 mod playlist_refresh_timers;
 mod segment_request_contexts;
+mod utils;
 
 use segment_request_contexts::SegmentRequestContexts;
 

--- a/src/rs-core/dispatcher/segment_request_contexts.rs
+++ b/src/rs-core/dispatcher/segment_request_contexts.rs
@@ -60,6 +60,17 @@ impl SegmentRequestContexts {
     {
         self.contexts.values().any(predicate)
     }
+
+    /// Return the ids for all contexts matching the given predicate.
+    pub(crate) fn ids_matching<F>(&self, predicate: F) -> Vec<SegmentRequestId>
+    where
+        F: Fn(&PendingSegmentRequest) -> bool,
+    {
+        self.contexts
+            .iter()
+            .filter_map(|(request_id, context)| predicate(context).then_some(*request_id))
+            .collect()
+    }
 }
 
 /// Singular item inserted into the `SegmentRequestContexts`.
@@ -76,6 +87,8 @@ pub(crate) enum PendingSegmentRequest {
     Media {
         /// The `MediaType` the media segment is linked to.
         media_type: MediaType,
+        /// Media sequence number identifying that segment within the current playlist lineage.
+        sequence: u32,
         /// Time-related metadata linked to that segment.
         time_info: SegmentTimeInfo,
         /// Additional context required for ABR

--- a/src/rs-core/dispatcher/utils.rs
+++ b/src/rs-core/dispatcher/utils.rs
@@ -1,0 +1,87 @@
+use super::{segment_request_contexts::PendingSegmentRequest, StartingPosition};
+use crate::{
+    bindings::{MediaType, StartingPositionType},
+    playlist_store::{PlaylistStore, ProbeSegmentContext, ProbeSegmentMetadata},
+};
+
+pub(super) fn was_last_segment(
+    playlist_store: Option<&PlaylistStore>,
+    media_type: MediaType,
+    seg_start: f64,
+) -> bool {
+    playlist_store
+        .and_then(|c| c.curr_media_playlist(media_type))
+        .map(|pl| {
+            pl.is_ended()
+                && pl
+                    .segment_list()
+                    .media()
+                    .last()
+                    .map(|x| x.start() == seg_start)
+                    .unwrap_or(false)
+        })
+        .unwrap_or(false)
+}
+
+pub(super) fn has_playlist_store_media_type(
+    playlist_store: Option<&PlaylistStore>,
+) -> Option<MediaType> {
+    let playlist_store = playlist_store?;
+    if playlist_store.has_media_type(MediaType::Video) {
+        Some(MediaType::Video)
+    } else if playlist_store.has_media_type(MediaType::Audio) {
+        Some(MediaType::Audio)
+    } else {
+        None
+    }
+}
+
+/// Returns the expected position at which we want to start playback, in seconds, according to
+/// both configuration and playlist metadata.
+pub(super) fn get_initial_position(
+    playlist_store: &PlaylistStore,
+    starting_position: Option<StartingPosition>,
+) -> f64 {
+    if let Some(starting_pos) = starting_position {
+        match starting_pos.start_type {
+            StartingPositionType::Absolute => starting_pos.position,
+            StartingPositionType::FromBeginning => {
+                playlist_store.curr_min_position().unwrap_or(0.) + starting_pos.position
+            }
+            StartingPositionType::FromEnd => playlist_store
+                .curr_max_position()
+                .map(|max| max - starting_pos.position)
+                .unwrap_or(playlist_store.expected_start_time()),
+        }
+    } else {
+        playlist_store.expected_start_time()
+    }
+}
+
+pub(super) fn is_stale_segment_request_context(
+    playlist_store: Option<&PlaylistStore>,
+    context: &PendingSegmentRequest,
+) -> bool {
+    match context {
+        PendingSegmentRequest::Media {
+            media_type,
+            sequence,
+            ..
+        } => playlist_store
+            .as_ref()
+            .and_then(|pl_store| pl_store.curr_media_playlist(*media_type))
+            .is_some_and(|playlist| !playlist.contains_sequence(*sequence)),
+
+        PendingSegmentRequest::Probe {
+            probe_segment:
+                ProbeSegmentMetadata {
+                    context: ProbeSegmentContext::Media { sequence, .. },
+                    ..
+                },
+        } => playlist_store
+            .as_ref()
+            .and_then(|pl_store| pl_store.direct_media_playlist())
+            .is_some_and(|(_, playlist)| !playlist.contains_sequence(*sequence)),
+        _ => false,
+    }
+}

--- a/src/rs-core/parser/media_playlist.rs
+++ b/src/rs-core/parser/media_playlist.rs
@@ -129,6 +129,8 @@ impl InitSegmentInfo {
 /// Information linked to a single media segment.
 #[derive(Clone, Debug)]
 pub(crate) struct MediaSegmentInfo {
+    /// Media sequence number identifying this segment within the current playlist lineage.
+    sequence: u32,
     /// Information on the time boundaries of that segment.
     ///
     /// It should be exclusive to the time boundaries of all other segments in this Media Playlist.
@@ -140,6 +142,11 @@ pub(crate) struct MediaSegmentInfo {
 }
 
 impl MediaSegmentInfo {
+    /// Media sequence number identifying this segment within the current playlist lineage.
+    pub(crate) fn sequence(&self) -> u32 {
+        self.sequence
+    }
+
     /// First presentation time the segment contains media data for, in seconds.
     pub(crate) fn start(&self) -> f64 {
         self.time_info.start()
@@ -168,6 +175,37 @@ impl MediaSegmentInfo {
     /// URL at which this initialization segment should be requested.
     pub(crate) fn url(&self) -> &Url {
         &self.url
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MediaPlaylistUpdateSummary {
+    previous_first_sequence: u32,
+    previous_segment_count: usize,
+    dropped_segments: usize,
+    retained_segments: usize,
+    appended_segments: usize,
+}
+
+impl MediaPlaylistUpdateSummary {
+    pub(crate) fn previous_first_sequence(&self) -> u32 {
+        self.previous_first_sequence
+    }
+
+    pub(crate) fn previous_segment_count(&self) -> usize {
+        self.previous_segment_count
+    }
+
+    pub(crate) fn dropped_segments(&self) -> usize {
+        self.dropped_segments
+    }
+
+    pub(crate) fn retained_segments(&self) -> usize {
+        self.retained_segments
+    }
+
+    pub(crate) fn appended_segments(&self) -> usize {
+        self.appended_segments
     }
 }
 
@@ -262,6 +300,9 @@ pub struct MediaPlaylist {
     segment_list: SegmentList,
     /// URL at which this Media Playlist may be updated.
     url: Url,
+    /// Summary of the latest refresh against the previous playlist if this playlist came from
+    /// an update and not an initial parse.
+    update_summary: Option<MediaPlaylistUpdateSummary>,
     // TODO
     // pub server_control: ServerControl,
     // pub part_inf: Option<f64>,
@@ -453,6 +494,7 @@ impl MediaPlaylist {
                 };
                 if let Some(duration) = next_segment_duration {
                     let seg = MediaSegmentInfo {
+                        sequence: 0,
                         time_info: SegmentTimeInfo::new(curr_start_time, duration),
                         byte_range: next_segment_byte_range,
                         url: seg_url,
@@ -474,7 +516,10 @@ impl MediaPlaylist {
                             byte_range,
                         });
                     }
-                    media_segments.push(seg);
+                    media_segments.push(MediaSegmentInfo {
+                        sequence: media_sequence + media_segments.len() as u32,
+                        ..seg
+                    });
                     curr_start_time += duration;
                     next_segment_duration = None;
                     next_segment_byte_range = None;
@@ -500,6 +545,9 @@ impl MediaPlaylist {
         if playlist_type == PlaylistNature::Unknown && !end_list {
             playlist_type = PlaylistNature::Live;
         }
+        let update_summary = prev_playlist.and_then(|prev| {
+            summarize_media_playlist_update(prev, media_sequence, media_segments.as_slice())
+        });
         Ok(MediaPlaylist {
             version,
             independent_segments,
@@ -511,6 +559,7 @@ impl MediaPlaylist {
             i_frames_only,
             segment_list: SegmentList::new(maps_info, media_segments),
             url,
+            update_summary,
             // TODO
             // server_control,
             // part_inf,
@@ -579,6 +628,10 @@ impl MediaPlaylist {
         self.target_duration as f64
     }
 
+    pub(crate) fn media_sequence(&self) -> u32 {
+        self.media_sequence
+    }
+
     /// Returns the start time of the first media segment referenced in that `MediaPlaylist`, in
     /// seconds.
     pub(crate) fn beginning(&self) -> Option<f64> {
@@ -611,6 +664,25 @@ impl MediaPlaylist {
     /// the last chronological one.
     pub(crate) fn is_ended(&self) -> bool {
         self.end_list
+    }
+
+    pub(crate) fn update_summary(&self) -> Option<&MediaPlaylistUpdateSummary> {
+        self.update_summary.as_ref()
+    }
+
+    pub(crate) fn first_sequence(&self) -> Option<u32> {
+        self.segment_list.media().first().map(|s| s.sequence())
+    }
+
+    pub(crate) fn last_sequence(&self) -> Option<u32> {
+        self.segment_list.media().last().map(|s| s.sequence())
+    }
+
+    pub(crate) fn contains_sequence(&self, sequence: u32) -> bool {
+        match (self.first_sequence(), self.last_sequence()) {
+            (Some(first), Some(last)) => first <= sequence && sequence <= last,
+            _ => false,
+        }
     }
 
     /// Return Mime-type associated to this MediaPlaylist.
@@ -661,4 +733,69 @@ impl MediaPlaylist {
     fn extension(&self) -> Option<&str> {
         self.segment_list.media().first().map(|s| s.url.extension())
     }
+}
+
+fn summarize_media_playlist_update(
+    prev_playlist: &MediaPlaylist,
+    new_media_sequence: u32,
+    new_segments: &[MediaSegmentInfo],
+) -> Option<MediaPlaylistUpdateSummary> {
+    let prev_segments = prev_playlist.segment_list.media();
+    let previous_first_sequence = prev_playlist.media_sequence();
+    let previous_segment_count = prev_segments.len();
+
+    if previous_segment_count == 0 {
+        return Some(MediaPlaylistUpdateSummary {
+            previous_first_sequence,
+            previous_segment_count,
+            dropped_segments: 0,
+            retained_segments: 0,
+            appended_segments: new_segments.len(),
+        });
+    }
+
+    let new_last_sequence = new_segments.last().map(|s| s.sequence());
+    let prev_last_sequence = prev_segments.last().map(|s| s.sequence()).unwrap();
+    let retained_segments = new_last_sequence
+        .map(|new_last| {
+            if new_media_sequence > prev_last_sequence || new_last < previous_first_sequence {
+                0
+            } else {
+                (u32::min(prev_last_sequence, new_last)
+                    - u32::max(previous_first_sequence, new_media_sequence)
+                    + 1) as usize
+            }
+        })
+        .unwrap_or(0);
+    let dropped_segments = previous_segment_count.saturating_sub(retained_segments);
+    let appended_segments = new_segments.len().saturating_sub(retained_segments);
+
+    if retained_segments > 0 {
+        let overlap_start = u32::max(previous_first_sequence, new_media_sequence);
+        let overlap_end = u32::min(prev_last_sequence, new_last_sequence.unwrap());
+        for sequence in overlap_start..=overlap_end {
+            let prev_idx = (sequence - previous_first_sequence) as usize;
+            let new_idx = (sequence - new_media_sequence) as usize;
+            let prev_seg = &prev_segments[prev_idx];
+            let new_seg = &new_segments[new_idx];
+            if prev_seg.url() != new_seg.url() || prev_seg.byte_range() != new_seg.byte_range() {
+                Logger::warn(&format!(
+                    "Parser: Media playlist refresh mismatch for sequence {} (prev: {} {:?}, new: {} {:?})",
+                    sequence,
+                    prev_seg.url().get_ref(),
+                    prev_seg.byte_range(),
+                    new_seg.url().get_ref(),
+                    new_seg.byte_range()
+                ));
+            }
+        }
+    }
+
+    Some(MediaPlaylistUpdateSummary {
+        previous_first_sequence,
+        previous_segment_count,
+        dropped_segments,
+        retained_segments,
+        appended_segments,
+    })
 }

--- a/src/rs-core/parser/media_playlist.rs
+++ b/src/rs-core/parser/media_playlist.rs
@@ -178,37 +178,6 @@ impl MediaSegmentInfo {
     }
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct MediaPlaylistUpdateSummary {
-    previous_first_sequence: u32,
-    previous_segment_count: usize,
-    dropped_segments: usize,
-    retained_segments: usize,
-    appended_segments: usize,
-}
-
-impl MediaPlaylistUpdateSummary {
-    pub(crate) fn previous_first_sequence(&self) -> u32 {
-        self.previous_first_sequence
-    }
-
-    pub(crate) fn previous_segment_count(&self) -> usize {
-        self.previous_segment_count
-    }
-
-    pub(crate) fn dropped_segments(&self) -> usize {
-        self.dropped_segments
-    }
-
-    pub(crate) fn retained_segments(&self) -> usize {
-        self.retained_segments
-    }
-
-    pub(crate) fn appended_segments(&self) -> usize {
-        self.appended_segments
-    }
-}
-
 // #[derive(Clone, Debug)]
 // pub struct ServerControl {
 //     can_skip_until: Option<f64>,
@@ -300,9 +269,6 @@ pub struct MediaPlaylist {
     segment_list: SegmentList,
     /// URL at which this Media Playlist may be updated.
     url: Url,
-    /// Summary of the latest refresh against the previous playlist if this playlist came from
-    /// an update and not an initial parse.
-    update_summary: Option<MediaPlaylistUpdateSummary>,
     // TODO
     // pub server_control: ServerControl,
     // pub part_inf: Option<f64>,
@@ -545,9 +511,6 @@ impl MediaPlaylist {
         if playlist_type == PlaylistNature::Unknown && !end_list {
             playlist_type = PlaylistNature::Live;
         }
-        let update_summary = prev_playlist.and_then(|prev| {
-            summarize_media_playlist_update(prev, media_sequence, media_segments.as_slice())
-        });
         Ok(MediaPlaylist {
             version,
             independent_segments,
@@ -559,7 +522,6 @@ impl MediaPlaylist {
             i_frames_only,
             segment_list: SegmentList::new(maps_info, media_segments),
             url,
-            update_summary,
             // TODO
             // server_control,
             // part_inf,
@@ -666,10 +628,6 @@ impl MediaPlaylist {
         self.end_list
     }
 
-    pub(crate) fn update_summary(&self) -> Option<&MediaPlaylistUpdateSummary> {
-        self.update_summary.as_ref()
-    }
-
     pub(crate) fn first_sequence(&self) -> Option<u32> {
         self.segment_list.media().first().map(|s| s.sequence())
     }
@@ -733,69 +691,4 @@ impl MediaPlaylist {
     fn extension(&self) -> Option<&str> {
         self.segment_list.media().first().map(|s| s.url.extension())
     }
-}
-
-fn summarize_media_playlist_update(
-    prev_playlist: &MediaPlaylist,
-    new_media_sequence: u32,
-    new_segments: &[MediaSegmentInfo],
-) -> Option<MediaPlaylistUpdateSummary> {
-    let prev_segments = prev_playlist.segment_list.media();
-    let previous_first_sequence = prev_playlist.media_sequence();
-    let previous_segment_count = prev_segments.len();
-
-    if previous_segment_count == 0 {
-        return Some(MediaPlaylistUpdateSummary {
-            previous_first_sequence,
-            previous_segment_count,
-            dropped_segments: 0,
-            retained_segments: 0,
-            appended_segments: new_segments.len(),
-        });
-    }
-
-    let new_last_sequence = new_segments.last().map(|s| s.sequence());
-    let prev_last_sequence = prev_segments.last().map(|s| s.sequence()).unwrap();
-    let retained_segments = new_last_sequence
-        .map(|new_last| {
-            if new_media_sequence > prev_last_sequence || new_last < previous_first_sequence {
-                0
-            } else {
-                (u32::min(prev_last_sequence, new_last)
-                    - u32::max(previous_first_sequence, new_media_sequence)
-                    + 1) as usize
-            }
-        })
-        .unwrap_or(0);
-    let dropped_segments = previous_segment_count.saturating_sub(retained_segments);
-    let appended_segments = new_segments.len().saturating_sub(retained_segments);
-
-    if retained_segments > 0 {
-        let overlap_start = u32::max(previous_first_sequence, new_media_sequence);
-        let overlap_end = u32::min(prev_last_sequence, new_last_sequence.unwrap());
-        for sequence in overlap_start..=overlap_end {
-            let prev_idx = (sequence - previous_first_sequence) as usize;
-            let new_idx = (sequence - new_media_sequence) as usize;
-            let prev_seg = &prev_segments[prev_idx];
-            let new_seg = &new_segments[new_idx];
-            if prev_seg.url() != new_seg.url() || prev_seg.byte_range() != new_seg.byte_range() {
-                Logger::warn(&format!(
-                    "Parser: Media playlist refresh mismatch for sequence {} (prev: {} {:?}, new: {} {:?})",
-                    sequence,
-                    prev_seg.url().get_ref(),
-                    prev_seg.byte_range(),
-                    new_seg.url().get_ref(),
-                    new_seg.byte_range()
-                ));
-            }
-        }
-    }
-
-    Some(MediaPlaylistUpdateSummary {
-        previous_first_sequence,
-        previous_segment_count,
-        dropped_segments,
-        retained_segments,
-        appended_segments,
-    })
 }

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -30,6 +30,8 @@ pub(crate) enum ProbeSegmentContext {
     Init { id: f64 },
     /// This probe segment is a full valid Media segment
     Media {
+        /// Sequence number identifying that segment in the playlist.
+        sequence: u32,
         /// Timing information linked to that media segment
         time_info: SegmentTimeInfo,
     },
@@ -429,6 +431,7 @@ impl PlaylistStore {
                 url: media_segment.url().clone(),
                 byte_range: media_segment.byte_range().cloned(),
                 context: ProbeSegmentContext::Media {
+                    sequence: media_segment.sequence(),
                     time_info: media_segment.time_info().clone(),
                 },
             })

--- a/src/rs-core/requester/mod.rs
+++ b/src/rs-core/requester/mod.rs
@@ -702,6 +702,41 @@ impl Requester {
         aborted_requests
     }
 
+    pub(crate) fn abort_segments(&mut self, request_ids: &[u32]) {
+        if request_ids.is_empty() {
+            return;
+        }
+
+        let mut i = 0;
+        let mut aborted_pending = false;
+        while i < self.pending_segment_requests.len() {
+            let next_req = &self.pending_segment_requests[i];
+            if request_ids.contains(&next_req.caller_id) {
+                log_segment_abort(next_req);
+                aborted_pending = true;
+                jsAbortRequest(next_req.host_id);
+                self.pending_segment_requests.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+
+        i = 0;
+        while i < self.segment_waiting_queue.len() {
+            let next_req = &self.segment_waiting_queue[i];
+            if request_ids.contains(&next_req.caller_id) {
+                log_segment_abort(next_req);
+                self.segment_waiting_queue.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+
+        if aborted_pending {
+            self.check_segment_queue();
+        }
+    }
+
     fn end_pending_request(&mut self, host_id: RequestId) -> Option<FinishedRequestType> {
         if let Some(res) = self.end_pending_segment_request(host_id) {
             Some(FinishedRequestType::Segment(res))

--- a/src/rs-core/requester/mod.rs
+++ b/src/rs-core/requester/mod.rs
@@ -702,41 +702,6 @@ impl Requester {
         aborted_requests
     }
 
-    pub(crate) fn abort_segments(&mut self, request_ids: &[u32]) {
-        if request_ids.is_empty() {
-            return;
-        }
-
-        let mut i = 0;
-        let mut aborted_pending = false;
-        while i < self.pending_segment_requests.len() {
-            let next_req = &self.pending_segment_requests[i];
-            if request_ids.contains(&next_req.caller_id) {
-                log_segment_abort(next_req);
-                aborted_pending = true;
-                jsAbortRequest(next_req.host_id);
-                self.pending_segment_requests.remove(i);
-            } else {
-                i += 1;
-            }
-        }
-
-        i = 0;
-        while i < self.segment_waiting_queue.len() {
-            let next_req = &self.segment_waiting_queue[i];
-            if request_ids.contains(&next_req.caller_id) {
-                log_segment_abort(next_req);
-                self.segment_waiting_queue.remove(i);
-            } else {
-                i += 1;
-            }
-        }
-
-        if aborted_pending {
-            self.check_segment_queue();
-        }
-    }
-
     fn end_pending_request(&mut self, host_id: RequestId) -> Option<FinishedRequestType> {
         if let Some(res) = self.end_pending_segment_request(host_id) {
             Some(FinishedRequestType::Segment(res))


### PR DESCRIPTION
The `EXT-X-MEDIA-SEQUENCE` has not been relied on until now because we mostly do not care about its main usage for now: identifying where a playlist refresh differs from the previous one.

This is because under the current wasp-hls logic the new fetched playlist becomes the new authority and the old is forgotten, the player being "smart" enough to know where it should continue from at any point.

However that sequence number could be relied on to notice temporary packaging issues or to support delta playlist updates in the future.

Here I just explore what implementing it could look like, and if it makes sense to parse it right now.