### PR TITLE
Implement `EXT-X-DEFINE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## Unreleased
 
+### Changes
+
+- The too specific `MultivariantPlaylistMediaTagMissingType`, `MultivariantPlaylistMediaTagMissingName` and `MultivariantPlaylistMediaTagMissingGroupId` error codes have been collapsed into a new `MultivariantPlaylistMissingRequiredAttribute` error code
+
 ### Features
 
+- Add parsing of `#EXT-X-DEFINE` tags
+- Add `MultivariantPlaylistVariableDefinitionError` and `MediaPlaylistVariableDefinitionError` error codes for when an `#EXT-X-DEFINE` tag or usage is not compliant to the HLS specification respectively on the MultiVariant Playlist or the Media Playlist.
+- Add `SourceBufferEmptyMimeType`, `SourceBufferMediaSourceIsClosed`, `SourceBufferNoMediaSourceAttached` and `SourceBufferQuotaExceededError` error codes on a `WaspSourceBufferCreationError` error type.
 - Add optional `bitDepth` and `sampleRate` properties to `getAudioTrackList`, `getCurrentAudioTrack`methods plus `audioTrackUpdate` and `audioTrackListUpdate` events reflecting respectively the bit depth of audio samples and the audio audio sample rate for the corresponding audio tracks if they're invariant for all renditions of that track.
 - Add optional `bitDephs` and `sampleRates` array properties to `getAudioTrackList`, `getCurrentAudioTrack`methods plus `audioTrackUpdate` and `audioTrackListUpdate` events listing respectively the known various bit depts and rates of audio samples in all renditions of that track.
 - Add `characteristics` property to `getAudioTrackList`, `getCurrentAudioTrack`methods plus `audioTrackUpdate` and `audioTrackListUpdate` events reflecting the `CHARACTERISTICS` of the original playlist, e.g. for audio-description audio tracks.
@@ -12,6 +19,7 @@
 
 ### Bug fixes
 
+- `SourceBufferAlreadyCreatedWithSameType` mistakenly also regrouped other kinds of SourceBuffer-related bug than what's documented. This is now fixed.
 - Better handle edge speed settings: negative speeds, non-finite speeds, `NaN` speed
 
 ### Other

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ most of them are not needed for playback):
 - [x] EXT-X-TARGETDURATION: Useful for heuristics for playlist refresh
 - [x] EXT-X-GAP: Those segments are just skipped, no variant switch or
       anything like that.
+- [x] EXT-X-DEFINE (Used in variable substitutions)
 - [x] EXT-X-START: Used to determine a default start time in the content.
 - EXT-X-MAP:
   - [x] URI: Used to fetch the initialization segment if one is present
@@ -377,8 +378,6 @@ most of them are not needed for playback):
       handled until now had compatible behaviors from version to version
 - [ ] EXT-X-INDEPENDENT-SEGMENTS: Might needs to be considered once we're
       doing some manual cleaning?
-- [ ] EXT-X-DEFINE: Seems rare enough, so may be supported if the time is
-      taken...
 - [ ] EXT-X-MEDIA-SEQUENCE: For now, playlist are refreshed without needing
       to identify the media sequence.
 - [ ] EXT-X-I-FRAMES-ONLY: To handle one day, perhaps (very low priority)

--- a/doc/API/Player_Errors.md
+++ b/doc/API/Player_Errors.md
@@ -158,26 +158,18 @@ of the following values:
   describing an HLS variant, had no `BANDWIDTH` attribute associated to it.
   It should be mandatory.
 
-- `"MultivariantPlaylistMediaTagMissingType"`:
-  An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-  an HLS variant, had no `TYPE` attribute associated to it. It should be
-  mandatory.
-
-- `"MultivariantPlaylistMediaTagMissingName"`:
-  An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-  an HLS variant, had no `NAME` attribute associated to it. It should be
-  mandatory.
-
-- `"MultivariantPlaylistMediaTagMissingGroupId"`:
-  An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-  an HLS variant, had no `GROUP-ID` attribute associated to it. It should be
-  mandatory.
+- `"MultivariantPlaylistMissingRequiredAttribute"`:
+  A mandatory attribute was missing from a tag in the Multivariant Playlist.
 
 - `"MultivariantPlaylistOtherParsingError"`:
   An uncategorized error arised while parsing the Multivariant Playlist.
 
 - `"MultivariantPlaylistInvalidValue"`:
   A value in the Multivariant Playlist was in an invalid format.
+
+- `"MultivariantPlaylistVariableDefinitionError"`:
+  An `EXT-X-DEFINE` variable definition or substitution was invalid in the
+  Multivariant Playlist.
 
 ## Error type: `WaspMediaPlaylistRequestError`
 
@@ -280,6 +272,10 @@ of the following values:
 - `"MediaPlaylistUnparsableByteRange"`:
   A `#EXT-X-BYTERANGE` tag or a `BYTERANGE` attribute in the Media Playlist
   was not in the right format.
+
+- `"MediaPlaylistVariableDefinitionError"`:
+  An `EXT-X-DEFINE` variable definition or substitution was invalid in the
+  Media Playlist.
 
 - `"MediaPlaylistOtherParsingError"`:
   Another uncategorized error happened while parsing the Media Playlist.
@@ -397,13 +393,30 @@ player.addEventlistener("error", (error) => {
 
 ### Error codes
 
-A `WaspSegmentParsingError`'s `code` property can be set to any
+A `WaspSourceBufferCreationError`'s `code` property can be set to any
 of the following values:
+
+- `"SourceBufferAlreadyCreatedWithSameType"`:
+  A `SourceBuffer` for that media type had already been created.
 
 - `"SourceBufferCantPlayType"`:
   The mime type communicated during SourceBuffer creation was not supported.
 
-- `"SourceBufferCreationOtherError":
+- `"SourceBufferEmptyMimeType"`:
+  The mime type communicated during SourceBuffer creation was empty.
+
+- `"SourceBufferMediaSourceIsClosed"`:
+  The current `MediaSource` was already closed when trying to create the
+  `SourceBuffer`.
+
+- `"SourceBufferNoMediaSourceAttached"`:
+  No `MediaSource` was attached when trying to create the `SourceBuffer`.
+
+- `"SourceBufferQuotaExceededError"`:
+  The browser reported a `QuotaExceededError` while creating the
+  `SourceBuffer`.
+
+- `"SourceBufferCreationOtherError"`:
   An uncategorized error arised while creating a SourceBuffer.
 
 ## Error type: `WaspSourceBufferError`

--- a/src/rs-core/bindings/abi_types.rs
+++ b/src/rs-core/bindings/abi_types.rs
@@ -219,22 +219,15 @@ pub enum MultivariantPlaylistParsingErrorCode {
     VariantMissingBandwidth = 4,
     /// A value in the Multivariant Playlist was in an invalid format.
     InvalidValue = 5,
-    /// An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-    /// an HLS variant, had no `TYPE` attribute associated to it. It should be
-    /// mandatory.
-    MediaTagMissingType = 6,
-    /// An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-    /// an HLS variant, had no `NAME` attribute associated to it. It should be
-    /// mandatory.
-    MediaTagMissingName = 7,
-    /// An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-    /// an HLS variant, had no `GROUP-ID` attribute associated to it. It should be
-    /// mandatory.
-    MediaTagMissingGroupId = 8,
+    /// A mandatory attribute was missing from a tag in the Multivariant Playlist.
+    MissingRequiredAttribute = 6,
+    /// An `EXT-X-DEFINE` variable definition or substitution was invalid in the
+    /// Multivariant Playlist.
+    VariableDefinitionError = 7,
     /// A line could not be read.
-    UnableToReadLine = 9,
+    UnableToReadLine = 8,
     /// Another, uncategorized, error arised.
-    Unknown = 10,
+    Unknown = 9,
 }
 
 impl MultivariantPlaylistParsingErrorCode {
@@ -246,11 +239,10 @@ impl MultivariantPlaylistParsingErrorCode {
             3 => Self::UnableToReadVariantUri,
             4 => Self::VariantMissingBandwidth,
             5 => Self::InvalidValue,
-            6 => Self::MediaTagMissingType,
-            7 => Self::MediaTagMissingName,
-            8 => Self::MediaTagMissingGroupId,
-            9 => Self::UnableToReadLine,
-            10 => Self::Unknown,
+            6 => Self::MissingRequiredAttribute,
+            7 => Self::VariableDefinitionError,
+            8 => Self::UnableToReadLine,
+            9 => Self::Unknown,
             _ => Self::Unknown,
         }
     }
@@ -274,8 +266,11 @@ pub enum MediaPlaylistParsingErrorCode {
     /// A `#EXT-X-BYTERANGE` tag or a `BYTERANGE` attribute in the Media Playlist
     /// was not in the right format.
     UnparsableByteRange = 4,
+    /// An `EXT-X-DEFINE` variable definition or substitution was invalid in the
+    /// Media Playlist.
+    VariableDefinitionError = 5,
     /// Another, uncategorized, error arised.
-    Unknown = 5,
+    Unknown = 6,
 }
 
 impl MediaPlaylistParsingErrorCode {
@@ -286,7 +281,8 @@ impl MediaPlaylistParsingErrorCode {
             2 => Self::MissingTargetDuration,
             3 => Self::UriWithoutExtInf,
             4 => Self::UnparsableByteRange,
-            5 => Self::Unknown,
+            5 => Self::VariableDefinitionError,
+            6 => Self::Unknown,
             _ => Self::Unknown,
         }
     }

--- a/src/rs-core/bindings/js_functions.rs
+++ b/src/rs-core/bindings/js_functions.rs
@@ -869,6 +869,7 @@ impl From<MultivariantPlaylistParsingError> for MultivariantPlaylistParsingError
             }
             MultivariantPlaylistParsingError::UnableToReadVariantUri
             | MultivariantPlaylistParsingError::UnableToReadLine
+            | MultivariantPlaylistParsingError::VariableDefinition(_)
             | MultivariantPlaylistParsingError::Unknown => {
                 MultivariantPlaylistParsingErrorCode::Unknown
             }
@@ -894,6 +895,9 @@ impl From<MediaPlaylistUpdateError> for MediaPlaylistParsingErrorCode {
             MediaPlaylistUpdateError::ParsingError(MediaPlaylistParsingError::UriWithoutExtInf) => {
                 MediaPlaylistParsingErrorCode::UriWithoutExtInf
             }
+            MediaPlaylistUpdateError::ParsingError(
+                MediaPlaylistParsingError::VariableDefinition(_),
+            ) => MediaPlaylistParsingErrorCode::Unknown,
             MediaPlaylistUpdateError::NotFound => MediaPlaylistParsingErrorCode::Unknown,
         }
     }

--- a/src/rs-core/bindings/js_functions.rs
+++ b/src/rs-core/bindings/js_functions.rs
@@ -852,14 +852,10 @@ impl From<MultivariantPlaylistParsingError> for MultivariantPlaylistParsingError
             MultivariantPlaylistParsingError::InvalidDecimalInteger => {
                 MultivariantPlaylistParsingErrorCode::InvalidValue
             }
-            MultivariantPlaylistParsingError::MediaTagMissingType => {
-                MultivariantPlaylistParsingErrorCode::MediaTagMissingType
-            }
-            MultivariantPlaylistParsingError::MediaTagMissingName => {
-                MultivariantPlaylistParsingErrorCode::MediaTagMissingName
-            }
-            MultivariantPlaylistParsingError::MediaTagMissingGroupId => {
-                MultivariantPlaylistParsingErrorCode::MediaTagMissingGroupId
+            MultivariantPlaylistParsingError::MediaTagMissingType
+            | MultivariantPlaylistParsingError::MediaTagMissingName
+            | MultivariantPlaylistParsingError::MediaTagMissingGroupId => {
+                MultivariantPlaylistParsingErrorCode::MissingRequiredAttribute
             }
             MultivariantPlaylistParsingError::VariantMissingBandwidth => {
                 MultivariantPlaylistParsingErrorCode::VariantMissingBandwidth
@@ -869,10 +865,11 @@ impl From<MultivariantPlaylistParsingError> for MultivariantPlaylistParsingError
             }
             MultivariantPlaylistParsingError::UnableToReadVariantUri
             | MultivariantPlaylistParsingError::UnableToReadLine
-                // XXX TODO: Add explicit `EXT-X-DEFINE`-related parse error codes to the wasm/TS API?
-            | MultivariantPlaylistParsingError::VariableDefinition(_)
             | MultivariantPlaylistParsingError::Unknown => {
                 MultivariantPlaylistParsingErrorCode::Unknown
+            }
+            MultivariantPlaylistParsingError::VariableDefinition(_) => {
+                MultivariantPlaylistParsingErrorCode::VariableDefinitionError
             }
         }
     }
@@ -897,9 +894,8 @@ impl From<MediaPlaylistUpdateError> for MediaPlaylistParsingErrorCode {
                 MediaPlaylistParsingErrorCode::UriWithoutExtInf
             }
             MediaPlaylistUpdateError::ParsingError(
-                // XXX TODO: Add explicit `EXT-X-DEFINE`-related parse error codes to the wasm/TS API?
                 MediaPlaylistParsingError::VariableDefinition(_),
-            ) => MediaPlaylistParsingErrorCode::Unknown,
+            ) => MediaPlaylistParsingErrorCode::VariableDefinitionError,
             MediaPlaylistUpdateError::NotFound => MediaPlaylistParsingErrorCode::Unknown,
         }
     }

--- a/src/rs-core/bindings/js_functions.rs
+++ b/src/rs-core/bindings/js_functions.rs
@@ -871,6 +871,7 @@ impl From<MultivariantPlaylistParsingError> for MultivariantPlaylistParsingError
             | MultivariantPlaylistParsingError::UnableToReadLine
             | MultivariantPlaylistParsingError::VariableDefinition(_)
             | MultivariantPlaylistParsingError::Unknown => {
+                // TODO: Add explicit `EXT-X-DEFINE`-related parse error codes to the wasm/TS API.
                 MultivariantPlaylistParsingErrorCode::Unknown
             }
         }
@@ -897,7 +898,10 @@ impl From<MediaPlaylistUpdateError> for MediaPlaylistParsingErrorCode {
             }
             MediaPlaylistUpdateError::ParsingError(
                 MediaPlaylistParsingError::VariableDefinition(_),
-            ) => MediaPlaylistParsingErrorCode::Unknown,
+            ) => {
+                // TODO: Add explicit `EXT-X-DEFINE`-related parse error codes to the wasm/TS API.
+                MediaPlaylistParsingErrorCode::Unknown
+            }
             MediaPlaylistUpdateError::NotFound => MediaPlaylistParsingErrorCode::Unknown,
         }
     }

--- a/src/rs-core/bindings/js_functions.rs
+++ b/src/rs-core/bindings/js_functions.rs
@@ -869,9 +869,9 @@ impl From<MultivariantPlaylistParsingError> for MultivariantPlaylistParsingError
             }
             MultivariantPlaylistParsingError::UnableToReadVariantUri
             | MultivariantPlaylistParsingError::UnableToReadLine
+                // XXX TODO: Add explicit `EXT-X-DEFINE`-related parse error codes to the wasm/TS API?
             | MultivariantPlaylistParsingError::VariableDefinition(_)
             | MultivariantPlaylistParsingError::Unknown => {
-                // TODO: Add explicit `EXT-X-DEFINE`-related parse error codes to the wasm/TS API.
                 MultivariantPlaylistParsingErrorCode::Unknown
             }
         }
@@ -897,11 +897,9 @@ impl From<MediaPlaylistUpdateError> for MediaPlaylistParsingErrorCode {
                 MediaPlaylistParsingErrorCode::UriWithoutExtInf
             }
             MediaPlaylistUpdateError::ParsingError(
+                // XXX TODO: Add explicit `EXT-X-DEFINE`-related parse error codes to the wasm/TS API?
                 MediaPlaylistParsingError::VariableDefinition(_),
-            ) => {
-                // TODO: Add explicit `EXT-X-DEFINE`-related parse error codes to the wasm/TS API.
-                MediaPlaylistParsingErrorCode::Unknown
-            }
+            ) => MediaPlaylistParsingErrorCode::Unknown,
             MediaPlaylistUpdateError::NotFound => MediaPlaylistParsingErrorCode::Unknown,
         }
     }

--- a/src/rs-core/parser/attribute_list.rs
+++ b/src/rs-core/parser/attribute_list.rs
@@ -1,0 +1,129 @@
+// Some tags contain an attribute list, with a special K1=V1,K2=V2 syntax
+// This struct is an Iterator allowing to simplify their parsing, by generating
+// `AttributeListItem` elements for each of those key/value couples.
+pub(crate) struct AttributeListIter<'a> {
+    line: &'a str,
+    offset: usize,
+}
+
+/// Represents a single Key/value item in an HLS "attribute list". This data
+/// is for now unparsed.
+//
+// TODO: We may even go further than that as we generally know the end offset?
+pub(crate) struct AttributeListItem<'a> {
+    /// The name/key of the attribute.
+    pub(crate) name: &'a str,
+    /// The offset at which its value starts at. No amount of parsing has been done,
+    /// as such it might point to a quote for quoted strings
+    pub(crate) value_start_offset: usize,
+}
+
+impl<'a> AttributeListIter<'a> {
+    /// Create a new `AttributeListIter` to iterate on
+    /// * `line` - The full line where the attribute is at
+    /// * `offset` - The offset in bytes of the first position in `line` part of the
+    ///   attribute list (i.e. the first byte after a tag prefix such as `EXT-X-MEDIA:`)
+    pub(crate) fn new(line: &'a str, offset: usize) -> Self {
+        Self { line, offset }
+    }
+}
+
+impl<'a> Iterator for AttributeListIter<'a> {
+    type Item = AttributeListItem<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.offset >= self.line.len() {
+            return None;
+        }
+        let idx = self.line[self.offset..].find('=')?;
+        let item = AttributeListItem {
+            name: &self.line[self.offset..self.offset + idx],
+            value_start_offset: self.offset + idx + 1,
+        };
+        self.offset = skip_attribute_list_value(self.line, item.value_start_offset) + 1;
+        Some(item)
+    }
+}
+
+#[inline]
+pub(super) fn find_attribute_end(line: &str, offset: usize) -> usize {
+    line[offset..].find(',').map_or(line.len(), |x| x + offset)
+}
+
+/// Parse enumerated string value as defined by the HLS specification:
+/// From the `value_start_offset` (which is the byte offset in `line` at which
+/// the value starts), to either the next encountered comma, or the end of `line`,
+/// whichever comes sooner.
+///
+/// More than parsing enumerated string values, this function actually just parse
+/// a string without quotes. As such it can be used for any value respecting that
+/// criteria.
+pub(super) fn parse_enumerated_string(line: &str, value_start_offset: usize) -> (&str, usize) {
+    let end = find_attribute_end(line, value_start_offset);
+    (line[value_start_offset..end].as_ref(), end)
+}
+
+pub(super) enum QuotedStringParsingError {
+    NoStartingQuote,
+    NoEndingQuote,
+}
+
+pub(super) fn parse_quoted_string(
+    line: &str,
+    value_start_offset: usize,
+) -> (Result<&str, QuotedStringParsingError>, usize) {
+    if &line[value_start_offset..value_start_offset + 1] != "\"" {
+        let end = find_attribute_end(line, value_start_offset);
+        (Err(QuotedStringParsingError::NoStartingQuote), end)
+    } else {
+        match line[value_start_offset + 1..].find('"') {
+            Some(relative_end_quote_idx) => {
+                let end_quote_idx = value_start_offset + 1 + relative_end_quote_idx;
+                let end = find_attribute_end(line, end_quote_idx + 1);
+                (Ok(&line[value_start_offset + 1..end_quote_idx]), end)
+            }
+            None => {
+                let end = find_attribute_end(line, value_start_offset + 1);
+                (Err(QuotedStringParsingError::NoEndingQuote), end)
+            }
+        }
+    }
+}
+
+pub(super) fn parse_comma_separated_list(
+    line: &str,
+    value_start_offset: usize,
+) -> (Result<Vec<&str>, QuotedStringParsingError>, usize) {
+    let parsed = parse_quoted_string(line, value_start_offset);
+    let splitted = parsed.0.map(|s| s.split(',').collect());
+    (splitted, parsed.1)
+}
+
+pub(super) fn skip_attribute_list_value(line: &str, value_start_offset: usize) -> usize {
+    if line.len() <= value_start_offset {
+        return value_start_offset;
+    }
+
+    // Check if the attribute list value is a quoted one
+    if &line[value_start_offset..value_start_offset + 1] == "\"" {
+        match line[value_start_offset + 1..].find('\"') {
+            Some(relative_end_quote_idx) => {
+                let end_quote_idx = value_start_offset + relative_end_quote_idx;
+
+                // Technically, a comma (',') character should always be found
+                // here if we're not at the end of the attribute list.
+                // Still, check where it is for resilience
+                match line[end_quote_idx + 1..].find(',') {
+                    Some(idx) => end_quote_idx + idx + 1,
+                    None => line.len(),
+                }
+            }
+            None => line.len(),
+        }
+    } else {
+        match line[value_start_offset..].find(',') {
+            Some(idx) => value_start_offset + idx,
+            None => line.len(),
+        }
+    }
+}

--- a/src/rs-core/parser/audio_track_list.rs
+++ b/src/rs-core/parser/audio_track_list.rs
@@ -1,6 +1,8 @@
 use super::MediaTag;
-use std::collections::BTreeSet;
-use std::ops::{Deref, DerefMut};
+use std::{
+    collections::BTreeSet,
+    ops::{Deref, DerefMut},
+};
 
 /// Allows to translate various `EXT-X-MEDIA` tag found inside a Multivariant Playlist into well
 /// defined audio tracks that make more sense in a player API.

--- a/src/rs-core/parser/media_playlist.rs
+++ b/src/rs-core/parser/media_playlist.rs
@@ -8,9 +8,9 @@ use std::{error, fmt, io::BufRead};
 use super::{
     multi_variant_playlist::MediaPlaylistContext,
     utils::{
-        parse_byte_range, parse_decimal_floating_point, parse_decimal_integer,
+        parse_byte_range, parse_decimal_floating_point, parse_decimal_integer, parse_define_tag,
         parse_enumerated_string, parse_iso_8601_date, parse_quoted_string, parse_start_attribute,
-        StartAttribute,
+        StartAttribute, VariableDefinition, VariableDefinitionError, VariableStore,
     },
 };
 
@@ -170,12 +170,13 @@ impl MediaSegmentInfo {
 ///
 /// See display implementation for more information on its variants.
 #[derive(Debug)]
-pub enum MediaPlaylistParsingError {
+pub(crate) enum MediaPlaylistParsingError {
     UnparsableExtInf,
     UnparsableByteRange,
     UriMissingInMap,
     MissingTargetDuration,
     UriWithoutExtInf,
+    VariableDefinition(VariableDefinitionError),
 }
 
 impl fmt::Display for MediaPlaylistParsingError {
@@ -196,11 +197,24 @@ impl fmt::Display for MediaPlaylistParsingError {
             MediaPlaylistParsingError::UnparsableByteRange => {
                 write!(f, "One of the uri had an Unparsable BYTERANGE")
             }
+            MediaPlaylistParsingError::VariableDefinition(err) => {
+                write!(
+                    f,
+                    "Invalid EXT-X-DEFINE usage in the Media Playlist: {:?}",
+                    err
+                )
+            }
         }
     }
 }
 
 impl error::Error for MediaPlaylistParsingError {}
+
+impl From<VariableDefinitionError> for MediaPlaylistParsingError {
+    fn from(err: VariableDefinitionError) -> MediaPlaylistParsingError {
+        MediaPlaylistParsingError::VariableDefinition(err)
+    }
+}
 
 /// Structure representing the concept of the `Media Playlist` in HLS.
 ///
@@ -270,6 +284,7 @@ impl MediaPlaylist {
         let mut next_segment_duration: Option<f64> = None;
         let mut current_byte: Option<usize> = None;
         let mut next_segment_byte_range: Option<ByteRange> = None;
+        let mut variable_store = VariableStore::from_url(&url);
 
         let lines = playlist.lines();
         for line in lines {
@@ -283,6 +298,18 @@ impl MediaPlaylist {
                 };
 
                 match &str_line[4..colon_idx] {
+                    "-X-DEFINE" => match parse_define_tag(&str_line) {
+                        Ok(VariableDefinition::Name { name, value }) => {
+                            variable_store.define(name, value)?
+                        }
+                        Ok(VariableDefinition::Import { name }) => {
+                            variable_store.import(&name, context.multivariant_variables())?
+                        }
+                        Ok(VariableDefinition::QueryParam { name }) => {
+                            variable_store.define_query_param(&name)?
+                        }
+                        Err(err) => return Err(err.into()),
+                    },
                     "-X-VERSION" => match parse_decimal_integer(&str_line, colon_idx + 1).0 {
                         Ok(v) if v <= (u32::MAX as u64) => version = Some(v as u32),
                         _ => Logger::warn("Unparsable VERSION value"),
@@ -360,7 +387,8 @@ impl MediaPlaylist {
                                             parse_quoted_string(&str_line, base_offset + idx + 1);
                                         base_offset = end_offset + 1;
                                         if let Ok(val) = parsed {
-                                            let init_url = Url::new(val.to_owned());
+                                            let val = variable_store.substitute(val)?;
+                                            let init_url = Url::new(val.into_owned());
                                             let init_url = if init_url.is_absolute() {
                                                 init_url
                                             } else {
@@ -375,7 +403,8 @@ impl MediaPlaylist {
                                             parse_quoted_string(&str_line, base_offset + idx + 1);
                                         base_offset = end_offset + 1;
                                         if let Ok(val) = parsed {
-                                            match parse_byte_range(val, 0, None) {
+                                            let val = variable_store.substitute(val)?;
+                                            match parse_byte_range(&val, 0, None) {
                                                 Some(br) => {
                                                     current_byte = Some(br.last_byte + 1);
                                                     map_info_byte_range = Some(br);
@@ -412,7 +441,8 @@ impl MediaPlaylist {
                 }
             } else {
                 // URI
-                let seg_url = Url::new(str_line);
+                let seg_line = variable_store.substitute(&str_line)?;
+                let seg_url = Url::new(seg_line.into_owned());
                 let seg_url = if seg_url.is_absolute() {
                     seg_url
                 } else {

--- a/src/rs-core/parser/media_playlist.rs
+++ b/src/rs-core/parser/media_playlist.rs
@@ -1,21 +1,25 @@
+use super::{
+    multi_variant_playlist::MediaPlaylistContext,
+    value_parsers::{
+        parse_byte_range, parse_decimal_floating_point, parse_decimal_integer,
+        parse_start_attribute, ByteRange,
+    },
+    variable_substitution::VariableDefinition,
+};
 use crate::{
     bindings::{MediaType, PlaylistNature},
+    parser::{
+        attribute_list::{parse_enumerated_string, AttributeListIter},
+        value_parsers::{parse_iso_8601_date, StartAttribute},
+        variable_substitution::{
+            parse_define_tag, parse_substituted_quoted_string, VariableDefinitionError,
+            VariableStore,
+        },
+    },
     utils::url::Url,
     Logger,
 };
 use std::{error, fmt, io::BufRead};
-
-use super::{
-    multi_variant_playlist::MediaPlaylistContext,
-    utils::{
-        parse_byte_range, parse_decimal_floating_point, parse_decimal_integer, parse_define_tag,
-        parse_enumerated_string, parse_iso_8601_date, parse_start_attribute,
-        parse_substituted_quoted_string, AttributeListIter, StartAttribute, VariableDefinition,
-        VariableDefinitionError, VariableStore,
-    },
-};
-
-pub use super::utils::ByteRange;
 
 /// Object storing the time information on a single media segment.
 #[derive(Clone, Debug)]

--- a/src/rs-core/parser/media_playlist.rs
+++ b/src/rs-core/parser/media_playlist.rs
@@ -9,8 +9,9 @@ use super::{
     multi_variant_playlist::MediaPlaylistContext,
     utils::{
         parse_byte_range, parse_decimal_floating_point, parse_decimal_integer, parse_define_tag,
-        parse_enumerated_string, parse_iso_8601_date, parse_quoted_string, parse_start_attribute,
-        StartAttribute, VariableDefinition, VariableDefinitionError, VariableStore,
+        parse_enumerated_string, parse_iso_8601_date, parse_start_attribute,
+        parse_substituted_quoted_string, AttributeListIter, StartAttribute, VariableDefinition,
+        VariableDefinitionError, VariableStore,
     },
 };
 
@@ -371,52 +372,41 @@ impl MediaPlaylist {
                     "-X-MAP" => {
                         let mut map_info_url: Option<Url> = None;
                         let mut map_info_byte_range: Option<ByteRange> = None;
-                        let mut base_offset = colon_idx + 1;
-                        loop {
-                            if base_offset >= str_line.len() {
-                                break;
-                            }
-                            match str_line[base_offset..].find('=') {
-                                None => {
-                                    Logger::warn("Attribute Name not followed by equal sign");
-                                    break;
+                        for item in AttributeListIter::new(&str_line, colon_idx + 1) {
+                            match item.name {
+                                "URI" => {
+                                    let val = parse_substituted_quoted_string(
+                                        &str_line,
+                                        item.value_start_offset,
+                                        &variable_store,
+                                    )?;
+                                    let init_url = Url::new(val);
+                                    let init_url = if init_url.is_absolute() {
+                                        init_url
+                                    } else {
+                                        Url::from_relative(playlist_base_url, init_url)
+                                    };
+                                    map_info_url = Some(init_url);
                                 }
-                                Some(idx) => match &str_line[base_offset..base_offset + idx] {
-                                    "URI" => {
-                                        let (parsed, end_offset) =
-                                            parse_quoted_string(&str_line, base_offset + idx + 1);
-                                        base_offset = end_offset + 1;
-                                        if let Ok(val) = parsed {
-                                            let val = variable_store.substitute(val)?;
-                                            let init_url = Url::new(val.into_owned());
-                                            let init_url = if init_url.is_absolute() {
-                                                init_url
-                                            } else {
-                                                Url::from_relative(playlist_base_url, init_url)
-                                            };
-                                            map_info_url = Some(init_url);
+                                "BYTERANGE" => {
+                                    let val = parse_substituted_quoted_string(
+                                        &str_line,
+                                        item.value_start_offset,
+                                        &variable_store,
+                                    )?;
+                                    match parse_byte_range(&val, 0, None) {
+                                        Some(br) => {
+                                            current_byte = Some(br.last_byte + 1);
+                                            map_info_byte_range = Some(br);
                                         }
-                                    }
-
-                                    "BYTERANGE" => {
-                                        let (parsed, end_offset) =
-                                            parse_quoted_string(&str_line, base_offset + idx + 1);
-                                        base_offset = end_offset + 1;
-                                        if let Ok(val) = parsed {
-                                            let val = variable_store.substitute(val)?;
-                                            match parse_byte_range(&val, 0, None) {
-                                                Some(br) => {
-                                                    current_byte = Some(br.last_byte + 1);
-                                                    map_info_byte_range = Some(br);
-                                                }
-                                                _ => return Err(
-                                                    MediaPlaylistParsingError::UnparsableByteRange,
-                                                ),
-                                            };
+                                        _ => {
+                                            return Err(
+                                                MediaPlaylistParsingError::UnparsableByteRange,
+                                            );
                                         }
-                                    }
-                                    _ => {}
-                                },
+                                    };
+                                }
+                                _ => {}
                             }
                         }
                         if let Some(url) = map_info_url {

--- a/src/rs-core/parser/media_playlist.rs
+++ b/src/rs-core/parser/media_playlist.rs
@@ -380,7 +380,7 @@ impl MediaPlaylist {
                                         item.value_start_offset,
                                         &variable_store,
                                     )?;
-                                    let init_url = Url::new(val);
+                                    let init_url = Url::new(val.into_owned());
                                     let init_url = if init_url.is_absolute() {
                                         init_url
                                     } else {

--- a/src/rs-core/parser/media_tag.rs
+++ b/src/rs-core/parser/media_tag.rs
@@ -3,7 +3,7 @@ use super::{
     multi_variant_playlist::MediaPlaylistContext,
     utils::{
         parse_comma_separated_list, parse_enumerated_string, parse_quoted_string,
-        skip_attribute_list_value,
+        skip_attribute_list_value, VariableStore,
     },
     MediaPlaylist,
 };
@@ -125,6 +125,7 @@ impl MediaTag {
         media_line: &str,
         multi_variant_playlist_url: &Url,
         id: u32,
+        variable_store: &VariableStore,
     ) -> Result<Self, MediaTagParsingError> {
         let playlist_base_url = multi_variant_playlist_url.pathname();
         let mut typ: Option<MediaTagType> = None;
@@ -174,7 +175,10 @@ impl MediaTag {
                             parse_quoted_string(media_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(parsed) = parsed {
-                            url = Some(Url::new(parsed.to_owned()));
+                            let parsed = variable_store
+                                .substitute(parsed)
+                                .map_err(|_| MediaTagParsingError::Unknown)?;
+                            url = Some(Url::new(parsed.into_owned()));
                         } else {
                             Logger::warn("Unparsable URI value");
                         }
@@ -184,7 +188,10 @@ impl MediaTag {
                             parse_quoted_string(media_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
-                            group_id = Some(val.to_owned());
+                            let val = variable_store
+                                .substitute(val)
+                                .map_err(|_| MediaTagParsingError::Unknown)?;
+                            group_id = Some(val.into_owned());
                         } else {
                             Logger::warn("Unparsable GROUP-ID value");
                         }
@@ -194,7 +201,10 @@ impl MediaTag {
                             parse_quoted_string(media_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
-                            language = Some(val.to_owned());
+                            let val = variable_store
+                                .substitute(val)
+                                .map_err(|_| MediaTagParsingError::Unknown)?;
+                            language = Some(val.into_owned());
                         } else {
                             Logger::warn("Unparsable LANGUAGE value");
                         }
@@ -204,7 +214,10 @@ impl MediaTag {
                             parse_quoted_string(media_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
-                            assoc_language = Some(val.to_owned());
+                            let val = variable_store
+                                .substitute(val)
+                                .map_err(|_| MediaTagParsingError::Unknown)?;
+                            assoc_language = Some(val.into_owned());
                         } else {
                             Logger::warn("Unparsable ASSOC-LANGUAGE value");
                         }
@@ -214,7 +227,10 @@ impl MediaTag {
                             parse_quoted_string(media_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
-                            name = Some(val.to_owned());
+                            let val = variable_store
+                                .substitute(val)
+                                .map_err(|_| MediaTagParsingError::Unknown)?;
+                            name = Some(val.into_owned());
                         } else {
                             Logger::warn("Unparsable NAME value");
                         }
@@ -224,7 +240,10 @@ impl MediaTag {
                             parse_quoted_string(media_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
-                            stable_rendition_id = Some(val.to_owned());
+                            let val = variable_store
+                                .substitute(val)
+                                .map_err(|_| MediaTagParsingError::Unknown)?;
+                            stable_rendition_id = Some(val.into_owned());
                         } else {
                             Logger::warn("Unparsable STABLE-RENDITION-ID value");
                         }
@@ -249,6 +268,9 @@ impl MediaTag {
                             parse_quoted_string(media_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
+                            let val = variable_store
+                                .substitute(val)
+                                .map_err(|_| MediaTagParsingError::Unknown)?;
                             match val.split('/').next().unwrap_or("").parse::<u32>() {
                                 Ok(parsed_channels) => channels = Some(parsed_channels),
                                 Err(_) => Logger::warn("Unparsable CHANNELS value"),
@@ -262,7 +284,14 @@ impl MediaTag {
                             parse_comma_separated_list(media_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(vals) = parsed {
-                            characteristics = vals.iter().map(|v| (*v).to_owned()).collect();
+                            let mut substituted_vals = Vec::with_capacity(vals.len());
+                            for value in vals {
+                                let value = variable_store
+                                    .substitute(value)
+                                    .map_err(|_| MediaTagParsingError::Unknown)?;
+                                substituted_vals.push(value.into_owned());
+                            }
+                            characteristics = substituted_vals;
                             characteristics.sort();
                             characteristics.dedup();
                         } else {

--- a/src/rs-core/parser/media_tag.rs
+++ b/src/rs-core/parser/media_tag.rs
@@ -1,9 +1,9 @@
 use super::{
+    attribute_list::{parse_enumerated_string, AttributeListIter},
     media_playlist::MediaPlaylistParsingError,
     multi_variant_playlist::MediaPlaylistContext,
-    utils::{
-        parse_enumerated_string, parse_substituted_comma_separated_list,
-        parse_substituted_quoted_string, AttributeListIter, VariableStore,
+    variable_substitution::{
+        parse_substituted_comma_separated_list, parse_substituted_quoted_string, VariableStore,
     },
     MediaPlaylist,
 };
@@ -147,9 +147,7 @@ impl MediaTag {
         for item in AttributeListIter::new(media_line, "#EXT-X-MEDIA:".len()) {
             match item.name {
                 "TYPE" => {
-                    let (parsed, end_offset) =
-                        parse_enumerated_string(media_line, item.value_start_offset);
-                    let _ = end_offset;
+                    let (parsed, _) = parse_enumerated_string(media_line, item.value_start_offset);
                     match parsed {
                         "AUDIO" => typ = Some(MediaTagType::Audio),
                         "VIDEO" => typ = Some(MediaTagType::Video),
@@ -260,18 +258,14 @@ impl MediaTag {
                     characteristics.dedup();
                 }
                 "BIT-DEPTH" => {
-                    let (parsed, end_offset) =
-                        parse_enumerated_string(media_line, item.value_start_offset);
-                    let _ = end_offset;
+                    let (parsed, _) = parse_enumerated_string(media_line, item.value_start_offset);
                     match parsed.parse::<u32>() {
                         Ok(val) => bit_depth = Some(val),
                         Err(_) => Logger::warn("Unparsable BIT-DEPTH value"),
                     }
                 }
                 "SAMPLE-RATE" => {
-                    let (parsed, end_offset) =
-                        parse_enumerated_string(media_line, item.value_start_offset);
-                    let _ = end_offset;
+                    let (parsed, _) = parse_enumerated_string(media_line, item.value_start_offset);
                     match parsed.parse::<u32>() {
                         Ok(val) => sample_rate = Some(val),
                         Err(_) => Logger::warn("Unparsable SAMPLE-RATE value"),

--- a/src/rs-core/parser/media_tag.rs
+++ b/src/rs-core/parser/media_tag.rs
@@ -168,7 +168,7 @@ impl MediaTag {
                         variable_store,
                     )
                     .map_err(|_| MediaTagParsingError::Unknown)?;
-                    url = Some(Url::new(parsed));
+                    url = Some(Url::new(parsed.into_owned()));
                 }
                 "GROUP-ID" => {
                     group_id = Some(
@@ -177,7 +177,8 @@ impl MediaTag {
                             item.value_start_offset,
                             variable_store,
                         )
-                        .map_err(|_| MediaTagParsingError::Unknown)?,
+                        .map_err(|_| MediaTagParsingError::Unknown)?
+                        .into_owned(),
                     );
                 }
                 "LANGUAGE" => {
@@ -187,7 +188,8 @@ impl MediaTag {
                             item.value_start_offset,
                             variable_store,
                         )
-                        .map_err(|_| MediaTagParsingError::Unknown)?,
+                        .map_err(|_| MediaTagParsingError::Unknown)?
+                        .into_owned(),
                     );
                 }
                 "ASSOC-LANGUAGE" => {
@@ -197,7 +199,8 @@ impl MediaTag {
                             item.value_start_offset,
                             variable_store,
                         )
-                        .map_err(|_| MediaTagParsingError::Unknown)?,
+                        .map_err(|_| MediaTagParsingError::Unknown)?
+                        .into_owned(),
                     );
                 }
                 "NAME" => {
@@ -207,7 +210,8 @@ impl MediaTag {
                             item.value_start_offset,
                             variable_store,
                         )
-                        .map_err(|_| MediaTagParsingError::Unknown)?,
+                        .map_err(|_| MediaTagParsingError::Unknown)?
+                        .into_owned(),
                     );
                 }
                 "STABLE-RENDITION-ID" => {
@@ -217,7 +221,8 @@ impl MediaTag {
                             item.value_start_offset,
                             variable_store,
                         )
-                        .map_err(|_| MediaTagParsingError::Unknown)?,
+                        .map_err(|_| MediaTagParsingError::Unknown)?
+                        .into_owned(),
                     );
                 }
                 "DEFAULT" => {
@@ -247,7 +252,10 @@ impl MediaTag {
                         item.value_start_offset,
                         variable_store,
                     )
-                    .map_err(|_| MediaTagParsingError::Unknown)?;
+                    .map_err(|_| MediaTagParsingError::Unknown)?
+                    .into_iter()
+                    .map(|v| v.into_owned())
+                    .collect();
                     characteristics.sort();
                     characteristics.dedup();
                 }

--- a/src/rs-core/parser/media_tag.rs
+++ b/src/rs-core/parser/media_tag.rs
@@ -2,8 +2,8 @@ use super::{
     media_playlist::MediaPlaylistParsingError,
     multi_variant_playlist::MediaPlaylistContext,
     utils::{
-        parse_comma_separated_list, parse_enumerated_string, parse_quoted_string,
-        skip_attribute_list_value, VariableStore,
+        parse_enumerated_string, parse_substituted_comma_separated_list,
+        parse_substituted_quoted_string, AttributeListIter, VariableStore,
     },
     MediaPlaylist,
 };
@@ -144,180 +144,132 @@ impl MediaTag {
         let mut bit_depth: Option<u32> = None;
         let mut sample_rate: Option<u32> = None;
 
-        let mut offset = "#EXT-X-MEDIA:".len();
-        loop {
-            if offset >= media_line.len() {
-                break;
-            }
-            match media_line[offset..].find('=') {
-                None => {
-                    Logger::warn("Attribute Name not followed by equal sign");
-                    break;
+        for item in AttributeListIter::new(media_line, "#EXT-X-MEDIA:".len()) {
+            match item.name {
+                "TYPE" => {
+                    let (parsed, end_offset) =
+                        parse_enumerated_string(media_line, item.value_start_offset);
+                    let _ = end_offset;
+                    match parsed {
+                        "AUDIO" => typ = Some(MediaTagType::Audio),
+                        "VIDEO" => typ = Some(MediaTagType::Video),
+                        "SUBTITLES" => typ = Some(MediaTagType::Subtitles),
+                        "CLOSED-CAPTIONS" => typ = Some(MediaTagType::ClosedCaptions),
+                        x => {
+                            Logger::warn(&format!("Unrecognized media type: {}", x));
+                            typ = Some(MediaTagType::Other);
+                        }
+                    };
                 }
-                Some(idx) => match &media_line[offset..offset + idx] {
-                    "TYPE" => {
-                        let (parsed, end_offset) =
-                            parse_enumerated_string(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        match parsed {
-                            "AUDIO" => typ = Some(MediaTagType::Audio),
-                            "VIDEO" => typ = Some(MediaTagType::Video),
-                            "SUBTITLES" => typ = Some(MediaTagType::Subtitles),
-                            "CLOSED-CAPTIONS" => typ = Some(MediaTagType::ClosedCaptions),
-                            x => {
-                                Logger::warn(&format!("Unrecognized media type: {}", x));
-                                typ = Some(MediaTagType::Other);
-                            }
-                        };
+                "URI" => {
+                    let parsed = parse_substituted_quoted_string(
+                        media_line,
+                        item.value_start_offset,
+                        variable_store,
+                    )
+                    .map_err(|_| MediaTagParsingError::Unknown)?;
+                    url = Some(Url::new(parsed));
+                }
+                "GROUP-ID" => {
+                    group_id = Some(
+                        parse_substituted_quoted_string(
+                            media_line,
+                            item.value_start_offset,
+                            variable_store,
+                        )
+                        .map_err(|_| MediaTagParsingError::Unknown)?,
+                    );
+                }
+                "LANGUAGE" => {
+                    language = Some(
+                        parse_substituted_quoted_string(
+                            media_line,
+                            item.value_start_offset,
+                            variable_store,
+                        )
+                        .map_err(|_| MediaTagParsingError::Unknown)?,
+                    );
+                }
+                "ASSOC-LANGUAGE" => {
+                    assoc_language = Some(
+                        parse_substituted_quoted_string(
+                            media_line,
+                            item.value_start_offset,
+                            variable_store,
+                        )
+                        .map_err(|_| MediaTagParsingError::Unknown)?,
+                    );
+                }
+                "NAME" => {
+                    name = Some(
+                        parse_substituted_quoted_string(
+                            media_line,
+                            item.value_start_offset,
+                            variable_store,
+                        )
+                        .map_err(|_| MediaTagParsingError::Unknown)?,
+                    );
+                }
+                "STABLE-RENDITION-ID" => {
+                    stable_rendition_id = Some(
+                        parse_substituted_quoted_string(
+                            media_line,
+                            item.value_start_offset,
+                            variable_store,
+                        )
+                        .map_err(|_| MediaTagParsingError::Unknown)?,
+                    );
+                }
+                "DEFAULT" => {
+                    default = true;
+                }
+                "AUTOSELECT" => {
+                    autoselect = true;
+                }
+                "FORCED" => {
+                    forced = true;
+                }
+                "CHANNELS" => {
+                    let val = parse_substituted_quoted_string(
+                        media_line,
+                        item.value_start_offset,
+                        variable_store,
+                    )
+                    .map_err(|_| MediaTagParsingError::Unknown)?;
+                    match val.split('/').next().unwrap_or("").parse::<u32>() {
+                        Ok(parsed_channels) => channels = Some(parsed_channels),
+                        Err(_) => Logger::warn("Unparsable CHANNELS value"),
                     }
-                    "URI" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(parsed) = parsed {
-                            let parsed = variable_store
-                                .substitute(parsed)
-                                .map_err(|_| MediaTagParsingError::Unknown)?;
-                            url = Some(Url::new(parsed.into_owned()));
-                        } else {
-                            Logger::warn("Unparsable URI value");
-                        }
+                }
+                "CHARACTERISTICS" => {
+                    characteristics = parse_substituted_comma_separated_list(
+                        media_line,
+                        item.value_start_offset,
+                        variable_store,
+                    )
+                    .map_err(|_| MediaTagParsingError::Unknown)?;
+                    characteristics.sort();
+                    characteristics.dedup();
+                }
+                "BIT-DEPTH" => {
+                    let (parsed, end_offset) =
+                        parse_enumerated_string(media_line, item.value_start_offset);
+                    let _ = end_offset;
+                    match parsed.parse::<u32>() {
+                        Ok(val) => bit_depth = Some(val),
+                        Err(_) => Logger::warn("Unparsable BIT-DEPTH value"),
                     }
-                    "GROUP-ID" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let val = variable_store
-                                .substitute(val)
-                                .map_err(|_| MediaTagParsingError::Unknown)?;
-                            group_id = Some(val.into_owned());
-                        } else {
-                            Logger::warn("Unparsable GROUP-ID value");
-                        }
+                }
+                "SAMPLE-RATE" => {
+                    let (parsed, end_offset) =
+                        parse_enumerated_string(media_line, item.value_start_offset);
+                    let _ = end_offset;
+                    match parsed.parse::<u32>() {
+                        Ok(val) => sample_rate = Some(val),
+                        Err(_) => Logger::warn("Unparsable SAMPLE-RATE value"),
                     }
-                    "LANGUAGE" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let val = variable_store
-                                .substitute(val)
-                                .map_err(|_| MediaTagParsingError::Unknown)?;
-                            language = Some(val.into_owned());
-                        } else {
-                            Logger::warn("Unparsable LANGUAGE value");
-                        }
-                    }
-                    "ASSOC-LANGUAGE" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let val = variable_store
-                                .substitute(val)
-                                .map_err(|_| MediaTagParsingError::Unknown)?;
-                            assoc_language = Some(val.into_owned());
-                        } else {
-                            Logger::warn("Unparsable ASSOC-LANGUAGE value");
-                        }
-                    }
-                    "NAME" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let val = variable_store
-                                .substitute(val)
-                                .map_err(|_| MediaTagParsingError::Unknown)?;
-                            name = Some(val.into_owned());
-                        } else {
-                            Logger::warn("Unparsable NAME value");
-                        }
-                    }
-                    "STABLE-RENDITION-ID" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let val = variable_store
-                                .substitute(val)
-                                .map_err(|_| MediaTagParsingError::Unknown)?;
-                            stable_rendition_id = Some(val.into_owned());
-                        } else {
-                            Logger::warn("Unparsable STABLE-RENDITION-ID value");
-                        }
-                    }
-                    "DEFAULT" => {
-                        let end_offset = skip_attribute_list_value(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        default = true;
-                    }
-                    "AUTOSELECT" => {
-                        let end_offset = skip_attribute_list_value(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        autoselect = true;
-                    }
-                    "FORCED" => {
-                        let end_offset = skip_attribute_list_value(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        forced = true;
-                    }
-                    "CHANNELS" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let val = variable_store
-                                .substitute(val)
-                                .map_err(|_| MediaTagParsingError::Unknown)?;
-                            match val.split('/').next().unwrap_or("").parse::<u32>() {
-                                Ok(parsed_channels) => channels = Some(parsed_channels),
-                                Err(_) => Logger::warn("Unparsable CHANNELS value"),
-                            }
-                        } else {
-                            Logger::warn("Unparsable CHANNELS value");
-                        }
-                    }
-                    "CHARACTERISTICS" => {
-                        let (parsed, end_offset) =
-                            parse_comma_separated_list(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(vals) = parsed {
-                            let mut substituted_vals = Vec::with_capacity(vals.len());
-                            for value in vals {
-                                let value = variable_store
-                                    .substitute(value)
-                                    .map_err(|_| MediaTagParsingError::Unknown)?;
-                                substituted_vals.push(value.into_owned());
-                            }
-                            characteristics = substituted_vals;
-                            characteristics.sort();
-                            characteristics.dedup();
-                        } else {
-                            Logger::warn("Unparsable CHARACTERISTICS value");
-                        }
-                    }
-                    "BIT-DEPTH" => {
-                        let (parsed, end_offset) =
-                            parse_enumerated_string(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        match parsed.parse::<u32>() {
-                            Ok(val) => bit_depth = Some(val),
-                            Err(_) => Logger::warn("Unparsable BIT-DEPTH value"),
-                        }
-                    }
-                    "SAMPLE-RATE" => {
-                        let (parsed, end_offset) =
-                            parse_enumerated_string(media_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        match parsed.parse::<u32>() {
-                            Ok(val) => sample_rate = Some(val),
-                            Err(_) => Logger::warn("Unparsable SAMPLE-RATE value"),
-                        }
-                    }
-                    _ => offset = skip_attribute_list_value(media_line, offset + idx + 1) + 1,
-                },
+                }
+                _ => {}
             }
         }
 

--- a/src/rs-core/parser/mod.rs
+++ b/src/rs-core/parser/mod.rs
@@ -1,18 +1,21 @@
+mod attribute_list;
 mod audio_track_list;
 mod media_playlist;
 mod media_tag;
 mod multi_variant_playlist;
-mod utils;
+mod value_parsers;
+mod variable_substitution;
 mod variant_stream;
 
 pub(crate) use audio_track_list::AudioTrack;
 pub(crate) use media_playlist::{
-    ByteRange, InitSegmentInfo, MediaPlaylist, MediaPlaylistParsingError, MediaSegmentInfo,
-    SegmentList, SegmentTimeInfo,
+    InitSegmentInfo, MediaPlaylist, MediaPlaylistParsingError, MediaSegmentInfo, SegmentList,
+    SegmentTimeInfo,
 };
 pub(crate) use media_tag::{MediaTag, MediaTagType};
 pub(crate) use multi_variant_playlist::{
     MediaPlaylistPermanentId, MediaPlaylistUpdateError, MultivariantPlaylist,
     MultivariantPlaylistParsingError,
 };
+pub(crate) use value_parsers::ByteRange;
 pub(crate) use variant_stream::{VariantStream, VideoResolution};

--- a/src/rs-core/parser/multi_variant_playlist.rs
+++ b/src/rs-core/parser/multi_variant_playlist.rs
@@ -1,12 +1,15 @@
 use super::audio_track_list::AudioTrackList;
 use super::media_playlist::{MediaPlaylist, MediaPlaylistParsingError};
 use super::media_tag::{MediaTag, MediaTagParsingError};
-use super::utils::StartAttribute;
+use super::utils::{
+    parse_define_tag, StartAttribute, VariableDefinition, VariableDefinitionError, VariableStore,
+};
 use super::variant_stream::{VariantParsingError, VariantStream};
 use super::{AudioTrack, MediaTagType};
 use crate::parser::utils::parse_start_attribute;
 use crate::utils::url::Url;
 use crate::Logger;
+use std::collections::HashMap;
 use std::{error, fmt, io};
 
 /// Represents a parsed HLS Multivariant Playlist (a.k.a. Master Playlist).
@@ -50,6 +53,7 @@ impl MultivariantPlaylist {
         let mut other_media: Vec<MediaTag> = vec![];
         let mut start = None;
         let mut independent_segments = None;
+        let mut variable_store = VariableStore::from_url(&url);
 
         let mut lines = playlist.lines();
         match lines.next() {
@@ -74,6 +78,18 @@ impl MultivariantPlaylist {
                     Some(idx) => idx + 4,
                 };
                 match &str_line[4..colon_idx] {
+                    "-X-DEFINE" => match parse_define_tag(&str_line) {
+                        Ok(VariableDefinition::Name { name, value }) => {
+                            variable_store.define(name, value)?
+                        }
+                        Ok(VariableDefinition::Import { .. }) => {
+                            return Err(MultivariantPlaylistParsingError::Unknown);
+                        }
+                        Ok(VariableDefinition::QueryParam { name }) => {
+                            variable_store.define_query_param(&name)?
+                        }
+                        Err(err) => return Err(err.into()),
+                    },
                     "-X-STREAM-INF" => {
                         let variant_url =
                             match lines.next() {
@@ -85,7 +101,10 @@ impl MultivariantPlaylist {
                                         MultivariantPlaylistParsingError::UnableToReadVariantUri,
                                     )
                                 }
-                                Some(Ok(l)) => Url::new(l),
+                                Some(Ok(l)) => {
+                                    let line = variable_store.substitute(&l)?;
+                                    Url::new(line.into_owned())
+                                }
                             };
 
                         let variant = VariantStream::create_from_stream_inf(
@@ -93,12 +112,13 @@ impl MultivariantPlaylist {
                             variant_url,
                             playlist_base_url,
                             last_id,
+                            &variable_store,
                         )?;
                         last_id += 1;
                         variants.push(variant);
                     }
                     "-X-MEDIA" => {
-                        let media = MediaTag::create(&str_line, &url, last_id)?;
+                        let media = MediaTag::create(&str_line, &url, last_id, &variable_store)?;
                         last_id += 1;
                         if media.typ() == MediaTagType::Audio {
                             audio_media.push(media);
@@ -147,6 +167,7 @@ impl MultivariantPlaylist {
             context: MediaPlaylistContext {
                 start,
                 independent_segments,
+                multivariant_variables: variable_store.definitions().clone(),
             },
         })
     }
@@ -480,6 +501,7 @@ impl MultivariantPlaylist {
 pub(crate) struct MediaPlaylistContext {
     independent_segments: Option<bool>,
     start: Option<StartAttribute>,
+    multivariant_variables: HashMap<String, String>,
 }
 
 impl MediaPlaylistContext {
@@ -489,12 +511,15 @@ impl MediaPlaylistContext {
     pub(crate) fn independent_segments(&self) -> Option<bool> {
         self.independent_segments
     }
+    pub(crate) fn multivariant_variables(&self) -> &HashMap<String, String> {
+        &self.multivariant_variables
+    }
 }
 
 // NOTE: should we add information on the line at which the error was encountered?
 // It may not be always trivial relatively to the cost of development though.
 #[derive(Debug)]
-pub enum MultivariantPlaylistParsingError {
+pub(crate) enum MultivariantPlaylistParsingError {
     MissingExtM3uHeader,
     MissingUriLineAfterVariant,
     UnableToReadVariantUri,
@@ -508,6 +533,8 @@ pub enum MultivariantPlaylistParsingError {
     MediaTagMissingGroupId,
 
     UnableToReadLine,
+
+    VariableDefinition(VariableDefinitionError),
 
     Unknown,
 }
@@ -546,6 +573,9 @@ impl fmt::Display for MultivariantPlaylistParsingError {
                 f,
                 "The first line of the Multivariant Playlist isn't `#EXTM3U`. Are you sure this is a Multivariant Playlist?"
             ),
+            MultivariantPlaylistParsingError::VariableDefinition(err) => {
+                write!(f, "Invalid EXT-X-DEFINE usage in the Multivariant Playlist: {:?}", err)
+            }
             MultivariantPlaylistParsingError::Unknown => write!(
                 f,
                 "An unknown error was encountered while parsing the MultivariantPlaylist"
@@ -586,8 +616,14 @@ impl From<MediaTagParsingError> for MultivariantPlaylistParsingError {
     }
 }
 
+impl From<VariableDefinitionError> for MultivariantPlaylistParsingError {
+    fn from(err: VariableDefinitionError) -> MultivariantPlaylistParsingError {
+        MultivariantPlaylistParsingError::VariableDefinition(err)
+    }
+}
+
 #[derive(Debug)]
-pub enum MediaPlaylistUpdateError {
+pub(crate) enum MediaPlaylistUpdateError {
     NotFound,
     ParsingError(MediaPlaylistParsingError),
 }
@@ -645,4 +681,125 @@ enum MediaPlaylistUrlLocation {
     AudioTrack,
     /// This Media Playlist's URL is defined as another media in the `MultivariantPlaylist` object.
     OtherMedia,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn substitutes_multivariant_variables_in_variant_and_media_tags() {
+        let playlist = r#"#EXTM3U
+#EXT-X-DEFINE:NAME="host",VALUE="https://cdn.example.com"
+#EXT-X-DEFINE:NAME="group",VALUE="aud-main"
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="{$group}",NAME="Track {$group}",URI="{$host}/audio.m3u8"
+#EXT-X-STREAM-INF:BANDWIDTH=1000,AUDIO="{$group}"
+{$host}/video.m3u8
+"#;
+        let parsed = MultivariantPlaylist::parse(
+            Cursor::new(playlist),
+            Url::new("https://example.com/master.m3u8".to_owned()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            parsed.variant_from_idx(0).unwrap().url().get_ref(),
+            "https://cdn.example.com/video.m3u8"
+        );
+        assert_eq!(parsed.audio_tracks()[0].name(), "Track aud-main");
+        assert_eq!(
+            parsed.audio_tracks()[0].medias()[0]
+                .url()
+                .unwrap()
+                .get_ref(),
+            "https://cdn.example.com/audio.m3u8"
+        );
+    }
+
+    #[test]
+    fn imports_multivariant_variables_and_query_params_in_media_playlists() {
+        let multivariant = r#"#EXTM3U
+#EXT-X-DEFINE:NAME="cdn",VALUE="https://cdn.example.com"
+#EXT-X-STREAM-INF:BANDWIDTH=1000
+video.m3u8
+"#;
+        let mut parsed = MultivariantPlaylist::parse(
+            Cursor::new(multivariant),
+            Url::new("https://example.com/master.m3u8".to_owned()),
+        )
+        .unwrap();
+        let media_playlist = r#"#EXTM3U
+#EXT-X-DEFINE:IMPORT="cdn"
+#EXT-X-DEFINE:QUERYPARAM="token"
+#EXT-X-TARGETDURATION:4
+#EXTINF:4,
+{$cdn}/seg.ts?auth={$token}
+"#;
+
+        let media = parsed
+            .update_media_playlist(
+                &MediaPlaylistPermanentId::new(MediaPlaylistUrlLocation::Variant, 0),
+                Cursor::new(media_playlist),
+                Url::new("https://example.com/video.m3u8?token=abc%20123".to_owned()),
+            )
+            .unwrap();
+
+        assert_eq!(
+            media.segment_list().media()[0].url().get_ref(),
+            "https://cdn.example.com/seg.ts?auth=abc 123"
+        );
+        assert!(parsed
+            .media_playlist(&MediaPlaylistPermanentId::new(
+                MediaPlaylistUrlLocation::Variant,
+                0
+            ))
+            .is_some());
+    }
+
+    #[test]
+    fn variables_do_not_implicitly_persist_across_media_playlist_reloads() {
+        let multivariant = r#"#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=1000
+video.m3u8
+"#;
+        let mut parsed = MultivariantPlaylist::parse(
+            Cursor::new(multivariant),
+            Url::new("https://example.com/master.m3u8".to_owned()),
+        )
+        .unwrap();
+        let first_media = r#"#EXTM3U
+#EXT-X-DEFINE:NAME="cdn",VALUE="https://cdn.example.com"
+#EXT-X-TARGETDURATION:4
+#EXTINF:4,
+{$cdn}/seg-1.ts
+"#;
+        parsed
+            .update_media_playlist(
+                &MediaPlaylistPermanentId::new(MediaPlaylistUrlLocation::Variant, 0),
+                Cursor::new(first_media),
+                Url::new("https://example.com/video.m3u8".to_owned()),
+            )
+            .unwrap();
+
+        let second_media = r#"#EXTM3U
+#EXT-X-TARGETDURATION:4
+#EXTINF:4,
+{$cdn}/seg-2.ts
+"#;
+        let err = parsed
+            .update_media_playlist(
+                &MediaPlaylistPermanentId::new(MediaPlaylistUrlLocation::Variant, 0),
+                Cursor::new(second_media),
+                Url::new("https://example.com/video.m3u8".to_owned()),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            MediaPlaylistUpdateError::ParsingError(MediaPlaylistParsingError::VariableDefinition(
+                _
+            ))
+        ));
+    }
 }

--- a/src/rs-core/parser/multi_variant_playlist.rs
+++ b/src/rs-core/parser/multi_variant_playlist.rs
@@ -1,16 +1,16 @@
-use super::audio_track_list::AudioTrackList;
-use super::media_playlist::{MediaPlaylist, MediaPlaylistParsingError};
-use super::media_tag::{MediaTag, MediaTagParsingError};
-use super::utils::{
-    parse_define_tag, StartAttribute, VariableDefinition, VariableDefinitionError, VariableStore,
+use super::{
+    audio_track_list::AudioTrackList,
+    media_playlist::{MediaPlaylist, MediaPlaylistParsingError},
+    media_tag::{MediaTag, MediaTagParsingError},
+    value_parsers::{parse_start_attribute, StartAttribute},
+    variable_substitution::{
+        parse_define_tag, VariableDefinition, VariableDefinitionError, VariableStore,
+    },
+    variant_stream::{VariantParsingError, VariantStream},
+    AudioTrack, MediaTagType,
 };
-use super::variant_stream::{VariantParsingError, VariantStream};
-use super::{AudioTrack, MediaTagType};
-use crate::parser::utils::parse_start_attribute;
-use crate::utils::url::Url;
-use crate::Logger;
-use std::collections::HashMap;
-use std::{error, fmt, io};
+use crate::{utils::url::Url, Logger};
+use std::{collections::HashMap, error, fmt, io};
 
 /// Represents a parsed HLS Multivariant Playlist (a.k.a. Master Playlist).
 ///
@@ -534,6 +534,8 @@ pub(crate) enum MultivariantPlaylistParsingError {
 
     UnableToReadLine,
 
+    // XXX TODO: Should we split those into each define error variants?
+    // Or would that be too much different error codes?
     VariableDefinition(VariableDefinitionError),
 
     Unknown,

--- a/src/rs-core/parser/multi_variant_playlist.rs
+++ b/src/rs-core/parser/multi_variant_playlist.rs
@@ -534,7 +534,7 @@ pub(crate) enum MultivariantPlaylistParsingError {
 
     UnableToReadLine,
 
-    // XXX TODO: Should we split those into each define error variants?
+    // TODO: Should we split those into each define error variants?
     // Or would that be too much different error codes?
     VariableDefinition(VariableDefinitionError),
 

--- a/src/rs-core/parser/utils.rs
+++ b/src/rs-core/parser/utils.rs
@@ -118,22 +118,71 @@ pub(crate) enum VariableDefinition {
     QueryParam { name: String },
 }
 
+pub(crate) struct AttributeListIter<'a> {
+    line: &'a str,
+    offset: usize,
+}
+
+pub(crate) struct AttributeListItem<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) value_start_offset: usize,
+}
+
+impl<'a> AttributeListIter<'a> {
+    pub(crate) fn new(line: &'a str, offset: usize) -> Self {
+        Self { line, offset }
+    }
+}
+
+impl<'a> Iterator for AttributeListIter<'a> {
+    type Item = AttributeListItem<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.offset >= self.line.len() {
+            return None;
+        }
+        let idx = self.line[self.offset..].find('=')?;
+        let item = AttributeListItem {
+            name: &self.line[self.offset..self.offset + idx],
+            value_start_offset: self.offset + idx + 1,
+        };
+        self.offset = skip_attribute_list_value(self.line, item.value_start_offset) + 1;
+        Some(item)
+    }
+}
+
+pub(crate) fn parse_substituted_quoted_string(
+    line: &str,
+    value_start_offset: usize,
+    variable_store: &VariableStore,
+) -> Result<String, VariableDefinitionError> {
+    let (parsed, _) = parse_quoted_string(line, value_start_offset);
+    let parsed = parsed.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
+    Ok(variable_store.substitute(parsed)?.into_owned())
+}
+
+pub(crate) fn parse_substituted_comma_separated_list(
+    line: &str,
+    value_start_offset: usize,
+    variable_store: &VariableStore,
+) -> Result<Vec<String>, VariableDefinitionError> {
+    let (parsed, _) = parse_comma_separated_list(line, value_start_offset);
+    let parsed = parsed.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
+    parsed
+        .into_iter()
+        .map(|value| variable_store.substitute(value).map(|v| v.into_owned()))
+        .collect()
+}
+
 pub(crate) fn parse_define_tag(line: &str) -> Result<VariableDefinition, VariableDefinitionError> {
     let mut name: Option<String> = None;
     let mut value: Option<String> = None;
     let mut import: Option<String> = None;
     let mut query_param: Option<String> = None;
-    let mut offset = "#EXT-X-DEFINE:".len();
-
-    while offset < line.len() {
-        let Some(idx) = line[offset..].find('=') else {
-            return Err(VariableDefinitionError::InvalidDefinition);
-        };
-        let attr_name = &line[offset..offset + idx];
-        let (parsed_value, end_offset) = parse_quoted_string(line, offset + idx + 1);
-        offset = end_offset + 1;
+    for item in AttributeListIter::new(line, "#EXT-X-DEFINE:".len()) {
+        let (parsed_value, _) = parse_quoted_string(line, item.value_start_offset);
         let parsed_value = parsed_value.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
-        match attr_name {
+        match item.name {
             "NAME" => name = Some(parsed_value.to_owned()),
             "VALUE" => value = Some(parsed_value.to_owned()),
             "IMPORT" => import = Some(parsed_value.to_owned()),
@@ -226,7 +275,7 @@ fn parse_query_params(url: &Url) -> HashMap<String, String> {
 }
 
 fn percent_decode(input: &str) -> Result<String, VariableDefinitionError> {
-    let mut result = String::with_capacity(input.len());
+    let mut result = Vec::with_capacity(input.len());
     let bytes = input.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
@@ -236,14 +285,14 @@ fn percent_decode(input: &str) -> Result<String, VariableDefinitionError> {
             }
             let high = from_hex(bytes[i + 1])?;
             let low = from_hex(bytes[i + 2])?;
-            result.push((high * 16 + low) as char);
+            result.push(high * 16 + low);
             i += 3;
         } else {
-            result.push(bytes[i] as char);
+            result.push(bytes[i]);
             i += 1;
         }
     }
-    Ok(result)
+    String::from_utf8(result).map_err(|_| VariableDefinitionError::InvalidPercentEncoding)
 }
 
 fn from_hex(byte: u8) -> Result<u8, VariableDefinitionError> {

--- a/src/rs-core/parser/utils.rs
+++ b/src/rs-core/parser/utils.rs
@@ -151,26 +151,26 @@ impl<'a> Iterator for AttributeListIter<'a> {
     }
 }
 
-pub(crate) fn parse_substituted_quoted_string(
-    line: &str,
+pub(crate) fn parse_substituted_quoted_string<'a>(
+    line: &'a str,
     value_start_offset: usize,
     variable_store: &VariableStore,
-) -> Result<String, VariableDefinitionError> {
+) -> Result<Cow<'a, str>, VariableDefinitionError> {
     let (parsed, _) = parse_quoted_string(line, value_start_offset);
     let parsed = parsed.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
-    Ok(variable_store.substitute(parsed)?.into_owned())
+    variable_store.substitute(parsed)
 }
 
-pub(crate) fn parse_substituted_comma_separated_list(
-    line: &str,
+pub(crate) fn parse_substituted_comma_separated_list<'a>(
+    line: &'a str,
     value_start_offset: usize,
     variable_store: &VariableStore,
-) -> Result<Vec<String>, VariableDefinitionError> {
+) -> Result<Vec<Cow<'a, str>>, VariableDefinitionError> {
     let (parsed, _) = parse_comma_separated_list(line, value_start_offset);
     let parsed = parsed.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
     parsed
         .into_iter()
-        .map(|value| variable_store.substitute(value).map(|v| v.into_owned()))
+        .map(|value| variable_store.substitute(value))
         .collect()
 }
 

--- a/src/rs-core/parser/utils.rs
+++ b/src/rs-core/parser/utils.rs
@@ -1,6 +1,259 @@
-use std::num::{ParseFloatError, ParseIntError};
+use crate::utils::url::Url;
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    num::{ParseFloatError, ParseIntError},
+};
 
 use crate::Logger;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum VariableDefinitionError {
+    DuplicateName,
+    MissingImportedVariable,
+    MissingQueryParam,
+    InvalidName,
+    InvalidPercentEncoding,
+    InvalidValue,
+    InvalidDefinition,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct VariableStore {
+    variables: HashMap<String, String>,
+    query_params: HashMap<String, String>,
+}
+
+impl VariableStore {
+    pub(crate) fn from_url(url: &Url) -> Self {
+        Self {
+            variables: HashMap::new(),
+            query_params: parse_query_params(url),
+        }
+    }
+
+    pub(crate) fn define(
+        &mut self,
+        name: String,
+        value: String,
+    ) -> Result<(), VariableDefinitionError> {
+        validate_variable_name(&name)?;
+        validate_variable_value(&value)?;
+        if self.variables.contains_key(&name) {
+            return Err(VariableDefinitionError::DuplicateName);
+        }
+        self.variables.insert(name, value);
+        Ok(())
+    }
+
+    pub(crate) fn import(
+        &mut self,
+        name: &str,
+        imported_variables: &HashMap<String, String>,
+    ) -> Result<(), VariableDefinitionError> {
+        validate_variable_name(name)?;
+        let value = imported_variables
+            .get(name)
+            .ok_or(VariableDefinitionError::MissingImportedVariable)?;
+        self.define(name.to_owned(), value.clone())
+    }
+
+    pub(crate) fn define_query_param(&mut self, name: &str) -> Result<(), VariableDefinitionError> {
+        validate_variable_name(name)?;
+        let value = self
+            .query_params
+            .get(name)
+            .ok_or(VariableDefinitionError::MissingQueryParam)?
+            .clone();
+        self.define(name.to_owned(), value)
+    }
+
+    pub(crate) fn substitute<'a>(
+        &self,
+        value: &'a str,
+    ) -> Result<Cow<'a, str>, VariableDefinitionError> {
+        let Some(first_idx) = value.find("{$") else {
+            return Ok(Cow::Borrowed(value));
+        };
+
+        let mut substituted = String::with_capacity(value.len());
+        substituted.push_str(&value[..first_idx]);
+        let mut offset = first_idx;
+        while offset < value.len() {
+            match value[offset..].find("{$") {
+                None => {
+                    substituted.push_str(&value[offset..]);
+                    break;
+                }
+                Some(relative_start) => {
+                    let start = offset + relative_start;
+                    substituted.push_str(&value[offset..start]);
+                    let after_start = start + 2;
+                    let Some(relative_end) = value[after_start..].find('}') else {
+                        return Err(VariableDefinitionError::InvalidDefinition);
+                    };
+                    let end = after_start + relative_end;
+                    let variable_name = &value[after_start..end];
+                    validate_variable_name(variable_name)?;
+                    let variable_value = self
+                        .variables
+                        .get(variable_name)
+                        .ok_or(VariableDefinitionError::InvalidDefinition)?;
+                    substituted.push_str(variable_value);
+                    offset = end + 1;
+                }
+            }
+        }
+        Ok(Cow::Owned(substituted))
+    }
+
+    pub(crate) fn definitions(&self) -> &HashMap<String, String> {
+        &self.variables
+    }
+}
+
+pub(crate) enum VariableDefinition {
+    Name { name: String, value: String },
+    Import { name: String },
+    QueryParam { name: String },
+}
+
+pub(crate) fn parse_define_tag(line: &str) -> Result<VariableDefinition, VariableDefinitionError> {
+    let mut name: Option<String> = None;
+    let mut value: Option<String> = None;
+    let mut import: Option<String> = None;
+    let mut query_param: Option<String> = None;
+    let mut offset = "#EXT-X-DEFINE:".len();
+
+    while offset < line.len() {
+        let Some(idx) = line[offset..].find('=') else {
+            return Err(VariableDefinitionError::InvalidDefinition);
+        };
+        let attr_name = &line[offset..offset + idx];
+        let (parsed_value, end_offset) = parse_quoted_string(line, offset + idx + 1);
+        offset = end_offset + 1;
+        let parsed_value = parsed_value.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
+        match attr_name {
+            "NAME" => name = Some(parsed_value.to_owned()),
+            "VALUE" => value = Some(parsed_value.to_owned()),
+            "IMPORT" => import = Some(parsed_value.to_owned()),
+            "QUERYPARAM" => query_param = Some(parsed_value.to_owned()),
+            _ => {}
+        }
+    }
+
+    let alternatives_count = usize::from(name.is_some())
+        + usize::from(import.is_some())
+        + usize::from(query_param.is_some());
+    if alternatives_count != 1 {
+        return Err(VariableDefinitionError::InvalidDefinition);
+    }
+
+    if let Some(name) = name {
+        if let Some(value) = value {
+            validate_variable_name(&name)?;
+            validate_variable_value(&value)?;
+            Ok(VariableDefinition::Name { name, value })
+        } else {
+            Err(VariableDefinitionError::InvalidDefinition)
+        }
+    } else if let Some(name) = import {
+        validate_variable_name(&name)?;
+        Ok(VariableDefinition::Import { name })
+    } else if let Some(name) = query_param {
+        validate_variable_name(&name)?;
+        Ok(VariableDefinition::QueryParam { name })
+    } else {
+        Err(VariableDefinitionError::InvalidDefinition)
+    }
+}
+
+fn validate_variable_name(name: &str) -> Result<(), VariableDefinitionError> {
+    if name.is_empty() {
+        return Err(VariableDefinitionError::InvalidName);
+    }
+    if name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    {
+        Ok(())
+    } else {
+        Err(VariableDefinitionError::InvalidName)
+    }
+}
+
+fn validate_variable_value(value: &str) -> Result<(), VariableDefinitionError> {
+    if value.contains('"') || value.contains('\r') || value.contains('\n') {
+        Err(VariableDefinitionError::InvalidValue)
+    } else {
+        Ok(())
+    }
+}
+
+fn parse_query_params(url: &Url) -> HashMap<String, String> {
+    let input = url.get_ref();
+    let Some(query_start) = input.find('?') else {
+        return HashMap::new();
+    };
+    let query = match input[query_start + 1..].find('#') {
+        Some(hash_offset) => &input[query_start + 1..query_start + 1 + hash_offset],
+        None => &input[query_start + 1..],
+    };
+
+    let mut result = HashMap::new();
+    for pair in query.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let Some(eq_idx) = pair.find('=') else {
+            continue;
+        };
+        let key = &pair[..eq_idx];
+        let val = &pair[eq_idx + 1..];
+        if result.contains_key(key) {
+            continue;
+        }
+        match percent_decode(val) {
+            Ok(decoded) => {
+                if validate_variable_value(&decoded).is_ok() {
+                    result.insert(key.to_owned(), decoded);
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+    result
+}
+
+fn percent_decode(input: &str) -> Result<String, VariableDefinitionError> {
+    let mut result = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if i + 2 >= bytes.len() {
+                return Err(VariableDefinitionError::InvalidPercentEncoding);
+            }
+            let high = from_hex(bytes[i + 1])?;
+            let low = from_hex(bytes[i + 2])?;
+            result.push((high * 16 + low) as char);
+            i += 3;
+        } else {
+            result.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    Ok(result)
+}
+
+fn from_hex(byte: u8) -> Result<u8, VariableDefinitionError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(VariableDefinitionError::InvalidPercentEncoding),
+    }
+}
 
 /// Parse decimal integer value as defined by the HLS specification:
 /// From the `value_start_offset` (which is the byte offset in `line` at which

--- a/src/rs-core/parser/value_parsers.rs
+++ b/src/rs-core/parser/value_parsers.rs
@@ -1,308 +1,8 @@
-use crate::utils::url::Url;
-use std::{
-    borrow::Cow,
-    collections::HashMap,
-    num::{ParseFloatError, ParseIntError},
+use super::attribute_list::{
+    find_attribute_end, parse_enumerated_string, skip_attribute_list_value,
 };
-
 use crate::Logger;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum VariableDefinitionError {
-    DuplicateName,
-    MissingImportedVariable,
-    MissingQueryParam,
-    InvalidName,
-    InvalidPercentEncoding,
-    InvalidValue,
-    InvalidDefinition,
-}
-
-#[derive(Clone, Debug, Default)]
-pub(crate) struct VariableStore {
-    variables: HashMap<String, String>,
-    query_params: HashMap<String, String>,
-}
-
-impl VariableStore {
-    pub(crate) fn from_url(url: &Url) -> Self {
-        Self {
-            variables: HashMap::new(),
-            query_params: parse_query_params(url),
-        }
-    }
-
-    pub(crate) fn define(
-        &mut self,
-        name: String,
-        value: String,
-    ) -> Result<(), VariableDefinitionError> {
-        validate_variable_name(&name)?;
-        validate_variable_value(&value)?;
-        if self.variables.contains_key(&name) {
-            return Err(VariableDefinitionError::DuplicateName);
-        }
-        self.variables.insert(name, value);
-        Ok(())
-    }
-
-    pub(crate) fn import(
-        &mut self,
-        name: &str,
-        imported_variables: &HashMap<String, String>,
-    ) -> Result<(), VariableDefinitionError> {
-        validate_variable_name(name)?;
-        let value = imported_variables
-            .get(name)
-            .ok_or(VariableDefinitionError::MissingImportedVariable)?;
-        self.define(name.to_owned(), value.clone())
-    }
-
-    pub(crate) fn define_query_param(&mut self, name: &str) -> Result<(), VariableDefinitionError> {
-        validate_variable_name(name)?;
-        let value = self
-            .query_params
-            .get(name)
-            .ok_or(VariableDefinitionError::MissingQueryParam)?
-            .clone();
-        self.define(name.to_owned(), value)
-    }
-
-    pub(crate) fn substitute<'a>(
-        &self,
-        value: &'a str,
-    ) -> Result<Cow<'a, str>, VariableDefinitionError> {
-        let Some(first_idx) = value.find("{$") else {
-            return Ok(Cow::Borrowed(value));
-        };
-
-        let mut substituted = String::with_capacity(value.len());
-        substituted.push_str(&value[..first_idx]);
-        let mut offset = first_idx;
-        while offset < value.len() {
-            match value[offset..].find("{$") {
-                None => {
-                    substituted.push_str(&value[offset..]);
-                    break;
-                }
-                Some(relative_start) => {
-                    let start = offset + relative_start;
-                    substituted.push_str(&value[offset..start]);
-                    let after_start = start + 2;
-                    let Some(relative_end) = value[after_start..].find('}') else {
-                        return Err(VariableDefinitionError::InvalidDefinition);
-                    };
-                    let end = after_start + relative_end;
-                    let variable_name = &value[after_start..end];
-                    validate_variable_name(variable_name)?;
-                    let variable_value = self
-                        .variables
-                        .get(variable_name)
-                        .ok_or(VariableDefinitionError::InvalidDefinition)?;
-                    substituted.push_str(variable_value);
-                    offset = end + 1;
-                }
-            }
-        }
-        Ok(Cow::Owned(substituted))
-    }
-
-    pub(crate) fn definitions(&self) -> &HashMap<String, String> {
-        &self.variables
-    }
-}
-
-pub(crate) enum VariableDefinition {
-    Name { name: String, value: String },
-    Import { name: String },
-    QueryParam { name: String },
-}
-
-pub(crate) struct AttributeListIter<'a> {
-    line: &'a str,
-    offset: usize,
-}
-
-pub(crate) struct AttributeListItem<'a> {
-    pub(crate) name: &'a str,
-    pub(crate) value_start_offset: usize,
-}
-
-impl<'a> AttributeListIter<'a> {
-    pub(crate) fn new(line: &'a str, offset: usize) -> Self {
-        Self { line, offset }
-    }
-}
-
-impl<'a> Iterator for AttributeListIter<'a> {
-    type Item = AttributeListItem<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.offset >= self.line.len() {
-            return None;
-        }
-        let idx = self.line[self.offset..].find('=')?;
-        let item = AttributeListItem {
-            name: &self.line[self.offset..self.offset + idx],
-            value_start_offset: self.offset + idx + 1,
-        };
-        self.offset = skip_attribute_list_value(self.line, item.value_start_offset) + 1;
-        Some(item)
-    }
-}
-
-pub(crate) fn parse_substituted_quoted_string<'a>(
-    line: &'a str,
-    value_start_offset: usize,
-    variable_store: &VariableStore,
-) -> Result<Cow<'a, str>, VariableDefinitionError> {
-    let (parsed, _) = parse_quoted_string(line, value_start_offset);
-    let parsed = parsed.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
-    variable_store.substitute(parsed)
-}
-
-pub(crate) fn parse_substituted_comma_separated_list<'a>(
-    line: &'a str,
-    value_start_offset: usize,
-    variable_store: &VariableStore,
-) -> Result<Vec<Cow<'a, str>>, VariableDefinitionError> {
-    let (parsed, _) = parse_comma_separated_list(line, value_start_offset);
-    let parsed = parsed.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
-    parsed
-        .into_iter()
-        .map(|value| variable_store.substitute(value))
-        .collect()
-}
-
-pub(crate) fn parse_define_tag(line: &str) -> Result<VariableDefinition, VariableDefinitionError> {
-    let mut name: Option<String> = None;
-    let mut value: Option<String> = None;
-    let mut import: Option<String> = None;
-    let mut query_param: Option<String> = None;
-    for item in AttributeListIter::new(line, "#EXT-X-DEFINE:".len()) {
-        let (parsed_value, _) = parse_quoted_string(line, item.value_start_offset);
-        let parsed_value = parsed_value.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
-        match item.name {
-            "NAME" => name = Some(parsed_value.to_owned()),
-            "VALUE" => value = Some(parsed_value.to_owned()),
-            "IMPORT" => import = Some(parsed_value.to_owned()),
-            "QUERYPARAM" => query_param = Some(parsed_value.to_owned()),
-            _ => {}
-        }
-    }
-
-    let alternatives_count = usize::from(name.is_some())
-        + usize::from(import.is_some())
-        + usize::from(query_param.is_some());
-    if alternatives_count != 1 {
-        return Err(VariableDefinitionError::InvalidDefinition);
-    }
-
-    if let Some(name) = name {
-        if let Some(value) = value {
-            validate_variable_name(&name)?;
-            validate_variable_value(&value)?;
-            Ok(VariableDefinition::Name { name, value })
-        } else {
-            Err(VariableDefinitionError::InvalidDefinition)
-        }
-    } else if let Some(name) = import {
-        validate_variable_name(&name)?;
-        Ok(VariableDefinition::Import { name })
-    } else if let Some(name) = query_param {
-        validate_variable_name(&name)?;
-        Ok(VariableDefinition::QueryParam { name })
-    } else {
-        Err(VariableDefinitionError::InvalidDefinition)
-    }
-}
-
-fn validate_variable_name(name: &str) -> Result<(), VariableDefinitionError> {
-    if name.is_empty() {
-        return Err(VariableDefinitionError::InvalidName);
-    }
-    if name
-        .bytes()
-        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
-    {
-        Ok(())
-    } else {
-        Err(VariableDefinitionError::InvalidName)
-    }
-}
-
-fn validate_variable_value(value: &str) -> Result<(), VariableDefinitionError> {
-    if value.contains('"') || value.contains('\r') || value.contains('\n') {
-        Err(VariableDefinitionError::InvalidValue)
-    } else {
-        Ok(())
-    }
-}
-
-fn parse_query_params(url: &Url) -> HashMap<String, String> {
-    let input = url.get_ref();
-    let Some(query_start) = input.find('?') else {
-        return HashMap::new();
-    };
-    let query = match input[query_start + 1..].find('#') {
-        Some(hash_offset) => &input[query_start + 1..query_start + 1 + hash_offset],
-        None => &input[query_start + 1..],
-    };
-
-    let mut result = HashMap::new();
-    for pair in query.split('&') {
-        if pair.is_empty() {
-            continue;
-        }
-        let Some(eq_idx) = pair.find('=') else {
-            continue;
-        };
-        let key = &pair[..eq_idx];
-        let val = &pair[eq_idx + 1..];
-        if result.contains_key(key) {
-            continue;
-        }
-        match percent_decode(val) {
-            Ok(decoded) => {
-                if validate_variable_value(&decoded).is_ok() {
-                    result.insert(key.to_owned(), decoded);
-                }
-            }
-            Err(_) => continue,
-        }
-    }
-    result
-}
-
-fn percent_decode(input: &str) -> Result<String, VariableDefinitionError> {
-    let mut result = Vec::with_capacity(input.len());
-    let bytes = input.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' {
-            if i + 2 >= bytes.len() {
-                return Err(VariableDefinitionError::InvalidPercentEncoding);
-            }
-            let high = from_hex(bytes[i + 1])?;
-            let low = from_hex(bytes[i + 2])?;
-            result.push(high * 16 + low);
-            i += 3;
-        } else {
-            result.push(bytes[i]);
-            i += 1;
-        }
-    }
-    String::from_utf8(result).map_err(|_| VariableDefinitionError::InvalidPercentEncoding)
-}
-
-fn from_hex(byte: u8) -> Result<u8, VariableDefinitionError> {
-    match byte {
-        b'0'..=b'9' => Ok(byte - b'0'),
-        b'a'..=b'f' => Ok(byte - b'a' + 10),
-        b'A'..=b'F' => Ok(byte - b'A' + 10),
-        _ => Err(VariableDefinitionError::InvalidPercentEncoding),
-    }
-}
+use std::num::{ParseFloatError, ParseIntError};
 
 /// Parse decimal integer value as defined by the HLS specification:
 /// From the `value_start_offset` (which is the byte offset in `line` at which
@@ -316,89 +16,6 @@ pub(super) fn parse_decimal_integer(
     match line[value_start_offset..end].parse::<u64>() {
         Ok(val) => (Ok(val), end),
         Err(x) => (Err(x), end),
-    }
-}
-
-/// Parse enumerated string value as defined by the HLS specification:
-/// From the `value_start_offset` (which is the byte offset in `line` at which
-/// the value starts), to either the next encountered comma, or the end of `line`,
-/// whichever comes sooner.
-///
-/// More than parsing enumerated string values, this function actually just parse
-/// a string without quotes. As such it can be used for any value respecting that
-/// criteria.
-pub(super) fn parse_enumerated_string(line: &str, value_start_offset: usize) -> (&str, usize) {
-    let end = find_attribute_end(line, value_start_offset);
-    (line[value_start_offset..end].as_ref(), end)
-}
-
-pub(super) enum QuotedStringParsingError {
-    NoStartingQuote,
-    NoEndingQuote,
-}
-
-#[inline]
-pub(super) fn find_attribute_end(line: &str, offset: usize) -> usize {
-    line[offset..].find(',').map_or(line.len(), |x| x + offset)
-}
-
-pub(super) fn parse_quoted_string(
-    line: &str,
-    value_start_offset: usize,
-) -> (Result<&str, QuotedStringParsingError>, usize) {
-    if &line[value_start_offset..value_start_offset + 1] != "\"" {
-        let end = find_attribute_end(line, value_start_offset);
-        (Err(QuotedStringParsingError::NoStartingQuote), end)
-    } else {
-        match line[value_start_offset + 1..].find('"') {
-            Some(relative_end_quote_idx) => {
-                let end_quote_idx = value_start_offset + 1 + relative_end_quote_idx;
-                let end = find_attribute_end(line, end_quote_idx + 1);
-                (Ok(&line[value_start_offset + 1..end_quote_idx]), end)
-            }
-            None => {
-                let end = find_attribute_end(line, value_start_offset + 1);
-                (Err(QuotedStringParsingError::NoEndingQuote), end)
-            }
-        }
-    }
-}
-
-pub(super) fn parse_comma_separated_list(
-    line: &str,
-    value_start_offset: usize,
-) -> (Result<Vec<&str>, QuotedStringParsingError>, usize) {
-    let parsed = parse_quoted_string(line, value_start_offset);
-    let splitted = parsed.0.map(|s| s.split(',').collect());
-    (splitted, parsed.1)
-}
-
-pub(super) fn skip_attribute_list_value(line: &str, value_start_offset: usize) -> usize {
-    if line.len() <= value_start_offset {
-        return value_start_offset;
-    }
-
-    // Check if the attribute list value is a quoted one
-    if &line[value_start_offset..value_start_offset + 1] == "\"" {
-        match line[value_start_offset + 1..].find('\"') {
-            Some(relative_end_quote_idx) => {
-                let end_quote_idx = value_start_offset + relative_end_quote_idx;
-
-                // Technically, a comma (',') character should always be found
-                // here if we're not at the end of the attribute list.
-                // Still, check where it is for resilience
-                match line[end_quote_idx + 1..].find(',') {
-                    Some(idx) => end_quote_idx + idx + 1,
-                    None => line.len(),
-                }
-            }
-            None => line.len(),
-        }
-    } else {
-        match line[value_start_offset..].find(',') {
-            Some(idx) => value_start_offset + idx,
-            None => line.len(),
-        }
     }
 }
 
@@ -643,6 +260,82 @@ pub fn parse_byte_range(
         first_byte: range_base,
         last_byte: range_base + range_size - 1,
     })
+}
+
+/// Value of the "EXT-X-START" tag as specified by the HLS specification.
+///
+/// Indicates at which position a player should start this Media Playlist
+#[derive(Clone, Debug)]
+pub(crate) struct StartAttribute {
+    /// A positive number indicates a time offset in seconds from the beginning of the Playlist.
+    /// A negative number indicates a negative time offset in seconds from the end of the last
+    /// media segment in the Playlist.
+    pub(super) time_offset: f64,
+    /// If `true`, we should start playing at exactly the calculated time offset.
+    ///
+    /// If `false`, we should start playing at the beginning of the segment which includes the
+    /// calculated time offset.
+    pub(super) precise: bool,
+}
+
+pub(super) enum StartAttributeParsingError {
+    NoTimeOffset,
+    TimeOffsetParsingError(ParseFloatError),
+    InvalidPreciseValue,
+}
+
+pub(super) fn parse_start_attribute(
+    start_line: &str,
+) -> Result<StartAttribute, StartAttributeParsingError> {
+    let mut time_offset: Option<f64> = None;
+    let mut precise = false;
+
+    let mut offset = "#EXT-X-START:".len();
+    loop {
+        if offset >= start_line.len() {
+            break;
+        }
+        match start_line[offset..].find('=') {
+            None => {
+                Logger::warn("Attribute Name not followed by equal sign");
+                break;
+            }
+            Some(idx) => match &start_line[offset..offset + idx] {
+                "PRECISE" => {
+                    let (parsed, end_offset) =
+                        parse_enumerated_string(start_line, offset + idx + 1);
+                    offset = end_offset + 1;
+                    match parsed {
+                        "YES" => precise = true,
+                        "NO" => precise = false,
+                        _ => {
+                            return Err(StartAttributeParsingError::InvalidPreciseValue);
+                        }
+                    };
+                }
+                "TIME-OFFSET" => {
+                    let (parsed, end_offset) =
+                        parse_decimal_floating_point(start_line, offset + idx + 1);
+                    offset = end_offset + 1;
+                    match parsed {
+                        Err(x) => {
+                            return Err(StartAttributeParsingError::TimeOffsetParsingError(x));
+                        }
+                        Ok(x) => time_offset = Some(x),
+                    }
+                }
+                _ => offset = skip_attribute_list_value(start_line, offset + idx + 1) + 1,
+            },
+        }
+    }
+    if let Some(time_offset) = time_offset {
+        Ok(StartAttribute {
+            time_offset,
+            precise,
+        })
+    } else {
+        Err(StartAttributeParsingError::NoTimeOffset)
+    }
 }
 
 fn read_integer_until(value: &[u8], base_offset: usize, ending_char: u8) -> (Option<u64>, usize) {
@@ -935,81 +628,5 @@ mod tests {
         assert_eq!(parse_iso_8601_date("1968-03-2916:01:21.050Z", 0), None);
         assert_eq!(parse_iso_8601_date("1968-02-29R20:54:56.810Z", 0), None);
         assert_eq!(parse_iso_8601_date("1968-0229T16:01:21.050Z", 0), None);
-    }
-}
-
-/// Value of the "EXT-X-START" tag as specified by the HLS specification.
-///
-/// Indicates at which position a player should start this Media Playlist
-#[derive(Clone, Debug)]
-pub(crate) struct StartAttribute {
-    /// A positive number indicates a time offset in seconds from the beginning of the Playlist.
-    /// A negative number indicates a negative time offset in seconds from the end of the last
-    /// media segment in the Playlist.
-    pub(super) time_offset: f64,
-    /// If `true`, we should start playing at exactly the calculated time offset.
-    ///
-    /// If `false`, we should start playing at the beginning of the segment which includes the
-    /// calculated time offset.
-    pub(super) precise: bool,
-}
-
-pub(super) enum StartAttributeParsingError {
-    NoTimeOffset,
-    TimeOffsetParsingError(ParseFloatError),
-    InvalidPreciseValue,
-}
-
-pub(super) fn parse_start_attribute(
-    start_line: &str,
-) -> Result<StartAttribute, StartAttributeParsingError> {
-    let mut time_offset: Option<f64> = None;
-    let mut precise = false;
-
-    let mut offset = "#EXT-X-START:".len();
-    loop {
-        if offset >= start_line.len() {
-            break;
-        }
-        match start_line[offset..].find('=') {
-            None => {
-                Logger::warn("Attribute Name not followed by equal sign");
-                break;
-            }
-            Some(idx) => match &start_line[offset..offset + idx] {
-                "PRECISE" => {
-                    let (parsed, end_offset) =
-                        parse_enumerated_string(start_line, offset + idx + 1);
-                    offset = end_offset + 1;
-                    match parsed {
-                        "YES" => precise = true,
-                        "NO" => precise = false,
-                        _ => {
-                            return Err(StartAttributeParsingError::InvalidPreciseValue);
-                        }
-                    };
-                }
-                "TIME-OFFSET" => {
-                    let (parsed, end_offset) =
-                        parse_decimal_floating_point(start_line, offset + idx + 1);
-                    offset = end_offset + 1;
-                    match parsed {
-                        Err(x) => {
-                            return Err(StartAttributeParsingError::TimeOffsetParsingError(x));
-                        }
-                        Ok(x) => time_offset = Some(x),
-                    }
-                }
-                _ => offset = skip_attribute_list_value(start_line, offset + idx + 1) + 1,
-            },
-        }
-    }
-    if let Some(time_offset) = time_offset {
-        Ok(StartAttribute {
-            time_offset,
-            precise,
-        })
-    } else {
-        Err(StartAttributeParsingError::NoTimeOffset)
     }
 }

--- a/src/rs-core/parser/variable_substitution.rs
+++ b/src/rs-core/parser/variable_substitution.rs
@@ -1,0 +1,282 @@
+use super::attribute_list::{parse_comma_separated_list, parse_quoted_string, AttributeListIter};
+use crate::utils::url::Url;
+use std::{borrow::Cow, collections::HashMap};
+
+/// Errors linked to HLS's EXT-X-DEFINE - based variable substitution
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum VariableDefinitionError {
+    /// The given variable key was defined multiple times
+    DuplicateName,
+    /// The imported variable was not found in the banks of declared variable names
+    MissingImportedVariable,
+    /// The imported variable relied on a Query string params that did not exist
+    MissingQueryParam,
+    /// The variable name contained an un-authorized character
+    InvalidName,
+    /// Query params that may be used by variable definitions need to be percent decoded.
+    /// This error arises if the percent encoding was invalid.
+    InvalidPercentEncoding,
+    /// The variable value contained an un-authorized character
+    InvalidValue,
+    /// The definition or usage of a variable was invalid.
+    /// XXX TODO: different errors?
+    InvalidDefinition,
+}
+
+/// Store all variable definitions parsed until now and allow variable substitution
+/// of parsed attributes.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct VariableStore {
+    variables: HashMap<String, String>,
+    query_params: HashMap<String, String>,
+}
+
+impl VariableStore {
+    /// Create a new `VariableStore`. Rely on the corresponding playlist's URL
+    /// because variable definitions might rely on the query string.
+    pub(crate) fn from_url(url: &Url) -> Self {
+        Self {
+            variables: HashMap::new(),
+            query_params: parse_query_params(url),
+        }
+    }
+
+    /// Define a new variable with the given name and value.
+    pub(crate) fn define(
+        &mut self,
+        name: String,
+        value: String,
+    ) -> Result<(), VariableDefinitionError> {
+        validate_variable_name(&name)?;
+        validate_variable_value(&value)?;
+        if self.variables.contains_key(&name) {
+            return Err(VariableDefinitionError::DuplicateName);
+        }
+        self.variables.insert(name, value);
+        Ok(())
+    }
+
+    pub(crate) fn import(
+        &mut self,
+        name: &str,
+        imported_variables: &HashMap<String, String>,
+    ) -> Result<(), VariableDefinitionError> {
+        validate_variable_name(name)?;
+        let value = imported_variables
+            .get(name)
+            .ok_or(VariableDefinitionError::MissingImportedVariable)?;
+        self.define(name.to_owned(), value.clone())
+    }
+
+    pub(crate) fn define_query_param(&mut self, name: &str) -> Result<(), VariableDefinitionError> {
+        validate_variable_name(name)?;
+        let value = self
+            .query_params
+            .get(name)
+            .ok_or(VariableDefinitionError::MissingQueryParam)?
+            .clone();
+        self.define(name.to_owned(), value)
+    }
+
+    pub(crate) fn substitute<'a>(
+        &self,
+        value: &'a str,
+    ) -> Result<Cow<'a, str>, VariableDefinitionError> {
+        let Some(first_idx) = value.find("{$") else {
+            return Ok(Cow::Borrowed(value));
+        };
+
+        let mut substituted = String::with_capacity(value.len());
+        substituted.push_str(&value[..first_idx]);
+        let mut offset = first_idx;
+        while offset < value.len() {
+            match value[offset..].find("{$") {
+                None => {
+                    substituted.push_str(&value[offset..]);
+                    break;
+                }
+                Some(relative_start) => {
+                    let start = offset + relative_start;
+                    substituted.push_str(&value[offset..start]);
+                    let after_start = start + 2;
+                    let Some(relative_end) = value[after_start..].find('}') else {
+                        return Err(VariableDefinitionError::InvalidDefinition);
+                    };
+                    let end = after_start + relative_end;
+                    let variable_name = &value[after_start..end];
+                    validate_variable_name(variable_name)?;
+                    let variable_value = self
+                        .variables
+                        .get(variable_name)
+                        .ok_or(VariableDefinitionError::InvalidDefinition)?;
+                    substituted.push_str(variable_value);
+                    offset = end + 1;
+                }
+            }
+        }
+        Ok(Cow::Owned(substituted))
+    }
+
+    pub(crate) fn definitions(&self) -> &HashMap<String, String> {
+        &self.variables
+    }
+}
+
+pub(crate) enum VariableDefinition {
+    Name { name: String, value: String },
+    Import { name: String },
+    QueryParam { name: String },
+}
+
+pub(crate) fn parse_substituted_quoted_string<'a>(
+    line: &'a str,
+    value_start_offset: usize,
+    variable_store: &VariableStore,
+) -> Result<Cow<'a, str>, VariableDefinitionError> {
+    let (parsed, _) = parse_quoted_string(line, value_start_offset);
+    let parsed = parsed.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
+    variable_store.substitute(parsed)
+}
+
+pub(crate) fn parse_substituted_comma_separated_list<'a>(
+    line: &'a str,
+    value_start_offset: usize,
+    variable_store: &VariableStore,
+) -> Result<Vec<Cow<'a, str>>, VariableDefinitionError> {
+    let (parsed, _) = parse_comma_separated_list(line, value_start_offset);
+    let parsed = parsed.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
+    parsed
+        .into_iter()
+        .map(|value| variable_store.substitute(value))
+        .collect()
+}
+
+pub(crate) fn parse_define_tag(line: &str) -> Result<VariableDefinition, VariableDefinitionError> {
+    let mut name: Option<String> = None;
+    let mut value: Option<String> = None;
+    let mut import: Option<String> = None;
+    let mut query_param: Option<String> = None;
+    for item in AttributeListIter::new(line, "#EXT-X-DEFINE:".len()) {
+        let (parsed_value, _) = parse_quoted_string(line, item.value_start_offset);
+        let parsed_value = parsed_value.map_err(|_| VariableDefinitionError::InvalidDefinition)?;
+        match item.name {
+            "NAME" => name = Some(parsed_value.to_owned()),
+            "VALUE" => value = Some(parsed_value.to_owned()),
+            "IMPORT" => import = Some(parsed_value.to_owned()),
+            "QUERYPARAM" => query_param = Some(parsed_value.to_owned()),
+            _ => {}
+        }
+    }
+
+    let alternatives_count = usize::from(name.is_some())
+        + usize::from(import.is_some())
+        + usize::from(query_param.is_some());
+    if alternatives_count != 1 {
+        return Err(VariableDefinitionError::InvalidDefinition);
+    }
+
+    if let Some(name) = name {
+        if let Some(value) = value {
+            validate_variable_name(&name)?;
+            validate_variable_value(&value)?;
+            Ok(VariableDefinition::Name { name, value })
+        } else {
+            Err(VariableDefinitionError::InvalidDefinition)
+        }
+    } else if let Some(name) = import {
+        validate_variable_name(&name)?;
+        Ok(VariableDefinition::Import { name })
+    } else if let Some(name) = query_param {
+        validate_variable_name(&name)?;
+        Ok(VariableDefinition::QueryParam { name })
+    } else {
+        Err(VariableDefinitionError::InvalidDefinition)
+    }
+}
+
+fn validate_variable_name(name: &str) -> Result<(), VariableDefinitionError> {
+    if name.is_empty() {
+        return Err(VariableDefinitionError::InvalidName);
+    }
+    if name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    {
+        Ok(())
+    } else {
+        Err(VariableDefinitionError::InvalidName)
+    }
+}
+
+fn validate_variable_value(value: &str) -> Result<(), VariableDefinitionError> {
+    if value.contains('"') || value.contains('\r') || value.contains('\n') {
+        Err(VariableDefinitionError::InvalidValue)
+    } else {
+        Ok(())
+    }
+}
+
+fn parse_query_params(url: &Url) -> HashMap<String, String> {
+    let input = url.get_ref();
+    let Some(query_start) = input.find('?') else {
+        return HashMap::new();
+    };
+    let query = match input[query_start + 1..].find('#') {
+        Some(hash_offset) => &input[query_start + 1..query_start + 1 + hash_offset],
+        None => &input[query_start + 1..],
+    };
+
+    let mut result = HashMap::new();
+    for pair in query.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let Some(eq_idx) = pair.find('=') else {
+            continue;
+        };
+        let key = &pair[..eq_idx];
+        let val = &pair[eq_idx + 1..];
+        if result.contains_key(key) {
+            continue;
+        }
+        match percent_decode(val) {
+            Ok(decoded) => {
+                if validate_variable_value(&decoded).is_ok() {
+                    result.insert(key.to_owned(), decoded);
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+    result
+}
+
+fn percent_decode(input: &str) -> Result<String, VariableDefinitionError> {
+    let mut result = Vec::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if i + 2 >= bytes.len() {
+                return Err(VariableDefinitionError::InvalidPercentEncoding);
+            }
+            let high = from_hex(bytes[i + 1])?;
+            let low = from_hex(bytes[i + 2])?;
+            result.push(high * 16 + low);
+            i += 3;
+        } else {
+            result.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(result).map_err(|_| VariableDefinitionError::InvalidPercentEncoding)
+}
+
+fn from_hex(byte: u8) -> Result<u8, VariableDefinitionError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(VariableDefinitionError::InvalidPercentEncoding),
+    }
+}

--- a/src/rs-core/parser/variable_substitution.rs
+++ b/src/rs-core/parser/variable_substitution.rs
@@ -19,7 +19,7 @@ pub(crate) enum VariableDefinitionError {
     /// The variable value contained an un-authorized character
     InvalidValue,
     /// The definition or usage of a variable was invalid.
-    /// XXX TODO: different errors?
+    /// TODO: different errors?
     InvalidDefinition,
 }
 

--- a/src/rs-core/parser/variant_stream.rs
+++ b/src/rs-core/parser/variant_stream.rs
@@ -365,8 +365,8 @@ impl VariantStream {
                     )
                     .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
                     codecs = parsed_codecs
-                        .iter()
-                        .map(|c| (guess_media_type_from_codec(c), c.clone()))
+                        .into_iter()
+                        .map(|c| (guess_media_type_from_codec(&c), c.into_owned()))
                         .collect();
                 }
                 "FRAME-RATE" => {
@@ -430,7 +430,8 @@ impl VariantStream {
                             item.value_start_offset,
                             variable_store,
                         )
-                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?
+                        .into_owned(),
                     );
                 }
                 "AUDIO" => {
@@ -440,7 +441,8 @@ impl VariantStream {
                             item.value_start_offset,
                             variable_store,
                         )
-                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?
+                        .into_owned(),
                     );
                 }
                 "VIDEO" => {
@@ -450,7 +452,8 @@ impl VariantStream {
                             item.value_start_offset,
                             variable_store,
                         )
-                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?
+                        .into_owned(),
                     );
                 }
                 "SUBTITLES" => {
@@ -460,7 +463,8 @@ impl VariantStream {
                             item.value_start_offset,
                             variable_store,
                         )
-                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?
+                        .into_owned(),
                     );
                 }
                 "CLOSED-CAPTIONS" => {
@@ -472,7 +476,8 @@ impl VariantStream {
                                 item.value_start_offset,
                                 variable_store,
                             )
-                            .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                            .map_err(|_| VariantParsingError::InvalidDecimalInteger)?
+                            .into_owned(),
                         );
                     }
                 }
@@ -489,7 +494,8 @@ impl VariantStream {
                             item.value_start_offset,
                             variable_store,
                         )
-                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?
+                        .into_owned(),
                     );
                 }
                 _ => {}

--- a/src/rs-core/parser/variant_stream.rs
+++ b/src/rs-core/parser/variant_stream.rs
@@ -6,6 +6,7 @@ use super::{
     utils::{
         parse_comma_separated_list, parse_decimal_floating_point, parse_decimal_integer,
         parse_enumerated_string, parse_quoted_string, parse_resolution, skip_attribute_list_value,
+        VariableStore,
     },
 };
 use crate::{bindings::MediaType, utils::url::Url, Logger};
@@ -315,6 +316,7 @@ impl VariantStream {
         url: Url,
         base_uri: &str,
         id: u32,
+        variable_store: &VariableStore,
     ) -> Result<Self, VariantParsingError> {
         let mut bandwidth: Option<u64> = None;
         let mut resolution: Option<VideoResolution> = None;
@@ -369,10 +371,17 @@ impl VariantStream {
                             parse_comma_separated_list(variant_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
-                            codecs = val
-                                .iter()
-                                .map(|c| (guess_media_type_from_codec(c), (*c).to_owned()))
-                                .collect();
+                            let mut parsed_codecs = Vec::with_capacity(val.len());
+                            for codec in val {
+                                let codec = variable_store
+                                    .substitute(codec)
+                                    .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
+                                parsed_codecs.push((
+                                    guess_media_type_from_codec(&codec),
+                                    codec.into_owned(),
+                                ));
+                            }
+                            codecs = parsed_codecs;
                         } else {
                             Logger::warn("Unparsable CODECS value");
                         }
@@ -435,7 +444,10 @@ impl VariantStream {
                             parse_quoted_string(variant_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
-                            stable_variant_id = Some(val.to_owned());
+                            let val = variable_store
+                                .substitute(val)
+                                .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
+                            stable_variant_id = Some(val.into_owned());
                         } else {
                             Logger::warn("Unparsable STABLE-VARIANT-ID value");
                         }
@@ -445,7 +457,10 @@ impl VariantStream {
                             parse_quoted_string(variant_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
-                            audio = Some(val.to_owned());
+                            let val = variable_store
+                                .substitute(val)
+                                .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
+                            audio = Some(val.into_owned());
                         } else {
                             Logger::warn("Unparsable AUDIO value");
                         }
@@ -455,7 +470,10 @@ impl VariantStream {
                             parse_quoted_string(variant_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
-                            video = Some(val.to_owned());
+                            let val = variable_store
+                                .substitute(val)
+                                .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
+                            video = Some(val.into_owned());
                         } else {
                             Logger::warn("Unparsable VIDEO value");
                         }
@@ -465,7 +483,10 @@ impl VariantStream {
                             parse_quoted_string(variant_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
-                            subtitles = Some(val.to_owned());
+                            let val = variable_store
+                                .substitute(val)
+                                .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
+                            subtitles = Some(val.into_owned());
                         } else {
                             Logger::warn("Unparsable SUBTITLES value");
                         }
@@ -478,7 +499,10 @@ impl VariantStream {
                                 parse_quoted_string(variant_line, offset + idx + 1);
                             offset = end_offset + 1;
                             if let Ok(val) = parsed {
-                                closed_captions = Some(val.to_owned());
+                                let val = variable_store
+                                    .substitute(val)
+                                    .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
+                                closed_captions = Some(val.into_owned());
                             } else {
                                 Logger::warn("Unparsable CLOSED-CAPTIONS value");
                             }
@@ -495,7 +519,10 @@ impl VariantStream {
                             parse_quoted_string(variant_line, offset + idx + 1);
                         offset = end_offset + 1;
                         if let Ok(val) = parsed {
-                            pathway_id = Some(val.to_owned());
+                            let val = variable_store
+                                .substitute(val)
+                                .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
+                            pathway_id = Some(val.into_owned());
                         } else {
                             Logger::warn("Unparsable PATHWAY-ID value");
                         }

--- a/src/rs-core/parser/variant_stream.rs
+++ b/src/rs-core/parser/variant_stream.rs
@@ -4,9 +4,9 @@ use super::{
     media_playlist::{MediaPlaylist, MediaPlaylistParsingError},
     multi_variant_playlist::MediaPlaylistContext,
     utils::{
-        parse_comma_separated_list, parse_decimal_floating_point, parse_decimal_integer,
-        parse_enumerated_string, parse_quoted_string, parse_resolution, skip_attribute_list_value,
-        VariableStore,
+        parse_decimal_floating_point, parse_decimal_integer, parse_enumerated_string,
+        parse_resolution, parse_substituted_comma_separated_list, parse_substituted_quoted_string,
+        AttributeListIter, VariableStore,
     },
 };
 use crate::{bindings::MediaType, utils::url::Url, Logger};
@@ -334,203 +334,165 @@ impl VariantStream {
         let mut closed_captions: Option<String> = None;
         let mut pathway_id: Option<String> = None;
 
-        let mut offset = "#EXT-X-STREAM-INF:".len();
-        loop {
-            if offset >= variant_line.len() {
-                break;
-            }
+        for item in AttributeListIter::new(variant_line, "#EXT-X-STREAM-INF:".len()) {
             // #EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=746000,BANDWIDTH=886211,RESOLUTION=512x288,FRAME-RATE=25.000,CODECS="avc1.4D4015,mp4a.40.2",CLOSED-CAPTIONS=NONE,AUDIO="AUDIO_96000"
-            match variant_line[offset..].find('=') {
-                None => {
-                    Logger::warn("Attribute Name not followed by equal sign");
-                    break;
+            match item.name {
+                "AVERAGE-BANDWIDTH" => {
+                    let (parsed, end_offset) =
+                        parse_decimal_integer(variant_line, item.value_start_offset);
+                    let _ = end_offset;
+                    if let Ok(val) = parsed {
+                        average_bandwitdh = Some(val);
+                    } else {
+                        Logger::warn("Unparsable AVERAGE-BANDWIDTH value");
+                    }
                 }
-                Some(idx) => match &variant_line[offset..offset + idx] {
-                    "AVERAGE-BANDWIDTH" => {
-                        let (parsed, end_offset) =
-                            parse_decimal_integer(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            average_bandwitdh = Some(val);
-                        } else {
-                            Logger::warn("Unparsable AVERAGE-BANDWIDTH value");
-                        }
+                "BANDWIDTH" => {
+                    let (parsed, end_offset) =
+                        parse_decimal_integer(variant_line, item.value_start_offset);
+                    let _ = end_offset;
+                    if let Ok(val) = parsed {
+                        bandwidth = Some(val);
+                    } else {
+                        Logger::warn("Unparsable BANDWIDTH value");
                     }
-                    "BANDWIDTH" => {
-                        let (parsed, end_offset) =
-                            parse_decimal_integer(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            bandwidth = Some(val);
-                        } else {
-                            Logger::warn("Unparsable BANDWIDTH value");
-                        }
+                }
+                "CODECS" => {
+                    let parsed_codecs = parse_substituted_comma_separated_list(
+                        variant_line,
+                        item.value_start_offset,
+                        variable_store,
+                    )
+                    .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
+                    codecs = parsed_codecs
+                        .iter()
+                        .map(|c| (guess_media_type_from_codec(c), c.clone()))
+                        .collect();
+                }
+                "FRAME-RATE" => {
+                    let (parsed, end_offset) =
+                        parse_decimal_floating_point(variant_line, item.value_start_offset);
+                    let _ = end_offset;
+                    if let Ok(val) = parsed {
+                        frame_rate = Some(val);
+                    } else {
+                        Logger::warn("Unparsable FRAME-RATE value");
                     }
-                    "CODECS" => {
-                        let (parsed, end_offset) =
-                            parse_comma_separated_list(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let mut parsed_codecs = Vec::with_capacity(val.len());
-                            for codec in val {
-                                let codec = variable_store
-                                    .substitute(codec)
-                                    .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
-                                parsed_codecs.push((
-                                    guess_media_type_from_codec(&codec),
-                                    codec.into_owned(),
-                                ));
-                            }
-                            codecs = parsed_codecs;
-                        } else {
-                            Logger::warn("Unparsable CODECS value");
-                        }
+                }
+                "HDCP-LEVEL" => {
+                    let (parsed, end_offset) =
+                        parse_enumerated_string(variant_line, item.value_start_offset);
+                    let _ = end_offset;
+                    hdcp_level = match parsed {
+                        "TYPE-0" => HdcpLevel::Type0,
+                        "TYPE-1" => HdcpLevel::Type1,
+                        "NONE" => HdcpLevel::None,
+                        _ => HdcpLevel::Unknown,
+                    };
+                }
+                "PROGRAM-ID" => {
+                    let (parsed, end_offset) =
+                        parse_decimal_integer(variant_line, item.value_start_offset);
+                    let _ = end_offset;
+                    if let Ok(val) = parsed {
+                        program_id = Some(val);
+                    } else {
+                        Logger::warn("Unparsable PROGRAM-ID value");
                     }
-                    "FRAME-RATE" => {
-                        let (parsed, end_offset) =
-                            parse_decimal_floating_point(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            frame_rate = Some(val);
-                        } else {
-                            Logger::warn("Unparsable FRAME-RATE value");
-                        }
+                }
+                "RESOLUTION" => {
+                    let (parsed, end_offset) =
+                        parse_resolution(variant_line, item.value_start_offset);
+                    let _ = end_offset;
+                    if let Ok(res) = parsed {
+                        resolution = Some(VideoResolution {
+                            height: res.height,
+                            width: res.width,
+                        });
+                    } else {
+                        Logger::warn("Unparsable RESOLUTION value");
                     }
-                    "HDCP-LEVEL" => {
-                        let (parsed, end_offset) =
-                            parse_enumerated_string(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        hdcp_level = match parsed {
-                            "TYPE-0" => HdcpLevel::Type0,
-                            "TYPE-1" => HdcpLevel::Type1,
-                            "NONE" => HdcpLevel::None,
-                            _ => HdcpLevel::Unknown,
-                        };
+                }
+                "SCORE" => {
+                    let (parsed, end_offset) =
+                        parse_decimal_floating_point(variant_line, item.value_start_offset);
+                    let _ = end_offset;
+                    if let Ok(val) = parsed {
+                        score = Some(val);
+                    } else {
+                        Logger::warn("Unparsable SCORE value");
                     }
-                    "PROGRAM-ID" => {
-                        let (parsed, end_offset) =
-                            parse_decimal_integer(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            program_id = Some(val);
-                        } else {
-                            Logger::warn("Unparsable PROGRAM-ID value");
-                        }
+                }
+                "STABLE-VARIANT-ID" => {
+                    stable_variant_id = Some(
+                        parse_substituted_quoted_string(
+                            variant_line,
+                            item.value_start_offset,
+                            variable_store,
+                        )
+                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                    );
+                }
+                "AUDIO" => {
+                    audio = Some(
+                        parse_substituted_quoted_string(
+                            variant_line,
+                            item.value_start_offset,
+                            variable_store,
+                        )
+                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                    );
+                }
+                "VIDEO" => {
+                    video = Some(
+                        parse_substituted_quoted_string(
+                            variant_line,
+                            item.value_start_offset,
+                            variable_store,
+                        )
+                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                    );
+                }
+                "SUBTITLES" => {
+                    subtitles = Some(
+                        parse_substituted_quoted_string(
+                            variant_line,
+                            item.value_start_offset,
+                            variable_store,
+                        )
+                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                    );
+                }
+                "CLOSED-CAPTIONS" => {
+                    if variant_line[item.value_start_offset..].starts_with("NONE") {
+                    } else {
+                        closed_captions = Some(
+                            parse_substituted_quoted_string(
+                                variant_line,
+                                item.value_start_offset,
+                                variable_store,
+                            )
+                            .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                        );
                     }
-                    "RESOLUTION" => {
-                        let (parsed, end_offset) = parse_resolution(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(res) = parsed {
-                            resolution = Some(VideoResolution {
-                                height: res.height,
-                                width: res.width,
-                            });
-                        } else {
-                            Logger::warn("Unparsable RESOLUTION value");
-                        }
-                    }
-                    "SCORE" => {
-                        let (parsed, end_offset) =
-                            parse_decimal_floating_point(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            score = Some(val);
-                        } else {
-                            Logger::warn("Unparsable SCORE value");
-                        }
-                    }
-                    "STABLE-VARIANT-ID" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let val = variable_store
-                                .substitute(val)
-                                .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
-                            stable_variant_id = Some(val.into_owned());
-                        } else {
-                            Logger::warn("Unparsable STABLE-VARIANT-ID value");
-                        }
-                    }
-                    "AUDIO" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let val = variable_store
-                                .substitute(val)
-                                .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
-                            audio = Some(val.into_owned());
-                        } else {
-                            Logger::warn("Unparsable AUDIO value");
-                        }
-                    }
-                    "VIDEO" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let val = variable_store
-                                .substitute(val)
-                                .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
-                            video = Some(val.into_owned());
-                        } else {
-                            Logger::warn("Unparsable VIDEO value");
-                        }
-                    }
-                    "SUBTITLES" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let val = variable_store
-                                .substitute(val)
-                                .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
-                            subtitles = Some(val.into_owned());
-                        } else {
-                            Logger::warn("Unparsable SUBTITLES value");
-                        }
-                    }
-                    "CLOSED-CAPTIONS" => {
-                        if variant_line[offset + idx + 1..].starts_with("NONE") {
-                            offset = skip_attribute_list_value(variant_line, offset + idx + 1);
-                        } else {
-                            let (parsed, end_offset) =
-                                parse_quoted_string(variant_line, offset + idx + 1);
-                            offset = end_offset + 1;
-                            if let Ok(val) = parsed {
-                                let val = variable_store
-                                    .substitute(val)
-                                    .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
-                                closed_captions = Some(val.into_owned());
-                            } else {
-                                Logger::warn("Unparsable CLOSED-CAPTIONS value");
-                            }
-                        }
-                    }
-                    "VIDEO-RANGE" => {
-                        let (parsed, end_offset) =
-                            parse_enumerated_string(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        video_range = Some(parsed.to_owned());
-                    }
-                    "PATHWAY-ID" => {
-                        let (parsed, end_offset) =
-                            parse_quoted_string(variant_line, offset + idx + 1);
-                        offset = end_offset + 1;
-                        if let Ok(val) = parsed {
-                            let val = variable_store
-                                .substitute(val)
-                                .map_err(|_| VariantParsingError::InvalidDecimalInteger)?;
-                            pathway_id = Some(val.into_owned());
-                        } else {
-                            Logger::warn("Unparsable PATHWAY-ID value");
-                        }
-                    }
-                    _ => {
-                        offset = skip_attribute_list_value(variant_line, offset + idx + 1) + 1;
-                    }
-                },
+                }
+                "VIDEO-RANGE" => {
+                    let (parsed, end_offset) =
+                        parse_enumerated_string(variant_line, item.value_start_offset);
+                    let _ = end_offset;
+                    video_range = Some(parsed.to_owned());
+                }
+                "PATHWAY-ID" => {
+                    pathway_id = Some(
+                        parse_substituted_quoted_string(
+                            variant_line,
+                            item.value_start_offset,
+                            variable_store,
+                        )
+                        .map_err(|_| VariantParsingError::InvalidDecimalInteger)?,
+                    );
+                }
+                _ => {}
             }
         }
 

--- a/src/rs-core/parser/variant_stream.rs
+++ b/src/rs-core/parser/variant_stream.rs
@@ -1,15 +1,22 @@
-use std::io::BufRead;
-
 use super::{
+    attribute_list::AttributeListIter,
     media_playlist::{MediaPlaylist, MediaPlaylistParsingError},
     multi_variant_playlist::MediaPlaylistContext,
-    utils::{
-        parse_decimal_floating_point, parse_decimal_integer, parse_enumerated_string,
-        parse_resolution, parse_substituted_comma_separated_list, parse_substituted_quoted_string,
-        AttributeListIter, VariableStore,
-    },
+    variable_substitution::VariableStore,
 };
-use crate::{bindings::MediaType, utils::url::Url, Logger};
+use crate::{
+    bindings::MediaType,
+    parser::{
+        attribute_list::parse_enumerated_string,
+        value_parsers::{parse_decimal_floating_point, parse_decimal_integer, parse_resolution},
+        variable_substitution::{
+            parse_substituted_comma_separated_list, parse_substituted_quoted_string,
+        },
+    },
+    utils::url::Url,
+    Logger,
+};
+use std::io::BufRead;
 
 /// Stucture representing the HLS concept of a "variant stream".
 #[derive(Debug)]
@@ -338,25 +345,24 @@ impl VariantStream {
             // #EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=746000,BANDWIDTH=886211,RESOLUTION=512x288,FRAME-RATE=25.000,CODECS="avc1.4D4015,mp4a.40.2",CLOSED-CAPTIONS=NONE,AUDIO="AUDIO_96000"
             match item.name {
                 "AVERAGE-BANDWIDTH" => {
-                    let (parsed, end_offset) =
-                        parse_decimal_integer(variant_line, item.value_start_offset);
-                    let _ = end_offset;
-                    if let Ok(val) = parsed {
+                    if let (Ok(val), _) =
+                        parse_decimal_integer(variant_line, item.value_start_offset)
+                    {
                         average_bandwitdh = Some(val);
                     } else {
                         Logger::warn("Unparsable AVERAGE-BANDWIDTH value");
                     }
                 }
                 "BANDWIDTH" => {
-                    let (parsed, end_offset) =
-                        parse_decimal_integer(variant_line, item.value_start_offset);
-                    let _ = end_offset;
-                    if let Ok(val) = parsed {
+                    if let (Ok(val), _) =
+                        parse_decimal_integer(variant_line, item.value_start_offset)
+                    {
                         bandwidth = Some(val);
                     } else {
                         Logger::warn("Unparsable BANDWIDTH value");
                     }
                 }
+
                 "CODECS" => {
                     let parsed_codecs = parse_substituted_comma_separated_list(
                         variant_line,
@@ -370,19 +376,18 @@ impl VariantStream {
                         .collect();
                 }
                 "FRAME-RATE" => {
-                    let (parsed, end_offset) =
-                        parse_decimal_floating_point(variant_line, item.value_start_offset);
-                    let _ = end_offset;
-                    if let Ok(val) = parsed {
+                    if let (Ok(val), _) =
+                        parse_decimal_floating_point(variant_line, item.value_start_offset)
+                    {
                         frame_rate = Some(val);
                     } else {
                         Logger::warn("Unparsable FRAME-RATE value");
                     }
                 }
+
                 "HDCP-LEVEL" => {
-                    let (parsed, end_offset) =
+                    let (parsed, _) =
                         parse_enumerated_string(variant_line, item.value_start_offset);
-                    let _ = end_offset;
                     hdcp_level = match parsed {
                         "TYPE-0" => HdcpLevel::Type0,
                         "TYPE-1" => HdcpLevel::Type1,
@@ -391,20 +396,16 @@ impl VariantStream {
                     };
                 }
                 "PROGRAM-ID" => {
-                    let (parsed, end_offset) =
-                        parse_decimal_integer(variant_line, item.value_start_offset);
-                    let _ = end_offset;
-                    if let Ok(val) = parsed {
+                    if let (Ok(val), _) =
+                        parse_decimal_integer(variant_line, item.value_start_offset)
+                    {
                         program_id = Some(val);
                     } else {
                         Logger::warn("Unparsable PROGRAM-ID value");
                     }
                 }
                 "RESOLUTION" => {
-                    let (parsed, end_offset) =
-                        parse_resolution(variant_line, item.value_start_offset);
-                    let _ = end_offset;
-                    if let Ok(res) = parsed {
+                    if let (Ok(res), _) = parse_resolution(variant_line, item.value_start_offset) {
                         resolution = Some(VideoResolution {
                             height: res.height,
                             width: res.width,
@@ -414,10 +415,9 @@ impl VariantStream {
                     }
                 }
                 "SCORE" => {
-                    let (parsed, end_offset) =
-                        parse_decimal_floating_point(variant_line, item.value_start_offset);
-                    let _ = end_offset;
-                    if let Ok(val) = parsed {
+                    if let (Ok(val), _) =
+                        parse_decimal_floating_point(variant_line, item.value_start_offset)
+                    {
                         score = Some(val);
                     } else {
                         Logger::warn("Unparsable SCORE value");
@@ -482,9 +482,8 @@ impl VariantStream {
                     }
                 }
                 "VIDEO-RANGE" => {
-                    let (parsed, end_offset) =
+                    let (parsed, _) =
                         parse_enumerated_string(variant_line, item.value_start_offset);
-                    let _ = end_offset;
                     video_range = Some(parsed.to_owned());
                 }
                 "PATHWAY-ID" => {

--- a/src/ts-common/generatedWasmEnums.ts
+++ b/src/ts-common/generatedWasmEnums.ts
@@ -162,31 +162,22 @@ export const MultivariantPlaylistParsingErrorCode = Object.freeze({
    */
   InvalidValue: 5,
   /**
-   * An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-   * an HLS variant, had no `TYPE` attribute associated to it. It should be
-   * mandatory.
+   * A mandatory attribute was missing from a tag in the Multivariant Playlist.
    */
-  MediaTagMissingType: 6,
+  MissingRequiredAttribute: 6,
   /**
-   * An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-   * an HLS variant, had no `NAME` attribute associated to it. It should be
-   * mandatory.
+   * An `EXT-X-DEFINE` variable definition or substitution was invalid in the
+   * Multivariant Playlist.
    */
-  MediaTagMissingName: 7,
-  /**
-   * An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-   * an HLS variant, had no `GROUP-ID` attribute associated to it. It should be
-   * mandatory.
-   */
-  MediaTagMissingGroupId: 8,
+  VariableDefinitionError: 7,
   /**
    * A line could not be read.
    */
-  UnableToReadLine: 9,
+  UnableToReadLine: 8,
   /**
    * Another, uncategorized, error arised.
    */
-  Unknown: 10,
+  Unknown: 9,
 } as const);
 export type MultivariantPlaylistParsingErrorCode =
   (typeof MultivariantPlaylistParsingErrorCode)[keyof typeof MultivariantPlaylistParsingErrorCode];
@@ -220,9 +211,14 @@ export const MediaPlaylistParsingErrorCode = Object.freeze({
    */
   UnparsableByteRange: 4,
   /**
+   * An `EXT-X-DEFINE` variable definition or substitution was invalid in the
+   * Media Playlist.
+   */
+  VariableDefinitionError: 5,
+  /**
    * Another, uncategorized, error arised.
    */
-  Unknown: 5,
+  Unknown: 6,
 } as const);
 export type MediaPlaylistParsingErrorCode =
   (typeof MediaPlaylistParsingErrorCode)[keyof typeof MediaPlaylistParsingErrorCode];

--- a/src/ts-main/errors/WaspMediaPlaylistParsingError.ts
+++ b/src/ts-main/errors/WaspMediaPlaylistParsingError.ts
@@ -20,6 +20,7 @@ export default class WaspMediaPlaylistParsingError extends Error {
     | "MediaPlaylistMissingTargetDuration"
     | "MediaPlaylistUriWithoutExtInf"
     | "MediaPlaylistUnparsableByteRange"
+    | "MediaPlaylistVariableDefinitionError"
     | "MediaPlaylistOtherParsingError";
 
   /**
@@ -69,6 +70,9 @@ export default class WaspMediaPlaylistParsingError extends Error {
         break;
       case MediaPlaylistParsingErrorCode.UriWithoutExtInf:
         this.code = "MediaPlaylistUriWithoutExtInf";
+        break;
+      case MediaPlaylistParsingErrorCode.VariableDefinitionError:
+        this.code = "MediaPlaylistVariableDefinitionError";
         break;
       case MediaPlaylistParsingErrorCode.Unknown:
         this.code = "MediaPlaylistOtherParsingError";

--- a/src/ts-main/errors/WaspMultivariantPlaylistParsingError.ts
+++ b/src/ts-main/errors/WaspMultivariantPlaylistParsingError.ts
@@ -18,9 +18,8 @@ export default class WaspMultivariantPlaylistParsingError extends Error {
     | "MultivariantPlaylistWithoutVariant"
     | "MultivariantPlaylistVariantMissingBandwidth"
     | "MultivariantPlaylistInvalidValue"
-    | "MultivariantPlaylistMediaTagMissingType"
-    | "MultivariantPlaylistMediaTagMissingName"
-    | "MultivariantPlaylistMediaTagMissingGroupId"
+    | "MultivariantPlaylistMissingRequiredAttribute"
+    | "MultivariantPlaylistVariableDefinitionError"
     | "MultivariantPlaylistMissingExtM3uHeader"
     | "MultivariantPlaylistOtherParsingError";
 
@@ -62,14 +61,11 @@ export default class WaspMultivariantPlaylistParsingError extends Error {
       case MultivariantPlaylistParsingErrorCode.InvalidValue:
         this.code = "MultivariantPlaylistInvalidValue";
         break;
-      case MultivariantPlaylistParsingErrorCode.MediaTagMissingType:
-        this.code = "MultivariantPlaylistMediaTagMissingType";
+      case MultivariantPlaylistParsingErrorCode.MissingRequiredAttribute:
+        this.code = "MultivariantPlaylistMissingRequiredAttribute";
         break;
-      case MultivariantPlaylistParsingErrorCode.MediaTagMissingName:
-        this.code = "MultivariantPlaylistMediaTagMissingName";
-        break;
-      case MultivariantPlaylistParsingErrorCode.MediaTagMissingGroupId:
-        this.code = "MultivariantPlaylistMediaTagMissingGroupId";
+      case MultivariantPlaylistParsingErrorCode.VariableDefinitionError:
+        this.code = "MultivariantPlaylistVariableDefinitionError";
         break;
       case MultivariantPlaylistParsingErrorCode.Unknown:
         this.code = "MultivariantPlaylistOtherParsingError";

--- a/src/ts-main/errors/WaspSourceBufferCreationError.ts
+++ b/src/ts-main/errors/WaspSourceBufferCreationError.ts
@@ -10,7 +10,12 @@ export default class WaspSourceBufferCreationError extends Error {
 
   /** Specifies the exact error encountered. */
   public readonly code:
+    | "SourceBufferAlreadyCreatedWithSameType"
     | "SourceBufferCantPlayType"
+    | "SourceBufferEmptyMimeType"
+    | "SourceBufferMediaSourceIsClosed"
+    | "SourceBufferNoMediaSourceAttached"
+    | "SourceBufferQuotaExceededError"
     | "SourceBufferCreationOtherError";
 
   /**
@@ -47,19 +52,28 @@ export default class WaspSourceBufferCreationError extends Error {
     this.name = "WaspSourceBufferCreationError";
     this.mediaType = mediaType;
     switch (code) {
+      case SourceBufferCreationErrorCode.AlreadyCreatedWithSameType:
+        this.code = "SourceBufferAlreadyCreatedWithSameType";
+        break;
       case SourceBufferCreationErrorCode.CantPlayType:
         this.code = "SourceBufferCantPlayType";
         break;
-      case SourceBufferCreationErrorCode.AlreadyCreatedWithSameType:
       case SourceBufferCreationErrorCode.EmptyMimeType:
+        this.code = "SourceBufferEmptyMimeType";
+        break;
       case SourceBufferCreationErrorCode.MediaSourceIsClosed:
+        this.code = "SourceBufferMediaSourceIsClosed";
+        break;
       case SourceBufferCreationErrorCode.NoMediaSourceAttached:
+        this.code = "SourceBufferNoMediaSourceAttached";
+        break;
       case SourceBufferCreationErrorCode.QuotaExceededError:
+        this.code = "SourceBufferQuotaExceededError";
+        break;
       case SourceBufferCreationErrorCode.Unknown:
-        this.code = "SourceBufferCantPlayType";
+        this.code = "SourceBufferCreationOtherError";
         break;
       default:
-        // WHY TYPESCRIPT? I've done all MFing cases on purpose
         this.code = "SourceBufferCreationOtherError";
     }
     this.globalCode = this.code;

--- a/src/ts-main/errors/common.ts
+++ b/src/ts-main/errors/common.ts
@@ -94,8 +94,21 @@ export const WaspErrorCode = {
   /** An unknown error arised. */
   Unknown: "Unknown",
 
+  /**
+   * A SourceBuffer for that media type had already been created.
+   */
+  SourceBufferAlreadyCreatedWithSameType:
+    "SourceBufferAlreadyCreatedWithSameType",
   /** The mime type communicated during SourceBuffer creation was not supported. */
   SourceBufferCantPlayType: "SourceBufferCantPlayType",
+  /** The mime type communicated during SourceBuffer creation was empty. */
+  SourceBufferEmptyMimeType: "SourceBufferEmptyMimeType",
+  /** The MediaSource was closed before the SourceBuffer could be created. */
+  SourceBufferMediaSourceIsClosed: "SourceBufferMediaSourceIsClosed",
+  /** No MediaSource was attached when trying to create the SourceBuffer. */
+  SourceBufferNoMediaSourceAttached: "SourceBufferNoMediaSourceAttached",
+  /** The browser reported a QuotaExceededError while creating the SourceBuffer. */
+  SourceBufferQuotaExceededError: "SourceBufferQuotaExceededError",
   /** An uncategorized error arised while creating a SourceBuffer. */
   SourceBufferCreationOtherError: "SourceBufferCreationOtherError",
 
@@ -129,26 +142,16 @@ export const WaspErrorCode = {
   /** A value in the Multivariant Playlist was in an invalid format. */
   MultivariantPlaylistInvalidValue: "MultivariantPlaylistInvalidValue",
   /**
-   * An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-   * an HLS variant, had no `TYPE` attribute associated to it. It should be
-   * mandatory.
+   * A mandatory attribute was missing from a tag in the Multivariant Playlist.
    */
-  MultivariantPlaylistMediaTagMissingType:
-    "MultivariantPlaylistMediaTagMissingType",
+  MultivariantPlaylistMissingRequiredAttribute:
+    "MultivariantPlaylistMissingRequiredAttribute",
   /**
-   * An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-   * an HLS variant, had no `NAME` attribute associated to it. It should be
-   * mandatory.
+   * An `EXT-X-DEFINE` variable definition or substitution was invalid in the
+   * Multivariant Playlist.
    */
-  MultivariantPlaylistMediaTagMissingName:
-    "MultivariantPlaylistMediaTagMissingName",
-  /**
-   * An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing
-   * an HLS variant, had no `GROUP-ID` attribute associated to it. It should be
-   * mandatory.
-   */
-  MultivariantPlaylistMediaTagMissingGroupId:
-    "MultivariantPlaylistMediaTagMissingGroupId",
+  MultivariantPlaylistVariableDefinitionError:
+    "MultivariantPlaylistVariableDefinitionError",
   /**
    * An uncategorized error arised while parsing the Multivariant Playlist.
    */
@@ -179,6 +182,11 @@ export const WaspErrorCode = {
    * was not in the right format.
    */
   MediaPlaylistUnparsableByteRange: "MediaPlaylistUnparsableByteRange",
+  /**
+   * An `EXT-X-DEFINE` variable definition or substitution was invalid in the
+   * Media Playlist.
+   */
+  MediaPlaylistVariableDefinitionError: "MediaPlaylistVariableDefinitionError",
   /** Another uncategorized error happened while parsing the Media Playlist. */
   MediaPlaylistOtherParsingError: "MediaPlaylistOtherParsingError",
 

--- a/src/wasm/abi/wasm-enums.json
+++ b/src/wasm/abi/wasm-enums.json
@@ -187,36 +187,25 @@
             "A value in the Multivariant Playlist was in an invalid format."
           ]
         },
-        "MediaTagMissingType": {
+        "MissingRequiredAttribute": {
           "value": 6,
           "doc": [
-            "An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing",
-            "an HLS variant, had no `TYPE` attribute associated to it. It should be",
-            "mandatory."
+            "A mandatory attribute was missing from a tag in the Multivariant Playlist."
           ]
         },
-        "MediaTagMissingName": {
+        "VariableDefinitionError": {
           "value": 7,
           "doc": [
-            "An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing",
-            "an HLS variant, had no `NAME` attribute associated to it. It should be",
-            "mandatory."
-          ]
-        },
-        "MediaTagMissingGroupId": {
-          "value": 8,
-          "doc": [
-            "An `EXT-X-MEDIA` tag announced in the Multivariant Playlist, describing",
-            "an HLS variant, had no `GROUP-ID` attribute associated to it. It should be",
-            "mandatory."
+            "An `EXT-X-DEFINE` variable definition or substitution was invalid in the",
+            "Multivariant Playlist."
           ]
         },
         "UnableToReadLine": {
-          "value": 9,
+          "value": 8,
           "doc": ["A line could not be read."]
         },
         "Unknown": {
-          "value": 10,
+          "value": 9,
           "doc": ["Another, uncategorized, error arised."]
         }
       }
@@ -259,8 +248,15 @@
             "was not in the right format."
           ]
         },
-        "Unknown": {
+        "VariableDefinitionError": {
           "value": 5,
+          "doc": [
+            "An `EXT-X-DEFINE` variable definition or substitution was invalid in the",
+            "Media Playlist."
+          ]
+        },
+        "Unknown": {
+          "value": 6,
           "doc": ["Another, uncategorized, error arised."]
         }
       }


### PR DESCRIPTION
Doing a quick look at what remains to be handled by the player in terms of tag, `EXT-X-DEFINE` seems to be one of the most "important" ones (it is still rare enough though).

This can affect most parsed attributes though, leading me to factorize some things which led to a big PR in terms of LOC.

I'll take my time to re-review it.
