### PR TITLE
[WIP] Add integration test basis

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -145,3 +145,213 @@ jobs:
 
       - name: Build package and release artifacts
         run: npm run build -- --release
+
+  core_tests:
+    name: Core tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Set up Rust
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-bin-wasm-bindgen-${{ env.WASM_BINDGEN_CLI_VERSION }}
+
+      - name: Cache Rust target
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-target-tests-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-target-tests-
+
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --version ${{ env.WASM_BINDGEN_CLI_VERSION }} --locked --force
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Build artifacts for tests
+        run: npm run build
+
+      - name: Run Rust unit tests
+        run: npm test -- rust
+
+      - name: Run transmux tests
+        run: npm test -- transmux
+
+  integration_tests:
+    name: Integration tests (${{ matrix.os }}, ${{ matrix.browser }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    continue-on-error: ${{ matrix.allow_failure }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            browser: chrome
+            allow_failure: false
+          - os: ubuntu-24.04
+            browser: firefox
+            allow_failure: false
+          - os: macos-15
+            browser: chrome
+            allow_failure: false
+          - os: macos-15
+            browser: firefox
+            allow_failure: false
+          # Windows hosted-runner behavior has proven highly unstable and
+          # low-signal for this live-packager scenario. Keep a single
+          # best-effort smoke lane instead of blocking the full CI matrix on it.
+          - os: windows-2025
+            browser: firefox
+            allow_failure: true
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Set up Rust
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-bin-wasm-bindgen-${{ env.WASM_BINDGEN_CLI_VERSION }}
+
+      - name: Cache Rust target
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-target-integration-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-target-integration-
+
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --version ${{ env.WASM_BINDGEN_CLI_VERSION }} --locked --force
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install ffmpeg and gpac on Ubuntu
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl ffmpeg
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://dist.gpac.io/gpac/linux/gpg.asc -o /etc/apt/keyrings/gpac.asc
+          sudo chmod a+r /etc/apt/keyrings/gpac.asc
+          sudo tee /etc/apt/sources.list.d/gpac.sources >/dev/null <<EOF
+          Types: deb
+          URIs: https://dist.gpac.io/gpac/linux/ubuntu
+          Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+          Components: main
+          Signed-By: /etc/apt/keyrings/gpac.asc
+          EOF
+          sudo apt-get update
+          sudo apt-get install -y gpac
+
+      - name: Install ffmpeg and gpac on macOS
+        if: runner.os == 'macOS'
+        run: brew install ffmpeg gpac
+
+      - name: Install ffmpeg and gpac on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          choco upgrade ffmpeg gpac -y
+
+          $gpacCandidates = @(@(
+            (Join-Path $env:ProgramFiles 'GPAC\gpac.exe'),
+            (Join-Path ${env:ProgramFiles(x86)} 'GPAC\gpac.exe'),
+            (Join-Path $env:ChocolateyInstall 'bin\gpac.exe'),
+            (Join-Path $env:ChocolateyInstall 'lib\gpac\tools\gpac.exe'),
+            (Join-Path $env:ChocolateyInstall 'lib\gpac.portable\tools\gpac.exe')
+          ) | Where-Object { $_ -and (Test-Path $_) })
+
+          if ($gpacCandidates.Count -eq 0) {
+            throw 'GPAC was installed but gpac.exe could not be located.'
+          }
+
+          Write-Host "Resolved GPAC candidates:"
+          $gpacCandidates | ForEach-Object { Write-Host "  $_" }
+
+          $gpacBinary = $gpacCandidates[0]
+          Write-Host "Selected GPAC binary: $gpacBinary"
+          if (-not (Test-Path $gpacBinary)) {
+            throw "Resolved GPAC binary does not exist: $gpacBinary"
+          }
+          Split-Path -Parent $gpacBinary | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Write-Host "Windows GPAC binary exists and was added to PATH."
+
+          Write-Host "Windows GPAC install step completed."
+          exit 0
+
+      - name: Print media tool versions on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          ffmpeg -version
+
+          Write-Host "gpac command resolution:"
+          Get-Command gpac -All | Format-List *
+
+          Write-Host "Windows media tool version step completed."
+          exit 0
+
+      - name: Print media tool versions
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          ffmpeg -version
+          gpac -h
+
+      - name: Build artifacts for integration tests
+        run: npm run build
+
+      - name: Run integration tests
+        run: npm test -- integration --browser ${{ matrix.browser }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,18 +12,27 @@
         "@canalplus/readme.doc": "0.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@typescript-eslint/eslint-plugin": "^8.59.1",
-        "@typescript-eslint/parser": "^8.59.1",
+        "@typescript-eslint/eslint-plugin": "^8.59.3",
+        "@typescript-eslint/parser": "^8.59.3",
+        "@vitest/browser-webdriverio": "^4.1.6",
         "esbuild": "^0.28.0",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsdoc": "^62.9.0",
         "prettier": "^3.8.3",
-        "react": "^19.2.5",
-        "react-dom": "^19.2.5",
-        "typescript": "^6.0.3"
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.6"
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@canalplus/readme.doc": {
       "version": "0.6.0",
@@ -68,6 +77,40 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.86.0",
@@ -632,6 +675,37 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -762,6 +836,56 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -772,6 +896,339 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@promptbook/utils": {
+      "version": "0.69.5",
+      "resolved": "https://registry.npmjs.org/@promptbook/utils/-/utils-0.69.5.tgz",
+      "integrity": "sha512-xm5Ti/Hp3o4xHrsK9Yy3MS6KbDxYbq485hDsFvxqaNA7equHLPdo8H8faTitTeb14QCDfLW4iwCxdVYu5sn6YQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/webgptorg/promptbook/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "peer": true,
+      "dependencies": {
+        "spacetrim": "0.11.59"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -792,6 +1249,50 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -814,6 +1315,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -834,18 +1346,57 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
-      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/type-utils": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -858,22 +1409,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.1",
+        "@typescript-eslint/parser": "^8.59.3",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
-      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -889,14 +1440,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
-      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.1",
-        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -911,14 +1462,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
-      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -929,9 +1480,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
-      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -946,15 +1497,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
-      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -971,9 +1522,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
-      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -985,16 +1536,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
-      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.1",
-        "@typescript-eslint/tsconfig-utils": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1023,9 +1574,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1052,16 +1603,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
-      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1"
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1076,13 +1627,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/types": "8.59.3",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1106,6 +1657,306 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/browser": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.6.tgz",
+      "integrity": "sha512-ynsspTubXGSpa58JFJ24xIQt4z4A25epSbugEyaTmmrV1//Wec9EgE/LtoaC6yxUrXi5P7erGHRrkdZIHaVQuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.6"
+      }
+    },
+    "node_modules/@vitest/browser-webdriverio": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-webdriverio/-/browser-webdriverio-4.1.6.tgz",
+      "integrity": "sha512-ETduHXNt8qjkPw9TvCHs9msDrxsewOEhYRhuDyD9n56+JIUbVSmqxTiSXJcI/baU30Z/AL/VPHMn2HemnKMhIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "4.1.6"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.6",
+        "webdriverio": "*"
+      },
+      "peerDependenciesMeta": {
+        "webdriverio": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@wdio/config": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.27.1.tgz",
+      "integrity": "sha512-QVfSCqcpMfVum9KlpxgjaLlSLXkc53UQ2CPJU+IUVBp8LkbSyeX972HQS8V9Hnn6vSPE1dYScItg7wblnJ8RQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "deepmerge-ts": "^7.0.3",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0",
+        "jiti": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/logger": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/logger/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@wdio/protocols": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.27.1.tgz",
+      "integrity": "sha512-Ril46AmySoiYX9nuKqFr3SNJqquU3VmF9FzSndQlDib0G3oA4pYx9wcBXvdvkFxRjjmFwQDzmvztKrssAHymgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@wdio/repl": {
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.16.2.tgz",
+      "integrity": "sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/types": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.27.1.tgz",
+      "integrity": "sha512-EHBNCvLmvpYerln4mb/OBxzKtnavL2wdenjhwuYjzkZMOWHgm/uLXH6sLThM0y6DIbCU72Asth16fo1eDcsofA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/utils": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.27.1.tgz",
+      "integrity": "sha512-s2w1tFrvmpdkZ33LYsIw4ONRdWIIm4MxkyIuibbcG1ILV5fFMS9rU59csHuWIM0KhJoEoLU+fzE3ze9O7TpWhw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@puppeteer/browsers": "^2.2.0",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.27.1",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^7.0.3",
+        "edgedriver": "^6.1.2",
+        "geckodriver": "^6.1.0",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.2.24",
+        "mitt": "^3.0.1",
+        "safaridriver": "^1.0.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.8.26",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
+      "integrity": "sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1127,6 +1978,17 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1174,6 +2036,46 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/are-docs-informative": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
@@ -1188,6 +2090,17 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -1311,6 +2224,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -1337,11 +2282,163 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -1358,6 +2455,43 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/call-bind": {
@@ -1420,6 +2554,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1474,6 +2618,90 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1492,6 +2720,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/comment-parser": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
@@ -1502,11 +2741,73 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1539,6 +2840,21 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-shorthand-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.2.tgz",
+      "integrity": "sha512-C2AugXIpRGQTxaCW0N7n5jD/p5irUmCrwl03TrnMFBHDbdq44CFWR2zO7rK9xPN4Eo3pUxC4vQzQgbIpzrD1PQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/css-value": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
+      "integrity": "sha512-FUV3xaJ63buRLgHrLQVlVgQnQdR4yqdLGaDu7g8CQcWjInDfM9plBTPI9FRfpahju1UBSaMckeb2/46ApS/V1Q==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -1557,6 +2873,17 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -1630,12 +2957,37 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -1671,6 +3023,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dom-serializer": {
@@ -1750,12 +3128,94 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/edge-paths": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
+      "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/which": "^2.0.1",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/shirshak55"
+      }
+    },
+    "node_modules/edgedriver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.3.0.tgz",
+      "integrity": "sha512-ggEQL+oEyIcM4nP2QC3AtCQ04o4kDNefRM3hja0odvlPSnsaxiruMxEZ93v3gDCKWYW6BXUr51PPradb+3nffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
+        "edge-paths": "^3.0.5",
+        "fast-xml-parser": "^5.3.3",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "edgedriver": "bin/edgedriver.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/edgedriver/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/edgedriver/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -1857,6 +3317,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1960,6 +3427,17 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -1970,6 +3448,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -2192,37 +3693,6 @@
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
-    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/eslint-plugin-jsdoc/node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -2283,17 +3753,7 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/espree": {
+    "node_modules/eslint/node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
@@ -2311,17 +3771,60 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
-      "license": "Apache-2.0",
+      "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": ">= 4"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -2360,6 +3863,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2369,12 +3882,85 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2389,6 +3975,59 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2491,6 +4130,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2532,6 +4186,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/geckodriver": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
+      "integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "modern-tar": "^0.7.2"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -2540,6 +4217,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2567,6 +4255,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -2579,6 +4281,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -2597,6 +4316,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -2702,6 +4437,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -2795,6 +4546,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/htmlfy": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
+      "integrity": "sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -2814,6 +4573,58 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -2823,6 +4634,14 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -2841,6 +4660,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2849,6 +4680,14 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -2863,6 +4702,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3110,6 +4960,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3156,6 +5020,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -3285,6 +5163,17 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3341,6 +5230,64 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "peer": true,
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3349,6 +5296,64 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/levn": {
@@ -3365,6 +5370,290 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -3373,6 +5662,29 @@
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/locate-app": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.5.0.tgz",
+      "integrity": "sha512-xIqbzPMBYArJRmPGUZD9CzV9wOqmVtQnaAn3wrj3s6WYW0bQvPI7x+sPYUGmDTYMHefVK//zc6HEYZ1qnxIK+Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/hejny/locate-app/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@promptbook/utils": "0.69.5",
+        "type-fest": "4.26.0",
+        "userhome": "1.0.1"
       }
     },
     "node_modules/locate-path": {
@@ -3390,11 +5702,59 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loglevel-plugin-prefix": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -3402,6 +5762,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/markdown-it": {
       "version": "14.0.0",
@@ -3470,6 +5840,35 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3477,11 +5876,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -3599,6 +6039,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3665,12 +6127,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)",
+      "peer": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -3736,6 +6242,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3770,6 +6293,28 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -3783,6 +6328,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -3791,6 +6346,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -3819,6 +6403,88 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3839,10 +6505,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3850,16 +6524,70 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -3906,6 +6634,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reserved-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
@@ -3947,6 +6686,44 @@
         "node": ">=4"
       }
     },
+    "node_modules/resq": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resq/-/resq-1.11.0.tgz",
+      "integrity": "sha512-G10EBz+zAAy3zUd/CDoBbXRL6ia9kOo3xRHrMDsHljI0GDkhYlyjwoCx5+3eCC4swi1uCoZQhskuJkj7Gp57Bw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
+    },
+    "node_modules/resq/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/rgb2hex": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.5.tgz",
+      "integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/rimraf": {
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
@@ -3961,6 +6738,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+      }
+    },
+    "node_modules/safaridriver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.1.tgz",
+      "integrity": "sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -3982,6 +6804,28 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -4018,6 +6862,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4036,6 +6904,37 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
+      "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^4.31.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/set-function-length": {
@@ -4086,6 +6985,14 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4186,6 +7093,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4198,6 +7112,105 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spacetrim": {
+      "version": "0.11.59",
+      "resolved": "https://registry.npmjs.org/spacetrim/-/spacetrim-0.11.59.tgz",
+      "integrity": "sha512-lLYsktklSRKprreOm7NXReW8YiX2VBjbgmXYEziOoGf/qsJqAEACaDvoTtUOycwjpaSh+bT8eu0KrJn7UNxiCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/hejny/spacetrim/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
@@ -4224,6 +7237,31 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -4236,6 +7274,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -4424,6 +7486,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4449,6 +7525,75 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -4466,6 +7611,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-valid-identifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
@@ -4481,6 +7636,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4509,6 +7674,13 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4520,6 +7692,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
+      "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -4640,6 +7826,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4648,6 +7853,290 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/userhome": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.1.tgz",
+      "integrity": "sha512-5cnLm4gseXjAclKowC4IjByaGsjtAoV6PrOQOljplNB54ReUYJP8HdAFq2muHinSDAh09PPX/uXDPfdxRHvuSA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/vite": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/wait-port": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
+      "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^9.3.0",
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "wait-port": "bin/wait-port.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/webdriver": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.27.1.tgz",
+      "integrity": "sha512-vr6h+RNQ75O2cofgVrdupGxtKjPEBaBYx/lHCHe0giJfAK01oL0U/yrOksJi7kmpev/daN93ldFPhlIlmWtv8Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@types/ws": "^8.5.3",
+        "@wdio/config": "9.27.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.27.1",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "deepmerge-ts": "^7.0.3",
+        "https-proxy-agent": "^7.0.6",
+        "undici": "^6.21.3",
+        "ws": "^8.8.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/webdriverio": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.27.1.tgz",
+      "integrity": "sha512-iPaIU/DluYY7zfLiwXDdoLU/6ZW8eup4PNwQikrCzTfvH/ITllRhFUe6NRDTEEePSxxRTeXAn9nehCs98xWGVA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^20.11.30",
+        "@types/sinonjs__fake-timers": "^8.1.5",
+        "@wdio/config": "9.27.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.27.1",
+        "@wdio/repl": "9.16.2",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "archiver": "^7.0.1",
+        "aria-query": "^5.3.0",
+        "cheerio": "^1.0.0-rc.12",
+        "css-shorthand-properties": "^1.1.1",
+        "css-value": "^0.0.1",
+        "grapheme-splitter": "^1.0.4",
+        "htmlfy": "^0.8.1",
+        "is-plain-obj": "^4.1.0",
+        "jszip": "^3.10.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.zip": "^4.2.0",
+        "query-selector-shadow-dom": "^1.0.1",
+        "resq": "^1.11.0",
+        "rgb2hex": "0.2.5",
+        "serialize-error": "^12.0.0",
+        "urlpattern-polyfill": "^10.0.0",
+        "webdriver": "9.27.1"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      },
+      "peerDependencies": {
+        "puppeteer-core": ">=22.x || <=24.x"
+      },
+      "peerDependenciesMeta": {
+        "puppeteer-core": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {
@@ -4755,6 +8244,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4860,6 +8366,167 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yauzl/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4871,9 +8538,31 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     }
   },
   "dependencies": {
+    "@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "dev": true
+    },
     "@canalplus/readme.doc": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@canalplus/readme.doc/-/readme.doc-0.6.0.tgz",
@@ -4899,6 +8588,37 @@
           "integrity": "sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==",
           "dev": true
         }
+      }
+    },
+    "@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "@es-joy/jsdoccomment": {
@@ -5163,6 +8883,23 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+          "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+          "dev": true
+        },
+        "espree": {
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+          "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.15.0",
+            "acorn-jsx": "^5.3.2",
+            "eslint-visitor-keys": "^4.2.1"
+          }
+        },
         "ignore": {
           "version": "5.3.2",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5245,12 +8982,189 @@
         "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
       }
     },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "peer": true
+    },
+    "@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "dev": true
+    },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
       "optional": true
+    },
+    "@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true
+    },
+    "@promptbook/utils": {
+      "version": "0.69.5",
+      "resolved": "https://registry.npmjs.org/@promptbook/utils/-/utils-0.69.5.tgz",
+      "integrity": "sha512-xm5Ti/Hp3o4xHrsK9Yy3MS6KbDxYbq485hDsFvxqaNA7equHLPdo8H8faTitTeb14QCDfLW4iwCxdVYu5sn6YQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "spacetrim": "0.11.59"
+      }
+    },
+    "@puppeteer/browsers": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      }
+    },
+    "@rolldown/binding-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-freebsd-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      }
+    },
+    "@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true
     },
     "@rtsao/scc": {
       "version": "1.1.0",
@@ -5262,6 +9176,45 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
       "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true
+    },
+    "@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
+    "@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "peer": true
+    },
+    "@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "requires": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true
     },
     "@types/estree": {
@@ -5282,6 +9235,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -5298,92 +9261,127 @@
       "dev": true,
       "requires": {}
     },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
+      "peer": true
+    },
+    "@types/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
+      "dev": true,
+      "peer": true
+    },
+    "@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@typescript-eslint/eslint-plugin": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
-      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/type-utils": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
-      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3"
       }
     },
     "@typescript-eslint/project-service": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
-      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.1",
-        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
         "debug": "^4.4.3"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
-      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
       }
     },
     "@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
-      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
       "requires": {}
     },
     "@typescript-eslint/type-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
-      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
-      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
-      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/project-service": "8.59.1",
-        "@typescript-eslint/tsconfig-utils": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -5398,9 +9396,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+          "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"
@@ -5418,24 +9416,24 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
-      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1"
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/types": "8.59.3",
         "eslint-visitor-keys": "^5.0.0"
       },
       "dependencies": {
@@ -5445,6 +9443,210 @@
           "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
           "dev": true
         }
+      }
+    },
+    "@vitest/browser": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.6.tgz",
+      "integrity": "sha512-ynsspTubXGSpa58JFJ24xIQt4z4A25epSbugEyaTmmrV1//Wec9EgE/LtoaC6yxUrXi5P7erGHRrkdZIHaVQuA==",
+      "dev": true,
+      "requires": {
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      }
+    },
+    "@vitest/browser-webdriverio": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-webdriverio/-/browser-webdriverio-4.1.6.tgz",
+      "integrity": "sha512-ETduHXNt8qjkPw9TvCHs9msDrxsewOEhYRhuDyD9n56+JIUbVSmqxTiSXJcI/baU30Z/AL/VPHMn2HemnKMhIQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/browser": "4.1.6"
+      }
+    },
+    "@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "requires": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      }
+    },
+    "@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      }
+    },
+    "@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "requires": {
+        "tinyrainbow": "^3.1.0"
+      }
+    },
+    "@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "requires": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      }
+    },
+    "@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      }
+    },
+    "@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true
+    },
+    "@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      }
+    },
+    "@wdio/config": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.27.1.tgz",
+      "integrity": "sha512-QVfSCqcpMfVum9KlpxgjaLlSLXkc53UQ2CPJU+IUVBp8LkbSyeX972HQS8V9Hnn6vSPE1dYScItg7wblnJ8RQg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "deepmerge-ts": "^7.0.3",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0",
+        "jiti": "^2.6.1"
+      }
+    },
+    "@wdio/logger": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.6.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+          "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "@wdio/protocols": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.27.1.tgz",
+      "integrity": "sha512-Ril46AmySoiYX9nuKqFr3SNJqquU3VmF9FzSndQlDib0G3oA4pYx9wcBXvdvkFxRjjmFwQDzmvztKrssAHymgw==",
+      "dev": true,
+      "peer": true
+    },
+    "@wdio/repl": {
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.16.2.tgz",
+      "integrity": "sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/node": "^20.1.0"
+      }
+    },
+    "@wdio/types": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.27.1.tgz",
+      "integrity": "sha512-EHBNCvLmvpYerln4mb/OBxzKtnavL2wdenjhwuYjzkZMOWHgm/uLXH6sLThM0y6DIbCU72Asth16fo1eDcsofA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/node": "^20.1.0"
+      }
+    },
+    "@wdio/utils": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.27.1.tgz",
+      "integrity": "sha512-s2w1tFrvmpdkZ33LYsIw4ONRdWIIm4MxkyIuibbcG1ILV5fFMS9rU59csHuWIM0KhJoEoLU+fzE3ze9O7TpWhw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@puppeteer/browsers": "^2.2.0",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.27.1",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^7.0.3",
+        "edgedriver": "^6.1.2",
+        "geckodriver": "^6.1.0",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.2.24",
+        "mitt": "^3.0.1",
+        "safaridriver": "^1.0.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.1.0"
+      }
+    },
+    "@zip.js/zip.js": {
+      "version": "2.8.26",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
+      "integrity": "sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==",
+      "dev": true,
+      "peer": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
       }
     },
     "acorn": {
@@ -5459,6 +9661,13 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "peer": true
     },
     "ajv": {
       "version": "6.15.0",
@@ -5487,6 +9696,38 @@
         "color-convert": "^2.0.1"
       }
     },
+    "archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      }
+    },
+    "archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
     "are-docs-informative": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
@@ -5498,6 +9739,13 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "peer": true
     },
     "array-buffer-byte-length": {
       "version": "1.0.2",
@@ -5579,6 +9827,29 @@
         "is-array-buffer": "^3.0.4"
       }
     },
+    "assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true
+    },
+    "ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "tslib": "^2.0.1"
+      }
+    },
+    "async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "peer": true
+    },
     "async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -5594,11 +9865,93 @@
         "possible-typed-array-names": "^1.0.0"
       }
     },
+    "b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
+    },
+    "bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      }
+    },
+    "bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "peer": true
+    },
+    "bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      }
+    },
+    "bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "peer": true
+    },
+    "basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "peer": true
     },
     "boolbase": {
       "version": "1.0.0",
@@ -5615,6 +9968,24 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "peer": true
     },
     "call-bind": {
       "version": "1.0.9",
@@ -5652,6 +10023,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true
     },
     "chalk": {
@@ -5693,6 +10070,68 @@
         "domutils": "^3.0.1"
       }
     },
+    "cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true,
+          "peer": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true,
+          "peer": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5708,17 +10147,69 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "peer": true
+    },
     "comment-parser": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
       "integrity": "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==",
       "dev": true
     },
+    "compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "peer": true
+    },
+    "crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "peer": true
+    },
+    "crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      }
     },
     "cross-spawn": {
       "version": "7.0.6",
@@ -5744,6 +10235,20 @@
         "nth-check": "^2.0.1"
       }
     },
+    "css-shorthand-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.2.tgz",
+      "integrity": "sha512-C2AugXIpRGQTxaCW0N7n5jD/p5irUmCrwl03TrnMFBHDbdq44CFWR2zO7rK9xPN4Eo3pUxC4vQzQgbIpzrD1PQ==",
+      "dev": true,
+      "peer": true
+    },
+    "css-value": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
+      "integrity": "sha512-FUV3xaJ63buRLgHrLQVlVgQnQdR4yqdLGaDu7g8CQcWjInDfM9plBTPI9FRfpahju1UBSaMckeb2/46ApS/V1Q==",
+      "dev": true,
+      "peer": true
+    },
     "css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -5755,6 +10260,13 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true
+    },
+    "data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "peer": true
     },
     "data-view-buffer": {
       "version": "1.0.2",
@@ -5798,11 +10310,25 @@
         "ms": "^2.1.3"
       }
     },
+    "decamelize": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "dev": true,
+      "peer": true
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "dev": true,
+      "peer": true
     },
     "define-data-property": {
       "version": "1.1.4",
@@ -5825,6 +10351,24 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      }
+    },
+    "detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true
     },
     "dom-serializer": {
       "version": "2.0.0",
@@ -5880,11 +10424,68 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
+    "edge-paths": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
+      "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/which": "^2.0.1",
+        "which": "^2.0.2"
+      }
+    },
+    "edgedriver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.3.0.tgz",
+      "integrity": "sha512-ggEQL+oEyIcM4nP2QC3AtCQ04o4kDNefRM3hja0odvlPSnsaxiruMxEZ93v3gDCKWYW6BXUr51PPradb+3nffw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
+        "edge-paths": "^3.0.5",
+        "fast-xml-parser": "^5.3.3",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "which": "^6.0.0"
+      },
+      "dependencies": {
+        "isexe": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+          "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+          "dev": true,
+          "peer": true
+        },
+        "which": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+          "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "isexe": "^4.0.0"
+          }
+        }
+      }
+    },
     "emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "entities": {
       "version": "4.5.0",
@@ -5966,6 +10567,12 @@
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true
     },
+    "es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true
+    },
     "es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -6041,11 +10648,31 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
+    "escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "peer": true
+    },
     "escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
+    },
+    "escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "source-map": "~0.6.1"
+      }
     },
     "eslint": {
       "version": "9.39.4",
@@ -6094,6 +10721,17 @@
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
           "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
           "dev": true
+        },
+        "espree": {
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+          "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.15.0",
+            "acorn-jsx": "^5.3.2",
+            "eslint-visitor-keys": "^4.2.1"
+          }
         },
         "ignore": {
           "version": "5.3.2",
@@ -6227,23 +10865,6 @@
         "to-valid-identifier": "^1.0.0"
       },
       "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-          "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-          "dev": true
-        },
-        "espree": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-          "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-          "dev": true,
-          "requires": {
-            "acorn": "^8.16.0",
-            "acorn-jsx": "^5.3.2",
-            "eslint-visitor-keys": "^5.0.1"
-          }
-        },
         "html-entities": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -6269,23 +10890,30 @@
       "dev": true
     },
     "espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "requires": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-          "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+          "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
           "dev": true
         }
       }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "peer": true
     },
     "esquery": {
       "version": "1.7.0",
@@ -6311,17 +10939,76 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "peer": true
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "peer": true
+    },
+    "events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true
+    },
+    "extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "peer": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -6334,6 +11021,41 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
     },
     "fdir": {
       "version": "6.5.0",
@@ -6396,6 +11118,13 @@
         "signal-exit": "^4.0.1"
       }
     },
+    "fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6422,11 +11151,33 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
+    "geckodriver": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
+      "integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "modern-tar": "^0.7.2"
+      }
+    },
     "generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
       "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "peer": true
     },
     "get-intrinsic": {
       "version": "1.3.0",
@@ -6446,6 +11197,13 @@
         "math-intrinsics": "^1.1.0"
       }
     },
+    "get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "dev": true,
+      "peer": true
+    },
     "get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -6454,6 +11212,16 @@
       "requires": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
+      }
+    },
+    "get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "pump": "^3.0.0"
       }
     },
     "get-symbol-description": {
@@ -6465,6 +11233,18 @@
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6"
+      }
+    },
+    "get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
       }
     },
     "glob": {
@@ -6532,6 +11312,20 @@
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true
     },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "peer": true
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true,
+      "peer": true
+    },
     "has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -6586,6 +11380,13 @@
         "function-bind": "^1.1.2"
       }
     },
+    "htmlfy": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
+      "integrity": "sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==",
+      "dev": true,
+      "peer": true
+    },
     "htmlparser2": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -6598,11 +11399,47 @@
         "entities": "^4.4.0"
       }
     },
+    "http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "peer": true
+    },
     "ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "peer": true
     },
     "import-fresh": {
       "version": "3.3.1",
@@ -6614,11 +11451,25 @@
         "resolve-from": "^4.0.0"
       }
     },
+    "import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "peer": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "peer": true
     },
     "internal-slot": {
       "version": "1.1.0",
@@ -6630,6 +11481,13 @@
         "hasown": "^2.0.2",
         "side-channel": "^1.1.0"
       }
+    },
+    "ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "peer": true
     },
     "is-array-buffer": {
       "version": "3.0.5",
@@ -6775,6 +11633,13 @@
         "has-tostringtag": "^1.0.2"
       }
     },
+    "is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "peer": true
+    },
     "is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6801,6 +11666,13 @@
       "requires": {
         "call-bound": "^1.0.3"
       }
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "peer": true
     },
     "is-string": {
       "version": "1.1.1",
@@ -6879,6 +11751,13 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "peer": true
+    },
     "js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -6921,6 +11800,61 @@
         "minimist": "^1.2.0"
       }
     },
+    "jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+          "dev": true,
+          "peer": true
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "peer": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6928,6 +11862,58 @@
       "dev": true,
       "requires": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "readable-stream": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+          "dev": true,
+          "peer": true
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "peer": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "levn": {
@@ -6940,6 +11926,113 @@
         "type-check": "~0.4.0"
       }
     },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^2.0.3",
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "dev": true,
+      "optional": true
+    },
     "linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -6947,6 +12040,18 @@
       "dev": true,
       "requires": {
         "uc.micro": "^2.0.0"
+      }
+    },
+    "locate-app": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.5.0.tgz",
+      "integrity": "sha512-xIqbzPMBYArJRmPGUZD9CzV9wOqmVtQnaAn3wrj3s6WYW0bQvPI7x+sPYUGmDTYMHefVK//zc6HEYZ1qnxIK+Q==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@promptbook/utils": "0.69.5",
+        "type-fest": "4.26.0",
+        "userhome": "1.0.1"
       }
     },
     "locate-path": {
@@ -6958,17 +12063,61 @@
         "p-locate": "^5.0.0"
       }
     },
+    "lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "peer": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "peer": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
+      "dev": true,
+      "peer": true
+    },
+    "loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "dev": true,
+      "peer": true
+    },
+    "loglevel-plugin-prefix": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+      "dev": true,
+      "peer": true
+    },
     "lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "markdown-it": {
       "version": "14.0.0",
@@ -7017,10 +12166,36 @@
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true
     },
+    "mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "peer": true
+    },
+    "modern-tar": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "dev": true,
+      "peer": true
+    },
+    "mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true
     },
     "natural-compare": {
@@ -7028,6 +12203,20 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "peer": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "peer": true
     },
     "nth-check": {
       "version": "2.1.1",
@@ -7105,6 +12294,22 @@
         "es-object-atoms": "^1.0.0"
       }
     },
+    "obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
     "optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7148,11 +12353,46 @@
         "p-limit": "^3.0.2"
       }
     },
+    "pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      }
+    },
+    "pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      }
+    },
     "package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "peer": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -7203,6 +12443,13 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
+    "path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "peer": true
+    },
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -7225,10 +12472,35 @@
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       }
     },
+    "pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "peer": true
+    },
+    "picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
     "picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true
+    },
+    "pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
       "dev": true
     },
     "possible-typed-array-names": {
@@ -7236,6 +12508,17 @@
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true
+    },
+    "postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      }
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -7249,6 +12532,71 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "peer": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "peer": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "peer": true
+    },
+    "proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "peer": true
+    },
+    "pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7261,19 +12609,72 @@
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true
     },
+    "query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "dev": true,
+      "peer": true
+    },
     "react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "dev": true
     },
     "react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "dev": true,
       "requires": {
         "scheduler": "^0.27.0"
+      }
+    },
+    "readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      }
+    },
+    "readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "minimatch": "^5.1.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+          "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.9",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+          "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "reflect.getprototypeof": {
@@ -7306,6 +12707,13 @@
         "set-function-name": "^2.0.2"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "peer": true
+    },
     "reserved-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
@@ -7329,6 +12737,39 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "resq": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resq/-/resq-1.11.0.tgz",
+      "integrity": "sha512-G10EBz+zAAy3zUd/CDoBbXRL6ia9kOo3xRHrMDsHljI0GDkhYlyjwoCx5+3eCC4swi1uCoZQhskuJkj7Gp57Bw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
+      "peer": true
+    },
+    "rgb2hex": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.5.tgz",
+      "integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==",
+      "dev": true,
+      "peer": true
+    },
     "rimraf": {
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
@@ -7337,6 +12778,38 @@
       "requires": {
         "glob": "^10.3.7"
       }
+    },
+    "rolldown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "dev": true,
+      "requires": {
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1",
+        "@rolldown/pluginutils": "^1.0.0"
+      }
+    },
+    "safaridriver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.1.tgz",
+      "integrity": "sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==",
+      "dev": true,
+      "peer": true
     },
     "safe-array-concat": {
       "version": "1.1.4",
@@ -7350,6 +12823,13 @@
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "peer": true
     },
     "safe-push-apply": {
       "version": "1.0.0",
@@ -7372,6 +12852,16 @@
         "is-regex": "^1.2.1"
       }
     },
+    "safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "ret": "~0.5.0"
+      }
+    },
     "scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7383,6 +12873,25 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true
+    },
+    "serialize-error": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
+      "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "type-fest": "^4.31.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "4.41.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+          "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+          "dev": true,
+          "peer": true
+        }
+      }
     },
     "set-function-length": {
       "version": "1.2.2",
@@ -7420,6 +12929,13 @@
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0"
       }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "peer": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -7484,11 +13000,79 @@
         "side-channel-map": "^1.0.1"
       }
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true
+    },
+    "sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      }
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "peer": true
+    },
+    "socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true
+    },
+    "spacetrim": {
+      "version": "0.11.59",
+      "resolved": "https://registry.npmjs.org/spacetrim/-/spacetrim-0.11.59.tgz",
+      "integrity": "sha512-lLYsktklSRKprreOm7NXReW8YiX2VBjbgmXYEziOoGf/qsJqAEACaDvoTtUOycwjpaSh+bT8eu0KrJn7UNxiCg==",
+      "dev": true,
+      "peer": true
     },
     "spdx-exceptions": {
       "version": "2.5.0",
@@ -7512,6 +13096,25 @@
       "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
       "dev": true
     },
+    "split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "peer": true
+    },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true
+    },
     "stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -7520,6 +13123,28 @@
       "requires": {
         "es-errors": "^1.3.0",
         "internal-slot": "^1.1.0"
+      }
+    },
+    "streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "string-width": {
@@ -7643,6 +13268,13 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
+      "peer": true
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7658,6 +13290,64 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      }
+    },
+    "tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true
+    },
     "tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -7668,6 +13358,12 @@
         "picomatch": "^4.0.4"
       }
     },
+    "tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true
+    },
     "to-valid-identifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
@@ -7677,6 +13373,12 @@
         "@sindresorhus/base62": "^1.0.0",
         "reserved-identifiers": "^1.0.0"
       }
+    },
+    "totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true
     },
     "ts-api-utils": {
       "version": "2.5.0",
@@ -7697,6 +13399,12 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7705,6 +13413,13 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-fest": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
+      "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
+      "dev": true,
+      "peer": true
     },
     "typed-array-buffer": {
       "version": "1.0.3",
@@ -7783,6 +13498,20 @@
         "which-boxed-primitive": "^1.1.1"
       }
     },
+    "undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "dev": true,
+      "peer": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "peer": true
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -7790,6 +13519,135 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "dev": true,
+      "peer": true
+    },
+    "userhome": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.1.tgz",
+      "integrity": "sha512-5cnLm4gseXjAclKowC4IjByaGsjtAoV6PrOQOljplNB54ReUYJP8HdAFq2muHinSDAh09PPX/uXDPfdxRHvuSA==",
+      "dev": true,
+      "peer": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "peer": true
+    },
+    "vite": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.3",
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
+      }
+    },
+    "vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      }
+    },
+    "wait-port": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
+      "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "chalk": "^4.1.2",
+        "commander": "^9.3.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "webdriver": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.27.1.tgz",
+      "integrity": "sha512-vr6h+RNQ75O2cofgVrdupGxtKjPEBaBYx/lHCHe0giJfAK01oL0U/yrOksJi7kmpev/daN93ldFPhlIlmWtv8Q==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/node": "^20.1.0",
+        "@types/ws": "^8.5.3",
+        "@wdio/config": "9.27.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.27.1",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "deepmerge-ts": "^7.0.3",
+        "https-proxy-agent": "^7.0.6",
+        "undici": "^6.21.3",
+        "ws": "^8.8.0"
+      }
+    },
+    "webdriverio": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.27.1.tgz",
+      "integrity": "sha512-iPaIU/DluYY7zfLiwXDdoLU/6ZW8eup4PNwQikrCzTfvH/ITllRhFUe6NRDTEEePSxxRTeXAn9nehCs98xWGVA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/node": "^20.11.30",
+        "@types/sinonjs__fake-timers": "^8.1.5",
+        "@wdio/config": "9.27.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.27.1",
+        "@wdio/repl": "9.16.2",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "archiver": "^7.0.1",
+        "aria-query": "^5.3.0",
+        "cheerio": "^1.0.0-rc.12",
+        "css-shorthand-properties": "^1.1.1",
+        "css-value": "^0.0.1",
+        "grapheme-splitter": "^1.0.4",
+        "htmlfy": "^0.8.1",
+        "is-plain-obj": "^4.1.0",
+        "jszip": "^3.10.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.zip": "^4.2.0",
+        "query-selector-shadow-dom": "^1.0.1",
+        "resq": "^1.11.0",
+        "rgb2hex": "0.2.5",
+        "serialize-error": "^12.0.0",
+        "urlpattern-polyfill": "^10.0.0",
+        "webdriver": "9.27.1"
       }
     },
     "which": {
@@ -7862,6 +13720,16 @@
         "has-tostringtag": "^1.0.2"
       }
     },
+    "why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "requires": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      }
+    },
     "word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7932,11 +13800,132 @@
         }
       }
     },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "peer": true
+    },
+    "ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "requires": {}
+    },
+    "xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "peer": true
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "peer": true
+    },
+    "yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true,
+          "peer": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true,
+          "peer": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "peer": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      },
+      "dependencies": {
+        "buffer-crc32": {
+          "version": "0.2.13",
+          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+          "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
     "scripts": "node scripts/list-npm-scripts.mjs",
     "serve": "node scripts/tasks/index.mjs serve",
     "start": "node scripts/tasks/index.mjs start",
-    "test:transmux": "node --test tests/transmux-timeline-anchor.test.mjs"
+    "test": "node scripts/tasks/index.mjs test",
+    "test:integration": "node scripts/tasks/index.mjs test integration",
+    "test:rust": "node scripts/tasks/index.mjs test rust",
+    "test:transmux": "node scripts/tasks/index.mjs test transmux"
   },
   "scripts-list": {
     "Build": {
@@ -59,7 +62,13 @@
       "check -- main": "Typecheck and lint the main-thread TypeScript code.",
       "check -- worker": "Typecheck and lint the worker and transmux TypeScript code.",
       "check -- demo": "Typecheck and lint the demo app.",
-      "check -- rust": "Run clippy on the Rust code."
+      "check -- rust": "Run clippy on the Rust code.",
+      "test": "Run every test suite: Rust unit tests, transmux tests, and browser integration tests.",
+      "test -- rust": "Run only Rust unit tests.",
+      "test -- transmux": "Run only the Node-based transmux tests.",
+      "test -- integration": "Run only the browser integration tests.",
+      "test -- integration --browser firefox": "Run browser integration tests in Firefox.",
+      "test -- integration --filter dash_live_packaged": "Run only matching browser integration tests."
     },
     "Development": {
       "start": "Serve build/ and watch-rebuild the demo during development.",
@@ -80,16 +89,18 @@
     "@canalplus/readme.doc": "0.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@typescript-eslint/eslint-plugin": "^8.59.1",
-    "@typescript-eslint/parser": "^8.59.1",
+    "@typescript-eslint/eslint-plugin": "^8.59.3",
+    "@typescript-eslint/parser": "^8.59.3",
+    "@vitest/browser-webdriverio": "^4.1.6",
     "esbuild": "^0.28.0",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsdoc": "^62.9.0",
     "prettier": "^3.8.3",
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
-    "typescript": "^6.0.3"
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.6"
   }
 }

--- a/scripts/packager/README.md
+++ b/scripts/packager/README.md
@@ -9,6 +9,6 @@ to manually test the RxPlayer on a local content.
 Its entry point is the `main.mjs` file, you can run it directly with an `--help` flag to
 see options.
 
-When running it, `ffmpeg` has to be accessible in path. GPAC will be searched in
-path first and will otherwise be installed locally in `./tmp`, unless the GPAC
-binary is explicitly provided through `--gpac-path`.
+When running it, `ffmpeg` and `gpac` both have to be accessible in path (for the latter,
+unless the GPAC binary is explicitly provided through `--gpac-path`). On Windows, the
+packager also checks common `gpac.exe` install locations if the binary is not on `PATH`.

--- a/scripts/packager/constants.mjs
+++ b/scripts/packager/constants.mjs
@@ -11,6 +11,7 @@ export const DEFAULT_TIMESHIFT_BUFFER_DEPTH = 180;
 export const DEFAULT_BASE_PORT = 8881;
 export const DEFAULT_MEDIA_FORMAT = "fmp4";
 export const DEFAULT_SUBTITLE_FORMAT = "none";
+export const DEFAULT_PUBLISH_STRATEGY = "atomic";
 
 // Text track constants
 
@@ -20,11 +21,6 @@ export const TEXT_TRACK_SEGMENT_PREFIX = "text_en";
 export const TEXT_TRACK_CUE_SPACING = 4;
 export const TEXT_TRACK_CUE_DURATION = 2;
 export const TEXT_TRACK_INITIAL_AHEAD_DURATION = 4;
-
-// Packager startup polling
-
-export const PACKAGER_STARTUP_TIMEOUT_MS = 15000;
-export const PACKAGER_STARTUP_POLL_INTERVAL_MS = 300;
 
 // ANSI colour codes
 
@@ -70,10 +66,10 @@ export const DEFAULT_CONFIG = {
   basePort: DEFAULT_BASE_PORT,
   mediaFormat: DEFAULT_MEDIA_FORMAT,
   subtitleFormat: DEFAULT_SUBTITLE_FORMAT,
+  publishStrategy: DEFAULT_PUBLISH_STRATEGY,
   lowLatency: false,
   noConfirm: false,
   gpacPath: "",
   tmpDir: TMP_DIR,
-  scriptDir: SCRIPT_DIR,
   outputDir: resolve(TMP_DIR, "testcontents", "live"),
 };

--- a/scripts/packager/gpac_packager.mjs
+++ b/scripts/packager/gpac_packager.mjs
@@ -1,29 +1,17 @@
 // @ts-check
 
-import { execFileSync } from "child_process";
 import { existsSync } from "fs";
 import { resolve } from "path";
-import {
-  PACKAGER_STARTUP_TIMEOUT_MS,
-  PACKAGER_STARTUP_POLL_INTERVAL_MS,
-} from "./constants.mjs";
 import { commandExists } from "./utils.mjs";
 
 /**
  * Resolve the path (or command name) for the GPAC CLI binary.
  *
  * @param {string} tmpDir
- * @param {string} scriptDir
- * @param {boolean} noConfirm
  * @param {string} [explicitPath]
  * @returns {Promise<string>}
  */
-export async function resolveGpacBinary(
-  tmpDir,
-  scriptDir,
-  noConfirm,
-  explicitPath,
-) {
+export async function resolveGpacBinary(tmpDir, explicitPath) {
   if (explicitPath) {
     return explicitPath;
   }
@@ -37,121 +25,14 @@ export async function resolveGpacBinary(
     return "gpac";
   }
 
-  if (!(await downloadGpac(tmpDir, scriptDir, noConfirm))) {
-    throw new Error("Failed to install GPAC");
-  }
-
-  const downloadedBinary = normalizeDownloadedGpacBinaryPath(tmpDir);
-  if (downloadedBinary === null) {
-    throw new Error("Failed to resolve installed GPAC binary");
-  }
-  return downloadedBinary;
-}
-
-/**
- * Poll until GPAC is listening on every expected UDP port, or reject after
- * PACKAGER_STARTUP_TIMEOUT_MS.
- *
- * Falls back to a 3-second sleep when neither `ss` nor `netstat` is available.
- *
- * @param {number[]} portList
- * @returns {Promise<void>}
- */
-export async function waitForGpacReady(portList) {
-  const uniquePorts = [...new Set(portList)];
-  const canPoll = commandExists("ss") || commandExists("netstat");
-
-  if (!canPoll) {
-    console.warn(
-      "Warning: Cannot poll UDP ports (no ss/netstat). Falling back to 3s sleep.",
-    );
-    await sleep(3000);
-    return;
-  }
-
-  console.log(
-    `Waiting for GPAC to bind UDP ports: ${uniquePorts.join(", ")}...`,
-  );
-
-  const deadline = Date.now() + PACKAGER_STARTUP_TIMEOUT_MS;
-
-  while (Date.now() < deadline) {
-    await sleep(PACKAGER_STARTUP_POLL_INTERVAL_MS);
-
-    if (allPortsListening(uniquePorts)) {
-      console.log("GPAC is ready.");
-      return;
-    }
+  const installedWindowsBinary = findInstalledWindowsGpacBinary();
+  if (installedWindowsBinary !== null) {
+    return installedWindowsBinary;
   }
 
   throw new Error(
-    `Timed out waiting for GPAC to bind ports after ${PACKAGER_STARTUP_TIMEOUT_MS}ms.`,
+    "GPAC not installed on this machine. Please install and make it available to PATH before running the packager.",
   );
-}
-
-/** @param {number} ms */
-function sleep(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
-/**
- * Returns true if all `ports` appear in the current UDP listener list.
- *
- * @param {number[]} ports
- * @returns {boolean}
- */
-function allPortsListening(ports) {
-  let output = "";
-  try {
-    if (commandExists("ss")) {
-      output = execFileSync("ss", ["-uln"], { encoding: "utf8" });
-    } else {
-      const netstatArgs =
-        process.platform === "win32" ? ["-a", "-n", "-p", "UDP"] : ["-uln"];
-      output = execFileSync("netstat", netstatArgs, { encoding: "utf8" });
-    }
-  } catch {
-    return false;
-  }
-  return ports.every(
-    (port) => output.includes(`:${port} `) || output.includes(`:${port}\t`),
-  );
-}
-
-/**
- * Try to download GPAC via the install script.
- *
- * @param {string} tmpDir
- * @param {string} scriptDir
- * @param {boolean} noConfirm
- * @returns {Promise<boolean>}
- */
-async function downloadGpac(tmpDir, scriptDir, noConfirm) {
-  console.log("No GPAC binary found locally...");
-
-  const installScript = resolve(scriptDir, "install_gpac.sh");
-  if (!existsSync(installScript)) {
-    throw new Error(
-      `install_gpac.sh not found at ${installScript}. Cannot install GPAC automatically.`,
-    );
-  }
-  console.log(
-    `We will load the GPAC binary locally in the "${tmpDir}" directory`,
-  );
-
-  const args = noConfirm ? ["--no-confirmation"] : [];
-  try {
-    execFileSync("bash", [installScript, ...args], { stdio: "inherit" });
-  } catch {
-    return false;
-  }
-
-  if (normalizeDownloadedGpacBinaryPath(tmpDir) === null) {
-    console.error("ERROR: GPAC binary was not successfully installed\n");
-    return false;
-  }
-
-  return true;
 }
 
 /**
@@ -167,5 +48,55 @@ function normalizeDownloadedGpacBinaryPath(tmpDir) {
   if (existsSync(binary)) {
     return binary;
   }
+  return null;
+}
+
+/**
+ * Resolve common Windows install locations when `gpac.exe` is installed but not
+ * available on PATH.
+ *
+ * @returns {string | null}
+ */
+function findInstalledWindowsGpacBinary() {
+  if (process.platform !== "win32") {
+    return null;
+  }
+
+  const candidates = [
+    process.env.ProgramFiles
+      ? resolve(process.env.ProgramFiles, "GPAC", "gpac.exe")
+      : null,
+    process.env["ProgramFiles(x86)"]
+      ? resolve(process.env["ProgramFiles(x86)"], "GPAC", "gpac.exe")
+      : null,
+    process.env.ChocolateyInstall
+      ? resolve(process.env.ChocolateyInstall, "bin", "gpac.exe")
+      : null,
+    process.env.ChocolateyInstall
+      ? resolve(
+          process.env.ChocolateyInstall,
+          "lib",
+          "gpac",
+          "tools",
+          "gpac.exe",
+        )
+      : null,
+    process.env.ChocolateyInstall
+      ? resolve(
+          process.env.ChocolateyInstall,
+          "lib",
+          "gpac.portable",
+          "tools",
+          "gpac.exe",
+        )
+      : null,
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate !== null && existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
   return null;
 }

--- a/scripts/packager/live_packager.mjs
+++ b/scripts/packager/live_packager.mjs
@@ -9,7 +9,7 @@ import {
   cleanupMediaFiles,
 } from "./utils.mjs";
 import { checkPortRange, buildPortMap } from "./ports.mjs";
-import { resolveGpacBinary, waitForGpacReady } from "./gpac_packager.mjs";
+import { resolveGpacBinary } from "./gpac_packager.mjs";
 import { buildFfmpegArgs, spawnFfmpeg } from "./ffmpeg.mjs";
 import { showConfigAndConfirm, askConfirmation } from "./ui.mjs";
 import {
@@ -18,6 +18,11 @@ import {
   cleanup,
   createChildExitPromise,
 } from "./cleanup.mjs";
+import {
+  cleanupGpacWorkDir,
+  getGpacWorkDir,
+  startLiveOutputPublisher,
+} from "./publisher.mjs";
 
 /**
  * @typedef {object} PackageConfig
@@ -30,10 +35,10 @@ import {
  * @property {number}  timeshiftBufferDepth  - DVR window depth in seconds.
  * @property {"mpegts"|"fmp4"} mediaFormat   - HLS media output format.
  * @property {"none"|"webvtt"|"ttml"} subtitleFormat - HLS subtitle output format.
+ * @property {"atomic"|"direct"} publishStrategy - How GPAC output is exposed publicly.
  * @property {boolean} lowLatency            - Enable LL-HLS packaging when supported.
  * @property {string}  [gpacPath]            - Explicit path to the gpac binary.
  * @property {string}  tmpDir                - Directory used to cache the gpac binary.
- * @property {string}  scriptDir             - Directory containing install_gpac.sh.
  */
 
 /**
@@ -67,12 +72,7 @@ export async function packageLiveContent(config) {
     );
   }
 
-  const gpacCmd = await resolveGpacBinary(
-    config.tmpDir,
-    config.scriptDir,
-    config.noConfirm,
-    config.gpacPath,
-  );
+  const gpacCmd = await resolveGpacBinary(config.tmpDir, config.gpacPath);
 
   const ports = buildPortMap(config.basePort);
 
@@ -81,29 +81,29 @@ export async function packageLiveContent(config) {
   console.log("Starting...");
   console.log("Cleaning up any existing media files before starting...");
   cleanupMediaFiles(config.outputDir);
+  cleanupGpacWorkDir(config.outputDir);
   ensureOutputDir(config);
+  const useAtomicPublisher = config.publishStrategy !== "direct";
+  const gpacOutputDir = useAtomicPublisher
+    ? getGpacWorkDir(config.outputDir)
+    : config.outputDir;
+  const publisher = useAtomicPublisher
+    ? startLiveOutputPublisher({
+        sourceDir: gpacOutputDir,
+        targetDir: config.outputDir,
+      })
+    : { stop() {} };
+  console.log(
+    `Publishing strategy: ${useAtomicPublisher ? "atomic publisher" : "direct GPAC output"}`,
+  );
 
-  const gpacArgs = buildGpacArgs(config, ports);
+  const gpacArgs = buildGpacArgs(config, ports, gpacOutputDir);
 
   console.log(`Starting GPAC with command: ${gpacCmd}`);
   const gpac = spawn(gpacCmd, gpacArgs, { stdio: "inherit" });
   setPackagerProc(gpac);
   console.log(`GPAC started with PID: ${gpac.pid}`);
   const gpacExited = createChildExitPromise("gpac", gpac, config.outputDir);
-
-  try {
-    await waitForGpacReady([
-      ports.p720,
-      ports.p480,
-      ports.p360,
-      ports.audio1,
-      ports.audio2,
-      ports.audio3,
-    ]);
-  } catch (err) {
-    cleanup(config.outputDir);
-    throw err;
-  }
 
   const ffmpegArgs = buildFfmpegArgs({
     frameRate: config.frameRate,
@@ -118,8 +118,12 @@ export async function packageLiveContent(config) {
     config.outputDir,
   );
 
-  // Run until interrupted or one child crashes.
-  await Promise.race([ffmpegExited, gpacExited]);
+  try {
+    // Run until interrupted or one child crashes.
+    await Promise.race([ffmpegExited, gpacExited]);
+  } finally {
+    publisher.stop();
+  }
 }
 
 /**
@@ -189,10 +193,11 @@ async function checkIfOutputContainsMediaFiles(outputDir, noConfirm) {
  *
  * @param {PackageConfig} config
  * @param {ReturnType<import("./ports.mjs").buildPortMap>} ports
+ * @param {string} outputDir
  * @returns {string[]}
  */
-function buildGpacArgs(config, ports) {
-  const out = config.outputDir;
+function buildGpacArgs(config, ports, outputDir) {
+  const out = outputDir;
   const inputs = [
     {
       port: ports.p720,
@@ -240,7 +245,8 @@ function buildGpacArgs(config, ports) {
 
   const inputArgs = inputs.flatMap((input) => {
     let source =
-      `udp://127.0.0.1:${input.port}` +
+      // GPAC expects a trailing "/" before filter options on socket URLs.
+      `udp://127.0.0.1:${input.port}/` +
       `:#HLSPL=${input.playlist}` +
       `:#Representation=${input.representation}` +
       `:#Bitrate=${input.bitrate}`;

--- a/scripts/packager/main.mjs
+++ b/scripts/packager/main.mjs
@@ -24,6 +24,7 @@ import {
   DEFAULT_BASE_PORT,
   DEFAULT_MEDIA_FORMAT,
   DEFAULT_SUBTITLE_FORMAT,
+  DEFAULT_PUBLISH_STRATEGY,
 } from "./constants.mjs";
 import { isPositiveInteger, isValidPort, sanitizeDirPath } from "./utils.mjs";
 import { getMaxNbPortsUsed } from "./ports.mjs";
@@ -152,6 +153,16 @@ for (let i = 0; i < args.length; i++) {
       break;
     }
 
+    case "--publish-strategy": {
+      const { value, nextIndex } = requireNextArg(arg, i);
+      if (value !== "atomic" && value !== "direct") {
+        panic('--publish-strategy must be either "atomic" or "direct".');
+      }
+      configObj.publishStrategy = value;
+      i = nextIndex;
+      break;
+    }
+
     case "--low-latency":
       configObj.lowLatency = true;
       break;
@@ -235,6 +246,10 @@ Options:
                                       The current GPAC live path only supports
                                       'none'.
 
+  --publish-strategy <strategy>       How GPAC output is exposed publicly.
+                                      Accepted values: 'atomic', 'direct'.
+                                      Defaults to ${DEFAULT_PUBLISH_STRATEGY}.
+
   --no-confirmation                   Never ask for confirmation; validate all prompts.
                                       Intended for automated scripts.
 
@@ -244,8 +259,6 @@ Options:
                                       Defaults to ${DEFAULT_BASE_PORT} (ports ${DEFAULT_BASE_PORT}-${DEFAULT_BASE_PORT + maxNbPortsUsed - 1}).
 
   --gpac-path <path>                  Path to the gpac binary. If not specified,
-                                      the script will search common locations and,
-                                      as a last resort, try to install it locally
-                                      in \`tmp\` (you will be asked to confirm).
+                                      the script will search common locations.
 `);
 }

--- a/scripts/packager/publisher.mjs
+++ b/scripts/packager/publisher.mjs
@@ -1,0 +1,1434 @@
+// @ts-check
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { createHash } from "crypto";
+import { resolve } from "path";
+
+const WORK_DIR_NAME = ".gpac-workdir";
+const STATUS_FILE_NAME = ".publisher-status.json";
+const MIN_PUBLISHED_FRAGMENT_BYTES = 128;
+
+/**
+ * @param {string} publicOutputDir
+ * @returns {string}
+ */
+export function getGpacWorkDir(publicOutputDir) {
+  return resolve(publicOutputDir, WORK_DIR_NAME);
+}
+
+/**
+ * @param {string} publicOutputDir
+ * @returns {string}
+ */
+export function getPublisherStatusPath(publicOutputDir) {
+  return resolve(publicOutputDir, STATUS_FILE_NAME);
+}
+
+/**
+ * Remove the private GPAC work directory used to build coherent snapshots.
+ * @param {string} publicOutputDir
+ */
+export function cleanupGpacWorkDir(publicOutputDir) {
+  rmSync(getGpacWorkDir(publicOutputDir), {
+    recursive: true,
+    force: true,
+  });
+}
+
+/**
+ * @param {{ sourceDir: string; targetDir: string; intervalMs?: number }} params
+ * @returns {{ stop: () => void }}
+ */
+export function startLiveOutputPublisher({
+  sourceDir,
+  targetDir,
+  intervalMs = 250,
+}) {
+  mkdirSync(sourceDir, { recursive: true });
+  mkdirSync(targetDir, { recursive: true });
+
+  /** @type {Map<string, string>} */
+  const publishedSignatures = new Map();
+  /** @type {Map<string, string>} */
+  const observedBinarySignatures = new Map();
+  /** @type {Map<string, string>} */
+  const observedPublishedTextSignatures = new Map();
+  /** @type {Map<string, string>} */
+  const observedSourceTextSignatures = new Map();
+  /** @type {null | { content: string; size: number; mtimeMs: number; fingerprint: string; parsed: { preambleLines: string[]; variantEntries: Array<{ streamInfLine: string; uri: string }>; audioEntries: Array<{ mediaLine: string; uri: string }>; invalidAudioEntries: Array<{ lineNumber: number; line: string; uri: string }>; trailingLines: string[] } }} */
+  let lastStableMaster = null;
+  let isStopped = false;
+  let isPublishing = false;
+  let cycleCount = 0;
+
+  const writeStatus = (status) => {
+    try {
+      writeFileSync(
+        getPublisherStatusPath(targetDir),
+        JSON.stringify(
+          {
+            mode: "atomic",
+            sourceDir,
+            targetDir,
+            intervalMs,
+            cycleCount,
+            at: new Date().toISOString(),
+            ...status,
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+    } catch {
+      // Ignore publisher diagnostic write failures.
+    }
+  };
+
+  const publishOnce = () => {
+    if (isStopped || isPublishing) {
+      return;
+    }
+    isPublishing = true;
+    cycleCount++;
+    try {
+      const state = collectPublishableState(
+        sourceDir,
+        targetDir,
+        observedSourceTextSignatures,
+        lastStableMaster,
+      );
+      if (
+        state.status === "ready" &&
+        state.masterSource.contentSource === "source"
+      ) {
+        lastStableMaster = {
+          content: state.masterSource.content,
+          size: state.masterSource.size,
+          mtimeMs: state.masterSource.mtimeMs,
+          fingerprint: state.masterSource.fingerprint,
+          parsed: state.masterSource.parsed,
+        };
+      }
+      if (state.status !== "ready") {
+        writeStatus(state);
+        return;
+      }
+
+      /** @type {Set<string>} */
+      const readyAssetPaths = new Set();
+      let publishedAssetCount = 0;
+      for (const asset of state.assets) {
+        if (isAlreadyPublished(asset, targetDir, publishedSignatures)) {
+          readyAssetPaths.add(asset.relativePath);
+          continue;
+        }
+        if (
+          !isBinaryAssetReadyToPublish(
+            asset,
+            publishedSignatures,
+            observedBinarySignatures,
+          )
+        ) {
+          continue;
+        }
+        publishBinaryFileIfChanged(asset, targetDir, publishedSignatures);
+        readyAssetPaths.add(asset.relativePath);
+        publishedAssetCount++;
+      }
+      /** @type {Set<string>} */
+      const readyPlaylistPaths = new Set();
+      let publishedPlaylistCount = 0;
+      for (const playlist of state.playlists) {
+        const publishablePlaylist = buildPlaylistPublicationSnapshot(
+          playlist,
+          targetDir,
+          readyAssetPaths,
+        );
+        if (publishablePlaylist === null) {
+          continue;
+        }
+        if (
+          isTextAlreadyPublished(
+            publishablePlaylist,
+            targetDir,
+            publishedSignatures,
+          )
+        ) {
+          readyPlaylistPaths.add(playlist.relativePath);
+          publishedPlaylistCount++;
+          continue;
+        }
+        if (
+          !isTextFileReadyToPublish(
+            publishablePlaylist,
+            publishedSignatures,
+            observedPublishedTextSignatures,
+          )
+        ) {
+          continue;
+        }
+        publishTextFileIfChanged(
+          publishablePlaylist,
+          targetDir,
+          publishedSignatures,
+        );
+        readyPlaylistPaths.add(playlist.relativePath);
+        publishedPlaylistCount++;
+      }
+      let masterPublished = false;
+      if (
+        state.master !== null &&
+        state.master.requiredPlaylistPaths.every(
+          (playlistPath) =>
+            readyPlaylistPaths.has(playlistPath) ||
+            existsSync(resolve(targetDir, playlistPath)),
+        )
+      ) {
+        if (
+          isTextAlreadyPublished(state.master, targetDir, publishedSignatures)
+        ) {
+          masterPublished = true;
+        } else if (
+          isTextFileReadyToPublish(
+            state.master,
+            publishedSignatures,
+            observedPublishedTextSignatures,
+          )
+        ) {
+          publishTextFileIfChanged(
+            state.master,
+            targetDir,
+            publishedSignatures,
+          );
+          masterPublished = true;
+        }
+      }
+      writeStatus({
+        status: "ready",
+        sourcePlaylistCount: state.sourcePlaylistCount,
+        readyPlaylistCount: state.playlists.length,
+        assetCount: state.assets.length,
+        publishedAssetCount,
+        publishedPlaylistCount,
+        masterReady: state.master !== null,
+        masterPublished,
+        diagnostics: state.diagnostics,
+      });
+    } catch (_err) {
+      // Ignore transient publication failures caused by in-progress GPAC writes.
+      writeStatus({
+        status: "publish-error",
+      });
+    } finally {
+      isPublishing = false;
+    }
+  };
+
+  publishOnce();
+  const timer = setInterval(publishOnce, intervalMs);
+  timer.unref?.();
+
+  return {
+    stop() {
+      isStopped = true;
+      clearInterval(timer);
+      writeStatus({
+        status: "stopped",
+      });
+    },
+  };
+}
+
+/**
+ * Require seeing the same source signature on two consecutive publication
+ * cycles before exposing a binary asset to the public directory. The
+ * fingerprint includes the file bytes so fixed-size in-progress fragments do
+ * not look publishable on Windows.
+ *
+ * @param {{ relativePath: string; sourcePath: string; size: number; mtimeMs: number; content: Buffer; fingerprint: string }} asset
+ * @param {Map<string, string>} publishedSignatures
+ * @param {Map<string, string>} observedBinarySignatures
+ * @returns {boolean}
+ */
+function isBinaryAssetReadyToPublish(
+  asset,
+  publishedSignatures,
+  observedBinarySignatures,
+) {
+  const signature = `${asset.size}:${asset.mtimeMs}:${asset.fingerprint}`;
+  if (publishedSignatures.get(asset.relativePath) === signature) {
+    observedBinarySignatures.set(asset.relativePath, signature);
+    return false;
+  }
+
+  const previousObservedSignature = observedBinarySignatures.get(
+    asset.relativePath,
+  );
+  observedBinarySignatures.set(asset.relativePath, signature);
+  return previousObservedSignature === signature;
+}
+
+/**
+ * @param {{ relativePath: string; sourcePath: string; size: number; mtimeMs: number; content: Buffer; fingerprint: string }} asset
+ * @param {string} targetDir
+ * @param {Map<string, string>} publishedSignatures
+ * @returns {boolean}
+ */
+function isAlreadyPublished(asset, targetDir, publishedSignatures) {
+  const signature = `${asset.size}:${asset.mtimeMs}:${asset.fingerprint}`;
+  return (
+    publishedSignatures.get(asset.relativePath) === signature &&
+    existsSync(resolve(targetDir, asset.relativePath))
+  );
+}
+
+/**
+ * @param {{ relativePath: string; size: number; fingerprint: string }} file
+ * @param {string} targetDir
+ * @param {Map<string, string>} publishedSignatures
+ * @returns {boolean}
+ */
+function isTextAlreadyPublished(file, targetDir, publishedSignatures) {
+  const signature = `${file.size}:${file.fingerprint}`;
+  return (
+    publishedSignatures.get(file.relativePath) === signature &&
+    existsSync(resolve(targetDir, file.relativePath))
+  );
+}
+
+/**
+ * Require seeing the same text bytes on two consecutive publication cycles
+ * before exposing playlists publicly. This mirrors the binary asset rule and
+ * avoids treating a torn GPAC rewrite as a real invalid playlist on slow
+ * Windows runners.
+ *
+ * @param {{ relativePath: string; size: number; mtimeMs: number; fingerprint: string }} file
+ * @param {Map<string, string>} publishedSignatures
+ * @param {Map<string, string>} observedTextSignatures
+ * @returns {boolean}
+ */
+function isTextFileReadyToPublish(
+  file,
+  publishedSignatures,
+  observedTextSignatures,
+) {
+  const signature = `${file.size}:${file.fingerprint}`;
+  if (publishedSignatures.get(file.relativePath) === signature) {
+    observedTextSignatures.set(file.relativePath, signature);
+    return false;
+  }
+
+  const previousObservedSignature = observedTextSignatures.get(
+    file.relativePath,
+  );
+  observedTextSignatures.set(file.relativePath, signature);
+  return previousObservedSignature === signature;
+}
+
+/**
+ * Require seeing the same source text bytes on two consecutive cycles before
+ * treating a playlist as parseable. This filters torn in-place GPAC rewrites
+ * that may otherwise look stable enough under a single before/after stat check.
+ *
+ * @param {{ relativePath: string; size: number; mtimeMs: number; fingerprint: string }} file
+ * @param {Map<string, string>} observedSourceTextSignatures
+ * @returns {boolean}
+ */
+function isSourceTextFileStable(file, observedSourceTextSignatures) {
+  const signature = `${file.size}:${file.fingerprint}`;
+  const previousObservedSignature = observedSourceTextSignatures.get(
+    file.relativePath,
+  );
+  observedSourceTextSignatures.set(file.relativePath, signature);
+  return previousObservedSignature === signature;
+}
+
+/**
+ * @param {string} sourceDir
+ * @param {string} targetDir
+ * @param {Map<string, string>} observedSourceTextSignatures
+ * @param {null | { content: string; size: number; mtimeMs: number; fingerprint: string; parsed: { preambleLines: string[]; variantEntries: Array<{ streamInfLine: string; uri: string }>; audioEntries: Array<{ mediaLine: string; uri: string }>; invalidAudioEntries: Array<{ lineNumber: number; line: string; uri: string }>; trailingLines: string[] } }} lastStableMaster
+ * @returns {
+ * | { status: "missing-master" | "unstable-master" | "invalid-master" | "empty-master"; detail?: unknown }
+ * | {
+ *     status: "ready";
+ *     sourcePlaylistCount: number;
+ *     assets: Array<{ relativePath: string; sourcePath: string; size: number; mtimeMs: number; content: Buffer; fingerprint: string }>;
+ *     playlists: Array<{ relativePath: string; content: string; size: number; mtimeMs: number; fingerprint: string; requiredAssetPaths: string[]; mediaPlaylist: { headerLines: string[]; mapUris: string[]; mediaSequence: number | null; segments: Array<{ extinfLine: string; uri: string }> } }>;
+ *     master: { relativePath: string; content: string; size: number; mtimeMs: number; fingerprint: string; requiredPlaylistPaths: string[] } | null;
+ *     diagnostics: {
+ *       masterSource: { contentSource: "source" | "cached"; fallbackReason: string | null };
+ *       sourceMaster: { variantEntryCount: number; audioEntryCount: number; ignoredInvalidAudioEntryCount: number };
+ *       preparedMaster: null | { variantEntryCount: number; audioEntryCount: number };
+ *       playlists: Array<{ playlistName: string; status: string; detail?: string }>;
+ *     };
+ *     masterSource: { contentSource: "source" | "cached"; fallbackReason: string | null; content: string; size: number; mtimeMs: number; fingerprint: string; parsed: { preambleLines: string[]; variantEntries: Array<{ streamInfLine: string; uri: string }>; audioEntries: Array<{ mediaLine: string; uri: string }>; invalidAudioEntries: Array<{ lineNumber: number; line: string; uri: string }>; trailingLines: string[] } };
+ *   }
+ * | { status: "no-ready-playlists"; sourcePlaylistCount: number }
+ * }
+ */
+function collectPublishableState(
+  sourceDir,
+  targetDir,
+  observedSourceTextSignatures,
+  lastStableMaster,
+) {
+  const masterPath = resolve(sourceDir, "master.m3u8");
+  if (!existsSync(masterPath)) {
+    if (lastStableMaster !== null) {
+      return buildPublishableStateFromMaster({
+        sourceDir,
+        targetDir,
+        observedSourceTextSignatures,
+        masterFile: lastStableMaster,
+        parsedMaster: lastStableMaster.parsed,
+        contentSource: "cached",
+        fallbackReason: "missing-master",
+      });
+    }
+    return {
+      status: "missing-master",
+    };
+  }
+
+  const master = readStableTextFile(masterPath);
+  if (master === null) {
+    if (lastStableMaster !== null) {
+      return buildPublishableStateFromMaster({
+        sourceDir,
+        targetDir,
+        observedSourceTextSignatures,
+        masterFile: lastStableMaster,
+        parsedMaster: lastStableMaster.parsed,
+        contentSource: "cached",
+        fallbackReason: "unstable-master",
+      });
+    }
+    return {
+      status: "unstable-master",
+    };
+  }
+  if (
+    !isSourceTextFileStable(
+      {
+        relativePath: "master.m3u8",
+        size: master.size,
+        mtimeMs: master.mtimeMs,
+        fingerprint: master.fingerprint,
+      },
+      observedSourceTextSignatures,
+    )
+  ) {
+    if (lastStableMaster !== null) {
+      return buildPublishableStateFromMaster({
+        sourceDir,
+        targetDir,
+        observedSourceTextSignatures,
+        masterFile: lastStableMaster,
+        parsedMaster: lastStableMaster.parsed,
+        contentSource: "cached",
+        fallbackReason: "unstable-master",
+      });
+    }
+    return {
+      status: "unstable-master",
+    };
+  }
+
+  const masterPlaylist = parseMasterPlaylist(master.content);
+  if (masterPlaylist.status !== "ready") {
+    if (lastStableMaster !== null) {
+      return buildPublishableStateFromMaster({
+        sourceDir,
+        targetDir,
+        observedSourceTextSignatures,
+        masterFile: lastStableMaster,
+        parsedMaster: lastStableMaster.parsed,
+        contentSource: "cached",
+        fallbackReason: "invalid-master",
+      });
+    }
+    return {
+      status: "invalid-master",
+      detail: {
+        reason: masterPlaylist.reason,
+        lineNumber: masterPlaylist.lineNumber,
+        line: masterPlaylist.line,
+        uri: masterPlaylist.uri,
+        preview: summarizePlaylistText(master.content),
+      },
+    };
+  }
+  return buildPublishableStateFromMaster({
+    sourceDir,
+    targetDir,
+    observedSourceTextSignatures,
+    masterFile: master,
+    parsedMaster: masterPlaylist.value,
+    contentSource: "source",
+    fallbackReason: null,
+  });
+}
+
+/**
+ * @param {{
+ *   sourceDir: string;
+ *   targetDir: string;
+ *   observedSourceTextSignatures: Map<string, string>;
+ *   masterFile: { content: string; size: number; mtimeMs: number; fingerprint: string };
+ *   parsedMaster: { preambleLines: string[]; variantEntries: Array<{ streamInfLine: string; uri: string }>; audioEntries: Array<{ mediaLine: string; uri: string }>; invalidAudioEntries: Array<{ lineNumber: number; line: string; uri: string }>; trailingLines: string[] };
+ *   contentSource: "source" | "cached";
+ *   fallbackReason: string | null;
+ * }} params
+ */
+function buildPublishableStateFromMaster({
+  sourceDir,
+  targetDir,
+  observedSourceTextSignatures,
+  masterFile,
+  parsedMaster,
+  contentSource,
+  fallbackReason,
+}) {
+  const playlistNames = [
+    ...new Set([
+      ...parsedMaster.variantEntries.map((entry) => entry.uri),
+      ...parsedMaster.audioEntries.map((entry) => entry.uri),
+    ]),
+  ];
+  if (playlistNames.length === 0) {
+    return {
+      status: "empty-master",
+    };
+  }
+
+  /** @type {Map<string, { relativePath: string; sourcePath: string; size: number; mtimeMs: number; content: Buffer; fingerprint: string }>} */
+  const assetsByPath = new Map();
+  /** @type {Array<{ relativePath: string; content: string; size: number; mtimeMs: number; fingerprint: string; requiredAssetPaths: string[]; mediaPlaylist: { headerLines: string[]; mapUris: string[]; mediaSequence: number | null; segments: Array<{ extinfLine: string; uri: string }> } }>} */
+  const playlists = [];
+  /** @type {Array<{ playlistName: string; status: string; detail?: string }>} */
+  const playlistDiagnostics = [];
+  let readyPlaylistCount = 0;
+
+  for (const playlistName of playlistNames) {
+    const playlistPath = resolve(sourceDir, playlistName);
+    if (!existsSync(playlistPath)) {
+      playlistDiagnostics.push({
+        playlistName,
+        status: "missing-playlist-file",
+      });
+      continue;
+    }
+    const playlist = readStableTextFile(playlistPath);
+    if (playlist === null) {
+      playlistDiagnostics.push({
+        playlistName,
+        status: "unstable-playlist-file",
+      });
+      continue;
+    }
+    if (
+      !isSourceTextFileStable(
+        {
+          relativePath: playlistName,
+          size: playlist.size,
+          mtimeMs: playlist.mtimeMs,
+          fingerprint: playlist.fingerprint,
+        },
+        observedSourceTextSignatures,
+      )
+    ) {
+      playlistDiagnostics.push({
+        playlistName,
+        status: "unstable-playlist-file",
+      });
+      continue;
+    }
+
+    const preparedPlaylist = prepareMediaPlaylistForPublication({
+      playlistName,
+      playlist,
+      sourceDir,
+      targetDir,
+    });
+    if (preparedPlaylist.status !== "ready") {
+      playlistDiagnostics.push({
+        playlistName,
+        status: preparedPlaylist.status,
+        ...(preparedPlaylist.detail === undefined
+          ? {}
+          : { detail: preparedPlaylist.detail }),
+      });
+      continue;
+    }
+
+    readyPlaylistCount++;
+    playlistDiagnostics.push({
+      playlistName,
+      status: "ready",
+    });
+    for (const asset of preparedPlaylist.assets) {
+      assetsByPath.set(asset.relativePath, asset);
+    }
+    playlists.push({
+      relativePath: playlistName,
+      content: preparedPlaylist.content,
+      size: preparedPlaylist.content.length,
+      mtimeMs: playlist.mtimeMs,
+      fingerprint: playlist.fingerprint,
+      requiredAssetPaths: preparedPlaylist.requiredAssetPaths,
+      mediaPlaylist: preparedPlaylist.mediaPlaylist,
+    });
+  }
+
+  if (readyPlaylistCount === 0) {
+    return {
+      status: "no-ready-playlists",
+      sourcePlaylistCount: playlistNames.length,
+    };
+  }
+
+  const publishedPlaylistPaths = new Set(
+    playlistNames.filter(
+      (playlistName) =>
+        playlists.some((playlist) => playlist.relativePath === playlistName) ||
+        existsSync(resolve(targetDir, playlistName)),
+    ),
+  );
+  const preparedMaster = prepareMasterPlaylistForPublication(
+    parsedMaster,
+    publishedPlaylistPaths,
+  );
+
+  const diagnostics = {
+    masterSource: {
+      contentSource,
+      fallbackReason,
+    },
+    sourceMaster: {
+      variantEntryCount: parsedMaster.variantEntries.length,
+      audioEntryCount: parsedMaster.audioEntries.length,
+      ignoredInvalidAudioEntryCount: parsedMaster.invalidAudioEntries.length,
+    },
+    preparedMaster:
+      preparedMaster === null
+        ? null
+        : {
+            variantEntryCount: preparedMaster.variantEntryCount,
+            audioEntryCount: preparedMaster.audioEntryCount,
+          },
+    playlists: playlistDiagnostics,
+  };
+
+  return {
+    status: "ready",
+    sourcePlaylistCount: playlistNames.length,
+    assets: [...assetsByPath.values()],
+    playlists,
+    masterSource: {
+      contentSource,
+      fallbackReason,
+      content: masterFile.content,
+      size: masterFile.size,
+      mtimeMs: masterFile.mtimeMs,
+      fingerprint: masterFile.fingerprint,
+      parsed: parsedMaster,
+    },
+    master:
+      preparedMaster === null
+        ? null
+        : {
+            relativePath: "master.m3u8",
+            content: preparedMaster.content,
+            size: preparedMaster.content.length,
+            mtimeMs: masterFile.mtimeMs,
+            fingerprint: masterFile.fingerprint,
+            requiredPlaylistPaths: preparedMaster.requiredPlaylistPaths,
+          },
+    diagnostics,
+  };
+}
+
+/**
+ * @param {{ playlistName: string; playlist: { content: string; size: number; mtimeMs: number }; sourceDir: string; targetDir: string }} params
+ * @returns {
+ * | { status: "ready"; content: string; assets: Array<{ relativePath: string; sourcePath: string; size: number; mtimeMs: number; content: Buffer; fingerprint: string }>; requiredAssetPaths: string[]; mediaPlaylist: { headerLines: string[]; mapUris: string[]; mediaSequence: number | null; segments: Array<{ extinfLine: string; uri: string }> } }
+ * | { status: string; detail?: string }
+ * }
+ */
+function prepareMediaPlaylistForPublication({
+  playlistName,
+  playlist,
+  sourceDir,
+  targetDir,
+}) {
+  const mediaPlaylist = parseMediaPlaylist(playlist.content);
+  if (mediaPlaylist === null) {
+    return { status: "invalid-playlist" };
+  }
+
+  /** @type {Map<string, { relativePath: string; sourcePath: string; size: number; mtimeMs: number; content: Buffer; fingerprint: string }>} */
+  const assetsByPath = new Map();
+
+  for (const mapUri of mediaPlaylist.mapUris) {
+    const asset = getPublishableAsset(mapUri, sourceDir, targetDir);
+    if (asset === null) {
+      return {
+        status: "missing-map-asset",
+        detail: mapUri,
+      };
+    }
+    if (asset !== "already-published") {
+      assetsByPath.set(asset.relativePath, asset);
+    }
+  }
+
+  const segmentAvailability = mediaPlaylist.segments.map((segment) => ({
+    ...segment,
+    asset: getPublishableAsset(segment.uri, sourceDir, targetDir),
+  }));
+
+  const firstAvailableIndex = segmentAvailability.findIndex(
+    (segment) => segment.asset !== null,
+  );
+  if (firstAvailableIndex < 0) {
+    const missingSegment = segmentAvailability.find(
+      (segment) => segment.asset === null,
+    );
+    return {
+      status: "no-segment-assets-ready",
+      detail: missingSegment?.uri,
+    };
+  }
+
+  let lastAvailableIndex = -1;
+  for (let i = segmentAvailability.length - 1; i >= firstAvailableIndex; i--) {
+    if (segmentAvailability[i].asset !== null) {
+      lastAvailableIndex = i;
+      break;
+    }
+  }
+  if (lastAvailableIndex < firstAvailableIndex) {
+    return { status: "no-contiguous-segment-window" };
+  }
+
+  for (let i = firstAvailableIndex; i <= lastAvailableIndex; i++) {
+    if (segmentAvailability[i].asset === null) {
+      return {
+        status: "segment-gap-within-window",
+        detail: segmentAvailability[i].uri,
+      };
+    }
+  }
+
+  const retainedSegments = segmentAvailability.slice(
+    firstAvailableIndex,
+    lastAvailableIndex + 1,
+  );
+  for (const segment of retainedSegments) {
+    if (segment.asset !== "already-published") {
+      assetsByPath.set(segment.asset.relativePath, segment.asset);
+    }
+  }
+
+  return {
+    status: "ready",
+    content: stringifyMediaPlaylist(
+      mediaPlaylist,
+      retainedSegments.map(({ extinfLine, uri }) => ({ extinfLine, uri })),
+      firstAvailableIndex,
+      playlistName,
+    ),
+    assets: [...assetsByPath.values()],
+    requiredAssetPaths: [
+      ...mediaPlaylist.mapUris,
+      ...retainedSegments.map((segment) => segment.uri),
+    ],
+    mediaPlaylist,
+  };
+}
+
+/**
+ * Build the media-playlist snapshot that can be exposed publicly in the
+ * current cycle, based only on assets that are already public or are becoming
+ * public in the same publication pass.
+ *
+ * @param {{ relativePath: string; mtimeMs: number; mediaPlaylist: { headerLines: string[]; mapUris: string[]; mediaSequence: number | null; segments: Array<{ extinfLine: string; uri: string }> } }} playlist
+ * @param {string} targetDir
+ * @param {Set<string>} readyAssetPaths
+ * @returns {{ relativePath: string; content: string; size: number; mtimeMs: number; fingerprint: string } | null}
+ */
+export function buildPlaylistPublicationSnapshot(
+  playlist,
+  targetDir,
+  readyAssetPaths,
+) {
+  const isAssetAvailable = (assetPath) =>
+    readyAssetPaths.has(assetPath) || existsSync(resolve(targetDir, assetPath));
+
+  if (!playlist.mediaPlaylist.mapUris.every(isAssetAvailable)) {
+    return null;
+  }
+
+  const firstAvailableIndex = playlist.mediaPlaylist.segments.findIndex(
+    (segment) => isAssetAvailable(segment.uri),
+  );
+  if (firstAvailableIndex < 0) {
+    return null;
+  }
+
+  let lastAvailableIndex = firstAvailableIndex - 1;
+  for (
+    let i = firstAvailableIndex;
+    i < playlist.mediaPlaylist.segments.length;
+    i++
+  ) {
+    if (!isAssetAvailable(playlist.mediaPlaylist.segments[i].uri)) {
+      break;
+    }
+    lastAvailableIndex = i;
+  }
+
+  if (lastAvailableIndex < firstAvailableIndex) {
+    return null;
+  }
+
+  const retainedSegments = playlist.mediaPlaylist.segments.slice(
+    firstAvailableIndex,
+    lastAvailableIndex + 1,
+  );
+  const content = stringifyMediaPlaylist(
+    playlist.mediaPlaylist,
+    retainedSegments,
+    firstAvailableIndex,
+    playlist.relativePath,
+  );
+  return {
+    relativePath: playlist.relativePath,
+    content,
+    size: content.length,
+    mtimeMs: playlist.mtimeMs,
+    fingerprint: createHash("sha1").update(content, "utf8").digest("hex"),
+  };
+}
+
+/**
+ * @param {string} relativePath
+ * @param {string} sourceDir
+ * @param {string} targetDir
+ * @returns {{ relativePath: string; sourcePath: string; size: number; mtimeMs: number; content: Buffer; fingerprint: string } | "already-published" | null}
+ */
+function getPublishableAsset(relativePath, sourceDir, targetDir) {
+  if (existsSync(resolve(targetDir, relativePath))) {
+    return "already-published";
+  }
+
+  const sourcePath = resolve(sourceDir, relativePath);
+  if (!existsSync(sourcePath)) {
+    return null;
+  }
+
+  return readStableBinaryFile(sourcePath, relativePath);
+}
+
+/**
+ * @param {{ relativePath: string; sourcePath: string; size: number; mtimeMs: number; content: Buffer; fingerprint: string }} file
+ * @param {string} targetDir
+ * @param {Map<string, string>} publishedSignatures
+ */
+function publishBinaryFileIfChanged(file, targetDir, publishedSignatures) {
+  const signature = `${file.size}:${file.mtimeMs}:${file.fingerprint}`;
+  if (publishedSignatures.get(file.relativePath) === signature) {
+    return;
+  }
+
+  const targetPath = resolve(targetDir, file.relativePath);
+  const tempPath = `${targetPath}.tmp-publish`;
+  try {
+    writeFileSync(tempPath, file.content);
+    replacePublishedFile(tempPath, targetPath);
+  } catch (error) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Ignore cleanup failures for transient files.
+    }
+    throw error;
+  }
+  publishedSignatures.set(file.relativePath, signature);
+}
+
+/**
+ * @param {{ relativePath: string; content: string; size: number; mtimeMs: number; fingerprint: string }} file
+ * @param {string} targetDir
+ * @param {Map<string, string>} publishedSignatures
+ */
+function publishTextFileIfChanged(file, targetDir, publishedSignatures) {
+  const signature = `${file.size}:${file.fingerprint}`;
+  if (publishedSignatures.get(file.relativePath) === signature) {
+    return;
+  }
+
+  const targetPath = resolve(targetDir, file.relativePath);
+  const tempPath = `${targetPath}.tmp-publish`;
+  writeFileSync(tempPath, file.content, "utf8");
+  replacePublishedFile(tempPath, targetPath);
+  publishedSignatures.set(file.relativePath, signature);
+}
+
+/**
+ * Windows does not replace an existing destination with renameSync, so move the
+ * previous public file out of the way first and restore it if the swap fails.
+ *
+ * @param {string} tempPath
+ * @param {string} targetPath
+ */
+function replacePublishedFile(tempPath, targetPath) {
+  const backupPath = `${targetPath}.bak-publish`;
+  const hadExistingTarget = existsSync(targetPath);
+
+  if (!hadExistingTarget) {
+    renameSync(tempPath, targetPath);
+    return;
+  }
+
+  try {
+    try {
+      unlinkSync(backupPath);
+    } catch {
+      // Ignore missing stale backup files from prior interrupted runs.
+    }
+    renameSync(targetPath, backupPath);
+    renameSync(tempPath, targetPath);
+    unlinkSync(backupPath);
+  } catch (error) {
+    try {
+      if (!existsSync(targetPath) && existsSync(backupPath)) {
+        renameSync(backupPath, targetPath);
+      }
+    } catch {
+      // Ignore restore failures and rethrow the original error.
+    }
+    throw error;
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @returns {{ content: string; size: number; mtimeMs: number; fingerprint: string } | null}
+ */
+function readStableTextFile(filePath) {
+  const initialStats = statSync(filePath);
+  const contentBytes = readFileSync(filePath);
+  const finalStats = statSync(filePath);
+  if (
+    initialStats.size !== finalStats.size ||
+    initialStats.mtimeMs !== finalStats.mtimeMs
+  ) {
+    return null;
+  }
+  const content = contentBytes.toString("utf8");
+  return {
+    content,
+    size: finalStats.size,
+    mtimeMs: finalStats.mtimeMs,
+    fingerprint: createHash("sha1").update(contentBytes).digest("hex"),
+  };
+}
+
+/**
+ * @param {string} filePath
+ * @param {string} relativePath
+ * @returns {{ relativePath: string; sourcePath: string; size: number; mtimeMs: number; content: Buffer; fingerprint: string } | null}
+ */
+function readStableBinaryFile(filePath, relativePath) {
+  const initialStats = statSync(filePath);
+  const content = readFileSync(filePath);
+  const finalStats = statSync(filePath);
+  if (
+    initialStats.size !== finalStats.size ||
+    initialStats.mtimeMs !== finalStats.mtimeMs
+  ) {
+    return null;
+  }
+  if (
+    relativePath.endsWith(".m4s") &&
+    !isStructurallyValidMp4Fragment(content)
+  ) {
+    return null;
+  }
+  return {
+    relativePath,
+    sourcePath: filePath,
+    size: finalStats.size,
+    mtimeMs: finalStats.mtimeMs,
+    content,
+    fingerprint: createHash("sha1").update(content).digest("hex"),
+  };
+}
+
+/**
+ * Reject obviously truncated fMP4 fragments before publishing them.
+ *
+ * @param {Buffer} content
+ * @returns {boolean}
+ */
+function isStructurallyValidMp4Fragment(content) {
+  if (content.length < MIN_PUBLISHED_FRAGMENT_BYTES) {
+    return false;
+  }
+
+  const boxes = parseTopLevelBoxes(content);
+  if (boxes === null) {
+    return false;
+  }
+
+  let moofIndex = -1;
+  let mdatIndex = -1;
+  for (let i = 0; i < boxes.length; i++) {
+    if (boxes[i].type === "moof" && moofIndex === -1) {
+      moofIndex = i;
+    }
+    if (boxes[i].type === "mdat" && mdatIndex === -1) {
+      mdatIndex = i;
+    }
+  }
+  if (moofIndex === -1 || mdatIndex === -1 || moofIndex >= mdatIndex) {
+    return false;
+  }
+
+  const mdat = boxes[mdatIndex];
+  return mdat.size > 8;
+}
+
+/**
+ * @param {Buffer} content
+ * @returns {Array<{ type: string; size: number; start: number; end: number }> | null}
+ */
+function parseTopLevelBoxes(content) {
+  return parseChildBoxes(content, 0);
+}
+
+/**
+ * @param {Buffer} content
+ * @param {number} [baseOffset]
+ * @returns {Array<{ type: string; size: number; start: number; end: number }> | null}
+ */
+function parseChildBoxes(content, baseOffset = 0) {
+  /** @type {Array<{ type: string; size: number; start: number; end: number }>} */
+  const boxes = [];
+  let offset = 0;
+
+  while (offset < content.length) {
+    if (content.length - offset < 8) {
+      return null;
+    }
+
+    const size = content.readUInt32BE(offset);
+    const type = content.toString("ascii", offset + 4, offset + 8);
+    if (size === 0 || size === 1) {
+      return null;
+    }
+
+    const end = offset + size;
+    if (size < 8 || end > content.length) {
+      return null;
+    }
+
+    boxes.push({
+      type,
+      size,
+      start: baseOffset + offset,
+      end: baseOffset + end,
+    });
+    offset = end;
+  }
+
+  return offset === content.length ? boxes : null;
+}
+
+/**
+ * @param {string} playlistText
+ * @returns {string[]}
+ */
+function extractPlaylistReferences(playlistText) {
+  return playlistText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+}
+
+/**
+ * @param {string} playlistText
+ * @returns {string[]}
+ */
+function extractMediaTagUris(playlistText) {
+  return playlistText
+    .split("\n")
+    .map((line) => {
+      const trimmedLine = line.trim();
+      if (!trimmedLine.startsWith("#EXT-X-MEDIA:")) {
+        return null;
+      }
+      const match = /URI="([^"]+)"/.exec(trimmedLine);
+      return match === null ? null : match[1];
+    })
+    .filter((uri) => uri !== null);
+}
+
+/**
+ * Keep master/media playlist URIs on a narrow path-based subset so corrupted
+ * text or binary garbage is rejected instead of being treated as a filename.
+ *
+ * @param {string} uri
+ * @returns {boolean}
+ */
+function isValidRelativePlaylistUri(uri) {
+  if (uri.length === 0 || uri.includes("\0")) {
+    return false;
+  }
+  if (uri.includes("\uFFFD") || /[\x00-\x1f\x7f]/.test(uri)) {
+    return false;
+  }
+  if (/^[a-z]+:/i.test(uri) || uri.startsWith("/") || uri.startsWith("\\")) {
+    return false;
+  }
+  return /^[A-Za-z0-9._/-]+\.m3u8$/u.test(uri);
+}
+
+/**
+ * @param {string} playlistText
+ * @returns {{ headerLines: string[]; mapUris: string[]; mediaSequence: number | null; segments: Array<{ extinfLine: string; uri: string }> } | null}
+ */
+function parseMediaPlaylist(playlistText) {
+  /** @type {string[]} */
+  const headerLines = [];
+  const mapUris = [];
+  /** @type {Array<{ extinfLine: string; uri: string }>} */
+  const segments = [];
+  /** @type {string | null} */
+  let pendingExtinf = null;
+  /** @type {number | null} */
+  let mediaSequence = null;
+
+  const lines = playlistText.split("\n");
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+    if (trimmedLine.length === 0 && pendingExtinf !== null) {
+      return null;
+    }
+    if (trimmedLine.length === 0 && pendingExtinf === null) {
+      headerLines.push(trimmedLine);
+      continue;
+    }
+    if (trimmedLine.startsWith("#EXTINF:")) {
+      if (pendingExtinf !== null) {
+        return null;
+      }
+      pendingExtinf = trimmedLine;
+      continue;
+    }
+    if (trimmedLine.startsWith("#EXT-X-MAP:")) {
+      const match = /^#EXT-X-MAP:URI="([^"]+)"/.exec(trimmedLine);
+      if (match === null) {
+        return null;
+      }
+      headerLines.push(trimmedLine);
+      mapUris.push(match[1]);
+      continue;
+    }
+    if (trimmedLine.startsWith("#EXT-X-MEDIA-SEQUENCE:")) {
+      const value = Number(trimmedLine.slice("#EXT-X-MEDIA-SEQUENCE:".length));
+      if (!Number.isInteger(value) || value < 0) {
+        return null;
+      }
+      mediaSequence = value;
+      headerLines.push(trimmedLine);
+      continue;
+    }
+    if (trimmedLine.startsWith("#")) {
+      if (pendingExtinf !== null) {
+        return null;
+      }
+      headerLines.push(trimmedLine);
+      continue;
+    }
+    if (pendingExtinf === null) {
+      return null;
+    }
+    segments.push({
+      extinfLine: pendingExtinf,
+      uri: trimmedLine,
+    });
+    pendingExtinf = null;
+  }
+
+  if (pendingExtinf !== null) {
+    return null;
+  }
+  if (segments.length === 0) {
+    return null;
+  }
+
+  return { headerLines, mapUris, mediaSequence, segments };
+}
+
+/**
+ * @param {{ headerLines: string[]; mapUris: string[]; mediaSequence: number | null; segments: Array<{ extinfLine: string; uri: string }> }} mediaPlaylist
+ * @param {Array<{ extinfLine: string; uri: string }>} segments
+ * @param {number} droppedSegmentCount
+ * @param {string} playlistName
+ * @returns {string}
+ */
+function stringifyMediaPlaylist(
+  mediaPlaylist,
+  segments,
+  droppedSegmentCount,
+  playlistName,
+) {
+  const nextMediaSequence =
+    mediaPlaylist.mediaSequence === null
+      ? null
+      : mediaPlaylist.mediaSequence + droppedSegmentCount;
+  const hasMediaSequence = mediaPlaylist.headerLines.some((line) =>
+    line.startsWith("#EXT-X-MEDIA-SEQUENCE:"),
+  );
+
+  const headerLines = mediaPlaylist.headerLines.map((line) =>
+    line.startsWith("#EXT-X-MEDIA-SEQUENCE:")
+      ? `#EXT-X-MEDIA-SEQUENCE:${nextMediaSequence ?? 0}`
+      : line,
+  );
+
+  if (!hasMediaSequence && droppedSegmentCount > 0) {
+    const insertIndex = Math.min(1, headerLines.length);
+    headerLines.splice(
+      insertIndex,
+      0,
+      `#EXT-X-MEDIA-SEQUENCE:${droppedSegmentCount}`,
+    );
+  }
+
+  const lines = [
+    ...headerLines.filter(
+      (line, index, array) => !(line === "" && index === array.length - 1),
+    ),
+    ...segments.flatMap((segment) => [segment.extinfLine, segment.uri]),
+  ];
+  if (lines.length === 0) {
+    throw new Error(`Cannot publish empty media playlist: ${playlistName}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * @param {string} playlistText
+ * @returns {
+ * | { status: "invalid"; reason: string; lineNumber: number | null; line: string | null; uri?: string }
+ * | {
+ *     status: "ready";
+ *     value: {
+ *       preambleLines: string[];
+ *       variantEntries: Array<{ streamInfLine: string; uri: string }>;
+ *       audioEntries: Array<{ mediaLine: string; uri: string }>;
+ *       invalidAudioEntries: Array<{ lineNumber: number; line: string; uri: string }>;
+ *       trailingLines: string[];
+ *     };
+ *   }
+ * }
+ */
+function parseMasterPlaylist(playlistText) {
+  const preambleLines = [];
+  const variantEntries = [];
+  const audioEntries = [];
+  const invalidAudioEntries = [];
+  const trailingLines = [];
+  let pendingStreamInfLine = null;
+  let seenEntry = false;
+
+  const lines = playlistText.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNumber = i + 1;
+    const trimmedLine = line.trim();
+    if (trimmedLine.length === 0 && pendingStreamInfLine !== null) {
+      return {
+        status: "invalid",
+        reason: "blank-after-stream-inf",
+        lineNumber,
+        line,
+      };
+    }
+    if (trimmedLine.length === 0) {
+      if (!seenEntry) {
+        preambleLines.push(line);
+      } else {
+        trailingLines.push(line);
+      }
+      continue;
+    }
+
+    if (trimmedLine.startsWith("#EXT-X-STREAM-INF:")) {
+      if (pendingStreamInfLine !== null) {
+        return {
+          status: "invalid",
+          reason: "nested-stream-inf",
+          lineNumber,
+          line,
+        };
+      }
+      pendingStreamInfLine = line;
+      seenEntry = true;
+      continue;
+    }
+
+    if (pendingStreamInfLine !== null) {
+      if (trimmedLine.startsWith("#")) {
+        return {
+          status: "invalid",
+          reason: "tag-where-uri-expected",
+          lineNumber,
+          line,
+        };
+      }
+      if (!isValidRelativePlaylistUri(trimmedLine)) {
+        return {
+          status: "invalid",
+          reason: "invalid-variant-uri",
+          lineNumber,
+          line,
+          uri: trimmedLine,
+        };
+      }
+      variantEntries.push({
+        streamInfLine: pendingStreamInfLine,
+        uri: trimmedLine,
+      });
+      pendingStreamInfLine = null;
+      continue;
+    }
+
+    if (trimmedLine.startsWith("#EXT-X-MEDIA:")) {
+      const match = /URI="([^"]+)"/.exec(trimmedLine);
+      if (match !== null) {
+        seenEntry = true;
+        if (!isValidRelativePlaylistUri(match[1])) {
+          invalidAudioEntries.push({
+            lineNumber,
+            line,
+            uri: match[1],
+          });
+          continue;
+        }
+        audioEntries.push({
+          mediaLine: line,
+          uri: match[1],
+        });
+        continue;
+      }
+    }
+
+    if (!seenEntry) {
+      preambleLines.push(line);
+    } else {
+      trailingLines.push(line);
+    }
+  }
+
+  if (pendingStreamInfLine !== null) {
+    return {
+      status: "invalid",
+      reason: "dangling-stream-inf-at-eof",
+      lineNumber: lines.length,
+      line: lines[lines.length - 1] ?? "",
+    };
+  }
+  if (variantEntries.length === 0) {
+    return {
+      status: "invalid",
+      reason: "no-variant-entries",
+      lineNumber: null,
+      line: null,
+    };
+  }
+  if (audioEntries.length === 0 && invalidAudioEntries.length > 0) {
+    return {
+      status: "invalid",
+      reason: "invalid-media-uri",
+      lineNumber: invalidAudioEntries[0].lineNumber,
+      line: invalidAudioEntries[0].line,
+      uri: invalidAudioEntries[0].uri,
+    };
+  }
+
+  return {
+    status: "ready",
+    value: {
+      preambleLines,
+      variantEntries,
+      audioEntries,
+      invalidAudioEntries,
+      trailingLines,
+    },
+  };
+}
+
+/**
+ * @param {string} playlistText
+ * @returns {{ lineCount: number; firstLines: string[] }}
+ */
+function summarizePlaylistText(playlistText) {
+  const lines = playlistText.split(/\r?\n/).map((line) => line.trimEnd());
+  return {
+    lineCount: lines.length,
+    firstLines: lines.filter((line) => line.length > 0).slice(0, 12),
+  };
+}
+
+/**
+ * @param {{ preambleLines: string[]; variantEntries: Array<{ streamInfLine: string; uri: string }>; audioEntries: Array<{ mediaLine: string; uri: string }>; trailingLines: string[] }} masterPlaylist
+ * @param {Set<string>} publishedPlaylistPaths
+ * @returns {{ content: string; requiredPlaylistPaths: string[]; variantEntryCount: number; audioEntryCount: number } | null}
+ */
+function prepareMasterPlaylistForPublication(
+  masterPlaylist,
+  publishedPlaylistPaths,
+) {
+  const variantEntries = masterPlaylist.variantEntries.filter((entry) =>
+    publishedPlaylistPaths.has(entry.uri),
+  );
+  const audioEntries = masterPlaylist.audioEntries.filter((entry) =>
+    publishedPlaylistPaths.has(entry.uri),
+  );
+
+  if (variantEntries.length === 0) {
+    return null;
+  }
+
+  const lines = [
+    ...masterPlaylist.preambleLines,
+    ...variantEntries.flatMap((entry) => [entry.streamInfLine, entry.uri]),
+    ...audioEntries.map((entry) => entry.mediaLine),
+    ...masterPlaylist.trailingLines,
+  ];
+
+  return {
+    content: `${lines.join("\n")}\n`,
+    requiredPlaylistPaths: [
+      ...variantEntries.map((entry) => entry.uri),
+      ...audioEntries.map((entry) => entry.uri),
+    ],
+    variantEntryCount: variantEntries.length,
+    audioEntryCount: audioEntries.length,
+  };
+}

--- a/scripts/packager/publisher.test.mjs
+++ b/scripts/packager/publisher.test.mjs
@@ -1,0 +1,1034 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  buildPlaylistPublicationSnapshot,
+  getPublisherStatusPath,
+  startLiveOutputPublisher,
+} from "../../scripts/packager/publisher.mjs";
+
+function writeTextFile(rootDir, relativePath, content) {
+  mkdirSync(rootDir, { recursive: true });
+  writeFileSync(join(rootDir, relativePath), content, "utf8");
+}
+
+function writeBinaryFile(rootDir, relativePath, content) {
+  mkdirSync(rootDir, { recursive: true });
+  writeFileSync(join(rootDir, relativePath), content);
+}
+
+function makeBox(type, payload = Buffer.alloc(0)) {
+  const header = Buffer.alloc(8);
+  header.writeUInt32BE(payload.length + 8, 0);
+  header.write(type, 4, 4, "ascii");
+  return Buffer.concat([header, payload]);
+}
+
+function makeMediaSegment(payloadText) {
+  const payload = Buffer.alloc(256, 0);
+  payload.write(payloadText, 0, "utf8");
+  const moof = makeBox(
+    "moof",
+    Buffer.concat([
+      makeBox("mfhd", Buffer.alloc(4)),
+      makeBox(
+        "traf",
+        Buffer.concat([
+          makeBox("tfhd", Buffer.alloc(8)),
+          makeBox("tfdt", Buffer.alloc(8)),
+          makeBox("trun", Buffer.alloc(8)),
+        ]),
+      ),
+    ]),
+  );
+  return Buffer.concat([
+    makeBox("styp", Buffer.from("msdh")),
+    moof,
+    makeBox("mdat", payload),
+  ]);
+}
+
+async function waitFor(assertion, timeoutMs = 2000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      assertion();
+      return;
+    } catch (_err) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+  assertion();
+}
+
+function buildMasterPlaylist() {
+  return `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="English",DEFAULT=YES,AUTOSELECT=YES,URI="audio_eng.m3u8"
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="French",DEFAULT=NO,AUTOSELECT=YES,URI="audio_fra.m3u8"
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="Armenian",DEFAULT=NO,AUTOSELECT=YES,URI="audio_arm.m3u8"
+#EXT-X-STREAM-INF:BANDWIDTH=2500000,CODECS="avc1.64001f,mp4a.40.2",AUDIO="audio"
+h264_720p.m3u8
+`;
+}
+
+function buildMediaPlaylist(
+  segmentNames,
+  mediaSequence = 0,
+  initSegment = null,
+) {
+  const lines = [
+    "#EXTM3U",
+    "#EXT-X-VERSION:7",
+    "#EXT-X-TARGETDURATION:2",
+    `#EXT-X-MEDIA-SEQUENCE:${mediaSequence}`,
+  ];
+  if (initSegment !== null) {
+    lines.push(`#EXT-X-MAP:URI="${initSegment}"`);
+  }
+  for (const segmentName of segmentNames) {
+    lines.push("#EXTINF:2.0,");
+    lines.push(segmentName);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+test("publisher waits until referenced segments exist before exposing master", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  let publisher;
+
+  try {
+    writeTextFile(sourceDir, "master.m3u8", buildMasterPlaylist());
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeTextFile(
+      sourceDir,
+      "audio_eng.m3u8",
+      buildMediaPlaylist(["audio-1.m4s"], 0, "audio-init.mp4"),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(
+      existsSync(join(targetDir, "master.m3u8")),
+      false,
+      "master should stay hidden until every referenced file is publishable",
+    );
+
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(
+      sourceDir,
+      "video-1.m4s",
+      makeMediaSegment("video-segment"),
+    );
+    writeBinaryFile(sourceDir, "audio-init.mp4", Buffer.from("audio-init"));
+    writeBinaryFile(
+      sourceDir,
+      "audio-1.m4s",
+      makeMediaSegment("audio-segment"),
+    );
+
+    publisher = startLiveOutputPublisher({
+      sourceDir,
+      targetDir,
+      intervalMs: 50,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(
+      existsSync(join(targetDir, "master.m3u8")),
+      false,
+      "master should stay hidden until binary assets are seen stable twice",
+    );
+
+    await waitFor(() => {
+      assert.equal(existsSync(join(targetDir, "master.m3u8")), true);
+      assert.equal(existsSync(join(targetDir, "h264_720p.m3u8")), true);
+      assert.equal(existsSync(join(targetDir, "audio_eng.m3u8")), true);
+    });
+  } finally {
+    publisher?.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher trims unavailable old segments from the public playlist", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  const publisher = startLiveOutputPublisher({
+    sourceDir,
+    targetDir,
+    intervalMs: 20,
+  });
+
+  try {
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(sourceDir, "video-3.m4s", makeMediaSegment("video-3"));
+    writeBinaryFile(sourceDir, "video-4.m4s", makeMediaSegment("video-4"));
+    writeBinaryFile(sourceDir, "audio-init.mp4", Buffer.from("audio-init"));
+    writeBinaryFile(sourceDir, "audio-3.m4s", makeMediaSegment("audio-3"));
+    writeBinaryFile(sourceDir, "audio-4.m4s", makeMediaSegment("audio-4"));
+    writeTextFile(sourceDir, "master.m3u8", buildMasterPlaylist());
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(
+        ["video-1.m4s", "video-2.m4s", "video-3.m4s", "video-4.m4s"],
+        10,
+        "video-init.mp4",
+      ),
+    );
+    writeTextFile(
+      sourceDir,
+      "audio_eng.m3u8",
+      buildMediaPlaylist(
+        ["audio-1.m4s", "audio-2.m4s", "audio-3.m4s", "audio-4.m4s"],
+        20,
+        "audio-init.mp4",
+      ),
+    );
+
+    await waitFor(() => {
+      const videoPlaylist = readFileSync(
+        join(targetDir, "h264_720p.m3u8"),
+        "utf8",
+      );
+      const audioPlaylist = readFileSync(
+        join(targetDir, "audio_eng.m3u8"),
+        "utf8",
+      );
+      assert.match(videoPlaylist, /#EXT-X-MEDIA-SEQUENCE:12/);
+      assert.doesNotMatch(videoPlaylist, /video-1\.m4s/);
+      assert.doesNotMatch(videoPlaylist, /video-2\.m4s/);
+      assert.match(videoPlaylist, /video-3\.m4s/);
+      assert.match(videoPlaylist, /video-4\.m4s/);
+      assert.match(audioPlaylist, /#EXT-X-MEDIA-SEQUENCE:22/);
+      assert.doesNotMatch(audioPlaylist, /audio-1\.m4s/);
+      assert.doesNotMatch(audioPlaylist, /audio-2\.m4s/);
+      assert.match(audioPlaylist, /audio-3\.m4s/);
+      assert.match(audioPlaylist, /audio-4\.m4s/);
+      assert.equal(existsSync(join(targetDir, "master.m3u8")), true);
+    });
+  } finally {
+    publisher.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("playlist publication snapshot trims the window to public-or-ready assets", () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const targetDir = join(tmpRoot, "target");
+
+  try {
+    writeBinaryFile(targetDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(targetDir, "video-1.m4s", makeMediaSegment("video-1"));
+
+    const snapshot = buildPlaylistPublicationSnapshot(
+      {
+        relativePath: "h264_720p.m3u8",
+        mtimeMs: Date.now(),
+        mediaPlaylist: {
+          headerLines: [
+            "#EXTM3U",
+            "#EXT-X-VERSION:7",
+            "#EXT-X-TARGETDURATION:2",
+            "#EXT-X-MEDIA-SEQUENCE:10",
+            '#EXT-X-MAP:URI="video-init.mp4"',
+          ],
+          mapUris: ["video-init.mp4"],
+          mediaSequence: 10,
+          segments: [
+            { extinfLine: "#EXTINF:2.0,", uri: "video-1.m4s" },
+            { extinfLine: "#EXTINF:2.0,", uri: "video-2.m4s" },
+            { extinfLine: "#EXTINF:2.0,", uri: "video-3.m4s" },
+          ],
+        },
+      },
+      targetDir,
+      new Set(["video-2.m4s"]),
+    );
+
+    assert.ok(snapshot !== null);
+    assert.match(snapshot.content, /video-1\.m4s/);
+    assert.match(snapshot.content, /video-2\.m4s/);
+    assert.doesNotMatch(snapshot.content, /video-3\.m4s/);
+    assert.match(snapshot.content, /#EXT-X-MEDIA-SEQUENCE:10/);
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher filters master entries that never become publishable", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  const publisher = startLiveOutputPublisher({
+    sourceDir,
+    targetDir,
+    intervalMs: 20,
+  });
+
+  try {
+    writeTextFile(sourceDir, "master.m3u8", buildMasterPlaylist());
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeTextFile(
+      sourceDir,
+      "audio_eng.m3u8",
+      buildMediaPlaylist(["audio-eng-1.m4s"], 0, "audio-eng-init.mp4"),
+    );
+    writeTextFile(
+      sourceDir,
+      "audio_fra.m3u8",
+      buildMediaPlaylist(["audio-fra-1.m4s"], 0, "audio-fra-init.mp4"),
+    );
+
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(
+      sourceDir,
+      "video-1.m4s",
+      makeMediaSegment("video-segment"),
+    );
+    writeBinaryFile(
+      sourceDir,
+      "audio-eng-init.mp4",
+      Buffer.from("audio-eng-init"),
+    );
+    writeBinaryFile(
+      sourceDir,
+      "audio-eng-1.m4s",
+      makeMediaSegment("audio-eng-segment"),
+    );
+    writeBinaryFile(
+      sourceDir,
+      "audio-fra-init.mp4",
+      Buffer.from("audio-fra-init"),
+    );
+    writeBinaryFile(
+      sourceDir,
+      "audio-fra-1.m4s",
+      makeMediaSegment("audio-fra-segment"),
+    );
+
+    await waitFor(() => {
+      const masterPlaylist = readFileSync(
+        join(targetDir, "master.m3u8"),
+        "utf8",
+      );
+      assert.match(masterPlaylist, /audio_eng\.m3u8/);
+      assert.match(masterPlaylist, /audio_fra\.m3u8/);
+      assert.doesNotMatch(masterPlaylist, /audio_arm\.m3u8/);
+    });
+  } finally {
+    publisher.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher status explains why referenced audio playlists are excluded", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  const publisher = startLiveOutputPublisher({
+    sourceDir,
+    targetDir,
+    intervalMs: 20,
+  });
+
+  try {
+    writeTextFile(sourceDir, "master.m3u8", buildMasterPlaylist());
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeTextFile(
+      sourceDir,
+      "audio_eng.m3u8",
+      buildMediaPlaylist(["audio-1.m4s"], 0, "audio-init.mp4"),
+    );
+
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(
+      sourceDir,
+      "video-1.m4s",
+      makeMediaSegment("video-segment"),
+    );
+
+    await waitFor(() => {
+      const status = JSON.parse(
+        readFileSync(getPublisherStatusPath(targetDir), "utf8"),
+      );
+      assert.equal(status.status, "ready");
+      assert.deepEqual(status.diagnostics.sourceMaster, {
+        variantEntryCount: 1,
+        audioEntryCount: 3,
+        ignoredInvalidAudioEntryCount: 0,
+      });
+      assert.deepEqual(status.diagnostics.preparedMaster, {
+        variantEntryCount: 1,
+        audioEntryCount: 0,
+      });
+      assert.match(
+        JSON.stringify(status.diagnostics.playlists),
+        /"playlistName":"audio_eng\.m3u8","status":"missing-map-asset","detail":"audio-init\.mp4"/,
+      );
+      assert.match(
+        JSON.stringify(status.diagnostics.playlists),
+        /"playlistName":"audio_fra\.m3u8","status":"missing-playlist-file"/,
+      );
+      assert.match(
+        JSON.stringify(status.diagnostics.playlists),
+        /"playlistName":"audio_arm\.m3u8","status":"missing-playlist-file"/,
+      );
+    });
+  } finally {
+    publisher.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher ignores media playlists with a blank URI after EXTINF", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  const publisher = startLiveOutputPublisher({
+    sourceDir,
+    targetDir,
+    intervalMs: 20,
+  });
+
+  try {
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-STREAM-INF:BANDWIDTH=2500000
+h264_720p.m3u8
+`,
+    );
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:2
+#EXT-X-MAP:URI="video-init.mp4"
+#EXTINF:2.0,
+
+video-1.m4s
+`,
+    );
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("video-1"));
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    assert.equal(
+      existsSync(join(targetDir, "h264_720p.m3u8")),
+      false,
+      "playlist with a blank media URI should never be published",
+    );
+    assert.equal(
+      existsSync(join(targetDir, "master.m3u8")),
+      false,
+      "master should stay hidden when its child media playlist is incomplete",
+    );
+  } finally {
+    publisher.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher ignores master playlists with a blank URI after EXT-X-STREAM-INF", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  const publisher = startLiveOutputPublisher({
+    sourceDir,
+    targetDir,
+    intervalMs: 20,
+  });
+
+  try {
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-STREAM-INF:BANDWIDTH=2500000
+
+h264_720p.m3u8
+`,
+    );
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("video-1"));
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    assert.equal(
+      existsSync(join(targetDir, "master.m3u8")),
+      false,
+      "master with a blank variant URI should not be published",
+    );
+  } finally {
+    publisher.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher ignores master playlists with a corrupted audio URI", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  const publisher = startLiveOutputPublisher({
+    sourceDir,
+    targetDir,
+    intervalMs: 20,
+  });
+
+  try {
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="Broken",DEFAULT=NO,AUTOSELECT=YES,URI="0���>\u0002"
+#EXT-X-STREAM-INF:BANDWIDTH=2500000,AUDIO="audio"
+h264_720p.m3u8
+`,
+    );
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("video-1"));
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    assert.equal(
+      existsSync(join(targetDir, "master.m3u8")),
+      false,
+      "master with a corrupted audio URI should not be published",
+    );
+
+    const status = JSON.parse(
+      readFileSync(getPublisherStatusPath(targetDir), "utf8"),
+    );
+    assert.equal(status.status, "invalid-master");
+    assert.equal(status.detail.reason, "invalid-media-uri");
+  } finally {
+    publisher.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher publishes valid audio renditions even if another audio URI is corrupted", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  const publisher = startLiveOutputPublisher({
+    sourceDir,
+    targetDir,
+    intervalMs: 20,
+  });
+
+  try {
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="Broken",DEFAULT=NO,AUTOSELECT=YES,URI="0���>\u0002"
+#EXT-X-STREAM-INF:BANDWIDTH=2500000,AUDIO="audio"
+h264_720p.m3u8
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="English",DEFAULT=YES,AUTOSELECT=YES,URI="audio_eng.m3u8"
+`,
+    );
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeTextFile(
+      sourceDir,
+      "audio_eng.m3u8",
+      buildMediaPlaylist(["audio-1.m4s"], 0, "audio-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(sourceDir, "audio-init.mp4", Buffer.from("audio-init"));
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("video-1"));
+    writeBinaryFile(sourceDir, "audio-1.m4s", makeMediaSegment("audio-1"));
+
+    await waitFor(() => {
+      assert.equal(existsSync(join(targetDir, "master.m3u8")), true);
+      assert.equal(existsSync(join(targetDir, "audio_eng.m3u8")), true);
+    });
+
+    const master = readFileSync(join(targetDir, "master.m3u8"), "utf8");
+    assert.match(master, /audio_eng\.m3u8/);
+    assert.doesNotMatch(master, /0���>\u0002/);
+
+    const status = JSON.parse(
+      readFileSync(getPublisherStatusPath(targetDir), "utf8"),
+    );
+    assert.equal(status.status, "ready");
+    assert.equal(
+      status.diagnostics.sourceMaster.ignoredInvalidAudioEntryCount,
+      1,
+    );
+  } finally {
+    publisher.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher waits for identical binary bytes across cycles before publishing", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  let publisher;
+
+  try {
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-STREAM-INF:BANDWIDTH=2500000
+h264_720p.m3u8
+`,
+    );
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("aaaaaa"));
+
+    publisher = startLiveOutputPublisher({
+      sourceDir,
+      targetDir,
+      intervalMs: 50,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("bbbbbb"));
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.equal(
+      existsSync(join(targetDir, "video-1.m4s")),
+      false,
+      "segment bytes changed across cycles and should not have been published yet",
+    );
+
+    await waitFor(() => {
+      assert.equal(existsSync(join(targetDir, "video-1.m4s")), true);
+      assert.deepEqual(
+        readFileSync(join(targetDir, "video-1.m4s")),
+        makeMediaSegment("bbbbbb"),
+      );
+    });
+  } finally {
+    publisher?.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher waits for identical source text bytes before accepting a rewritten master", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  let publisher;
+
+  try {
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="Broken",DEFAULT=NO,AUTOSELECT=YES,URI="0���>\u0002"
+#EXT-X-STREAM-INF:BANDWIDTH=2500000,AUDIO="audio"
+h264_720p.m3u8
+`,
+    );
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeTextFile(
+      sourceDir,
+      "audio_eng.m3u8",
+      buildMediaPlaylist(["audio-1.m4s"], 0, "audio-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(sourceDir, "audio-init.mp4", Buffer.from("audio-init"));
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("video-1"));
+    writeBinaryFile(sourceDir, "audio-1.m4s", makeMediaSegment("audio-1"));
+
+    publisher = startLiveOutputPublisher({
+      sourceDir,
+      targetDir,
+      intervalMs: 50,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="English",DEFAULT=YES,AUTOSELECT=YES,URI="audio_eng.m3u8"
+#EXT-X-STREAM-INF:BANDWIDTH=2500000,AUDIO="audio"
+h264_720p.m3u8
+`,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 70));
+    assert.equal(
+      existsSync(join(targetDir, "master.m3u8")),
+      false,
+      "rewritten source master should stay hidden until its bytes repeat",
+    );
+
+    await waitFor(() => {
+      const master = readFileSync(join(targetDir, "master.m3u8"), "utf8");
+      assert.match(master, /audio_eng\.m3u8/);
+      assert.doesNotMatch(master, /0���>\u0002/);
+    });
+
+    const status = JSON.parse(
+      readFileSync(getPublisherStatusPath(targetDir), "utf8"),
+    );
+    assert.equal(status.status, "ready");
+  } finally {
+    publisher?.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher keeps using the last stable master while a torn rewrite is invalid", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  let publisher;
+
+  try {
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="English",DEFAULT=YES,AUTOSELECT=YES,URI="audio_eng.m3u8"
+#EXT-X-STREAM-INF:BANDWIDTH=2500000,AUDIO="audio"
+h264_720p.m3u8
+`,
+    );
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeTextFile(
+      sourceDir,
+      "audio_eng.m3u8",
+      buildMediaPlaylist(["audio-1.m4s"], 0, "audio-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(sourceDir, "audio-init.mp4", Buffer.from("audio-init"));
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("video-1"));
+    writeBinaryFile(sourceDir, "audio-1.m4s", makeMediaSegment("audio-1"));
+
+    publisher = startLiveOutputPublisher({
+      sourceDir,
+      targetDir,
+      intervalMs: 50,
+    });
+
+    await waitFor(() => {
+      const status = JSON.parse(
+        readFileSync(getPublisherStatusPath(targetDir), "utf8"),
+      );
+      assert.equal(status.status, "ready");
+      assert.equal(existsSync(join(targetDir, "master.m3u8")), true);
+      assert.deepEqual(status.diagnostics.masterSource, {
+        contentSource: "source",
+        fallbackReason: null,
+      });
+    });
+
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="English",DEFAULT=YES,AUTOSELECT=YES,URI=""
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="French",DEFAULT=NO,AUTOSELECT=YES,URI=""
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="Armenian",DEFAULT=NO,AUTOSELECT=YES,URI="0���>\u0002"
+#EXT-X-STREAM-INF:BANDWIDTH=2500000,AUDIO="audio"
+h264_720p.m3u8
+`,
+    );
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s", "video-2.m4s"], 0, "video-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-2.m4s", makeMediaSegment("video-2"));
+
+    await waitFor(() => {
+      const status = JSON.parse(
+        readFileSync(getPublisherStatusPath(targetDir), "utf8"),
+      );
+      assert.equal(status.status, "ready");
+      assert.deepEqual(status.diagnostics.masterSource, {
+        contentSource: "cached",
+        fallbackReason: "invalid-master",
+      });
+      const master = readFileSync(join(targetDir, "master.m3u8"), "utf8");
+      assert.match(master, /audio_eng\.m3u8/);
+      assert.doesNotMatch(master, /URI=""/);
+      assert.equal(existsSync(join(targetDir, "video-2.m4s")), true);
+    });
+  } finally {
+    publisher?.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher ignores mtime-only rewrites when text bytes stay identical", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  const publisher = startLiveOutputPublisher({
+    sourceDir,
+    targetDir,
+    intervalMs: 50,
+  });
+
+  try {
+    const master = `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="English",DEFAULT=YES,AUTOSELECT=YES,URI="audio_eng.m3u8"
+#EXT-X-STREAM-INF:BANDWIDTH=2500000,AUDIO="audio"
+h264_720p.m3u8
+`;
+    writeTextFile(sourceDir, "master.m3u8", master);
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeTextFile(
+      sourceDir,
+      "audio_eng.m3u8",
+      buildMediaPlaylist(["audio-1.m4s"], 0, "audio-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(sourceDir, "audio-init.mp4", Buffer.from("audio-init"));
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("video-1"));
+    writeBinaryFile(sourceDir, "audio-1.m4s", makeMediaSegment("audio-1"));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    writeTextFile(sourceDir, "master.m3u8", master);
+
+    await waitFor(() => {
+      assert.equal(existsSync(join(targetDir, "master.m3u8")), true);
+    });
+  } finally {
+    publisher.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher ignores truncated mp4 fragments", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  const publisher = startLiveOutputPublisher({
+    sourceDir,
+    targetDir,
+    intervalMs: 20,
+  });
+
+  try {
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-STREAM-INF:BANDWIDTH=2500000
+h264_720p.m3u8
+`,
+    );
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(
+      sourceDir,
+      "video-1.m4s",
+      Buffer.concat([makeBox("moof", Buffer.from("traf")), Buffer.from("bad")]),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    assert.equal(
+      existsSync(join(targetDir, "video-1.m4s")),
+      false,
+      "truncated fragment should not be published",
+    );
+
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("video-1"));
+
+    await waitFor(() => {
+      assert.equal(existsSync(join(targetDir, "video-1.m4s")), true);
+      assert.equal(existsSync(join(targetDir, "h264_720p.m3u8")), true);
+      assert.equal(existsSync(join(targetDir, "master.m3u8")), true);
+    });
+  } finally {
+    publisher.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher ignores tiny fragments even when top-level boxes exist", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  const publisher = startLiveOutputPublisher({
+    sourceDir,
+    targetDir,
+    intervalMs: 20,
+  });
+
+  try {
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-STREAM-INF:BANDWIDTH=2500000
+h264_720p.m3u8
+`,
+    );
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(
+      sourceDir,
+      "video-1.m4s",
+      Buffer.concat([
+        makeBox("styp", Buffer.from("msdh")),
+        makeBox("moof", Buffer.alloc(16)),
+        makeBox("mdat", Buffer.from("x")),
+      ]),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    assert.equal(
+      existsSync(join(targetDir, "video-1.m4s")),
+      false,
+      "tiny fragment should not be published",
+    );
+
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("video-1"));
+
+    await waitFor(() => {
+      assert.equal(existsSync(join(targetDir, "video-1.m4s")), true);
+    });
+  } finally {
+    publisher.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("publisher updates existing public files when source advances", async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "wasp-hls-publisher-"));
+  const sourceDir = join(tmpRoot, "source");
+  const targetDir = join(tmpRoot, "target");
+  const publisher = startLiveOutputPublisher({
+    sourceDir,
+    targetDir,
+    intervalMs: 20,
+  });
+
+  try {
+    writeTextFile(
+      sourceDir,
+      "master.m3u8",
+      `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-STREAM-INF:BANDWIDTH=2500000
+h264_720p.m3u8
+`,
+    );
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-1.m4s"], 0, "video-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-init.mp4", Buffer.from("video-init"));
+    writeBinaryFile(sourceDir, "video-1.m4s", makeMediaSegment("video-1"));
+
+    await waitFor(() => {
+      assert.match(
+        readFileSync(join(targetDir, "h264_720p.m3u8"), "utf8"),
+        /video-1\.m4s/,
+      );
+      assert.deepEqual(
+        readFileSync(join(targetDir, "video-1.m4s")),
+        makeMediaSegment("video-1"),
+      );
+    });
+
+    writeTextFile(
+      sourceDir,
+      "h264_720p.m3u8",
+      buildMediaPlaylist(["video-2.m4s"], 1, "video-init.mp4"),
+    );
+    writeBinaryFile(sourceDir, "video-2.m4s", makeMediaSegment("video-2"));
+
+    await waitFor(() => {
+      const playlist = readFileSync(join(targetDir, "h264_720p.m3u8"), "utf8");
+      assert.match(playlist, /video-2\.m4s/);
+      assert.doesNotMatch(playlist, /video-1\.m4s/);
+      assert.deepEqual(
+        readFileSync(join(targetDir, "video-2.m4s")),
+        makeMediaSegment("video-2"),
+      );
+    });
+  } finally {
+    publisher.stop();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/packager/text_track.mjs
+++ b/scripts/packager/text_track.mjs
@@ -31,7 +31,7 @@ export function createTextTrackAssets(ports, subtitleFormat) {
   }
 
   const commonAssetData = {
-    sourcePath: `udp://127.0.0.1:${ports.text1}`,
+    sourcePath: `udp://127.0.0.1:${ports.text1}/`,
     inputFormat: "webvtt",
     liveWriterMode: "webvtt",
     port: ports.text1,

--- a/scripts/run_integration_tests.mjs
+++ b/scripts/run_integration_tests.mjs
@@ -1,0 +1,390 @@
+#!/usr/bin/env node
+/**
+ * # run_integration_tests.mjs
+ *
+ * This file allows to run the integration test suite by running the `vitest`
+ * dependency on them with the right options.
+ *
+ * You can either run it directly as a script (run
+ * `node run_integration_tests.mjs -h` to see the different options) or by
+ * requiring it as a node module. If doing the latter you will obtain a
+ * function you will have to run with the right options.
+ */
+
+import { pathToFileURL } from "url";
+import { resolve } from "path";
+import { createVitest, startVitest } from "vitest/node";
+import { webdriverio } from "@vitest/browser-webdriverio";
+
+/** If not specified, run only this browser. */
+const DEFAULT_BROWSER = "chrome";
+
+/**
+ * First-run browser provisioning can include downloading Chrome/Firefox
+ * through WebdriverIO, which is counted against Vitest's browser connect
+ * timeout. Use a higher value to avoid timing out on slower connections.
+ */
+const BROWSER_CONNECT_TIMEOUT = 5 * 60 * 1000;
+
+/** Paths were integration tests are defined. */
+const INTEGRATION_TEST_FILES = [
+  "tests/integration/scenarios/**/*.[jt]s?(x)",
+  "tests/integration/**/*.test.[jt]s?(x)",
+];
+
+const baseGlobals = {
+  __TEST_CONTENT_SERVER__: {
+    URL: "127.0.0.1",
+    PORT: 3000,
+  },
+  __ENVIRONMENT__: {
+    PRODUCTION: 0,
+    DEV: 1,
+    CURRENT_ENV: 1,
+  },
+  __LOGGER_LEVEL__: {
+    CURRENT_LEVEL: '"NONE"',
+  },
+};
+
+const WDIO_CACHE_DIR = resolve(
+  process.cwd(),
+  process.env.WASP_HLS_WDIO_CACHE_DIR ?? "tmp/wdio-cache",
+);
+
+/**
+ * @param {Object} config - The test configuration object.
+ * @param {string} config.browser - The browser chosen to run the tests.
+ * Can be `"chrome"`, `"firefox"` or `"edge"`.
+ * @param {boolean} config.watch - If `true`, re-run tests when a depended file
+ * changed.
+ * @param {Array.<string>} testFilters - The filters you can pass to vitest ot
+ * only run some tests.
+ * @returns {Promise.<Object>} - The vitest object.
+ */
+export default function runVitests({ browser, watch }, testFilters = []) {
+  return startVitest(
+    "test",
+    testFilters,
+    {
+      reporters: "dot",
+      watch,
+      globalSetup: "tests/globalSetup.mjs",
+      projects: [generateTestConfig({ browser })],
+    },
+    {
+      test: {
+        browser: {
+          connectTimeout: BROWSER_CONNECT_TIMEOUT,
+        },
+      },
+    },
+  );
+}
+
+async function runVitestsWithManagedExit({ browser, watch }, testFilters = []) {
+  if (watch) {
+    return runVitests({ browser, watch }, testFilters);
+  }
+
+  process.env.TEST = "true";
+  process.env.VITEST = "true";
+  process.env.NODE_ENV ??= "test";
+
+  const ctx = await createVitest(
+    "test",
+    {
+      reporters: "dot",
+      watch: false,
+      globalSetup: "tests/globalSetup.mjs",
+      projects: [generateTestConfig({ browser })],
+    },
+    {
+      test: {
+        browser: {
+          connectTimeout: BROWSER_CONNECT_TIMEOUT,
+        },
+      },
+    },
+  );
+
+  try {
+    await ctx.start(testFilters);
+    return ctx;
+  } finally {
+    if (!ctx.shouldKeepServer()) {
+      await ctx.exit();
+    }
+  }
+}
+
+/**
+ * Generate the configuration associated to a particular browser adapted to
+ * RxPlayer tests (headless, autoplay enabled, memory control...).
+ * @param {string} browser - The browser chosen to run the tests.
+ * Can be `"chrome"`, `"firefox"` or `"edge"`.
+ * @returns {Object} - The `vitest`'s `browser` config to set to run that
+ * browser.
+ */
+function getBrowserConfig(browser) {
+  const providerOptions = getWdioProviderOptions(browser);
+  switch (browser) {
+    case "chrome":
+      return {
+        enabled: true,
+        provider: webdriverio(providerOptions),
+        headless: true,
+        screenshotFailures: false,
+        instances: [
+          {
+            browser: "chrome",
+          },
+        ],
+      };
+
+    case "firefox":
+      return {
+        enabled: true,
+        provider: webdriverio(providerOptions),
+        headless: true,
+        screenshotFailures: false,
+        instances: [
+          {
+            browser: "firefox",
+          },
+        ],
+      };
+
+    case "edge":
+      return {
+        enabled: true,
+        provider: webdriverio(providerOptions),
+        headless: true,
+        screenshotFailures: false,
+        instances: [
+          {
+            browser: "edge",
+          },
+        ],
+      };
+
+    default:
+      return {
+        enabled: false,
+      };
+  }
+}
+
+/**
+ * @param {"chrome" | "firefox" | "edge"} browser
+ * @returns {import("@vitest/browser-webdriverio").WebdriverProviderOptions}
+ */
+function getWdioProviderOptions(browser) {
+  return {
+    cacheDir: WDIO_CACHE_DIR,
+    logLevel: process.env.WASP_HLS_WDIO_LOG_LEVEL ?? "warn",
+    capabilities: buildBrowserCapabilities(browser),
+  };
+}
+
+/**
+ * @param {"chrome" | "firefox" | "edge"} browser
+ * @returns {Record<string, unknown>}
+ */
+function buildBrowserCapabilities(browser) {
+  switch (browser) {
+    case "chrome":
+      return {
+        browserName: "chrome",
+        "goog:chromeOptions": {
+          args: [
+            "--autoplay-policy=no-user-gesture-required",
+            "--enable-precise-memory-info",
+            "--js-flags=--expose-gc",
+          ],
+        },
+      };
+    case "firefox":
+      return {
+        browserName: "firefox",
+        "moz:firefoxOptions": {
+          prefs: {
+            "media.autoplay.default": 0,
+            "media.autoplay.enabled.user-gestures-needed": false,
+            "media.autoplay.block-webaudio": false,
+            "media.autoplay.ask-permission": false,
+            "media.autoplay.block-event.enabled": false,
+            "media.block-autoplay-until-in-foreground": false,
+          },
+        },
+      };
+    case "edge":
+      return {
+        browserName: "edge",
+        "ms:edgeOptions": {
+          args: ["--autoplay-policy=no-user-gesture-required"],
+        },
+      };
+  }
+}
+
+/**
+ * @param {Object} config - The test configuration object.
+ * @param {string} config.browser - The browser chosen to run the tests.
+ * Can be `"chrome"`, `"firefox"` or `"edge"`.
+ * @returns {Object} - The corresponding `vitest` config.
+ */
+function generateTestConfig({ browser }) {
+  const includedFiles = INTEGRATION_TEST_FILES;
+  return {
+    test: {
+      name: browser,
+      browser: getBrowserConfig(browser),
+      include: includedFiles,
+      globals: false,
+    },
+    define: {
+      ...baseGlobals,
+      __BROWSER_NAME__: JSON.stringify(browser),
+    },
+  };
+}
+
+// If true, this script is called directly
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main();
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let shouldWatch = false;
+  // TODO: multiple browsers?
+  let browser = "";
+  const filters = [];
+
+  if (args[0] === "-h" || args[0] === "--help") {
+    displayHelp();
+    process.exit(0);
+  }
+  for (let argOffset = 0; argOffset < args.length; argOffset++) {
+    const currentArg = args[argOffset];
+    switch (currentArg) {
+      case "-h":
+      case "--help":
+        displayHelp();
+        process.exit(0);
+        break;
+
+      case "-w":
+      case "--watch":
+        shouldWatch = true;
+        break;
+
+      case "-f":
+      case "--filter":
+        {
+          argOffset++;
+          const newFilter = args[argOffset];
+          if (newFilter === undefined) {
+            console.error(`ERROR: no filter provided to ${currentArg} flag.\n`);
+            displayHelp();
+            process.exit(1);
+          }
+          filters.push(newFilter);
+        }
+        break;
+
+      case "-b":
+      case "--browser":
+        {
+          argOffset++;
+          browser = args[argOffset];
+          if (browser === undefined) {
+            console.error("ERROR: no browser name provided\n");
+            displayHelp();
+            process.exit(1);
+          }
+          if (!["chrome", "firefox", "edge"].includes(browser)) {
+            console.error(
+              'ERROR: Invalid browser name provided.\nOnly "chrome", "firefox" or "edge" is authorized',
+            );
+            displayHelp();
+            process.exit(1);
+          }
+        }
+        break;
+
+      case "--":
+        argOffset = args.length;
+        break;
+
+      default: {
+        console.error('ERROR: unknown option: "' + currentArg + '"\n');
+        displayHelp();
+        process.exit(1);
+      }
+    }
+  }
+
+  console.warn(
+    `~~~ ⚠️ Integration tests have two dependencies: a local Wasp-hls build and ffmpeg.
+~~~ Make sure you:
+~~~ 1.  Have an ffmpeg executable in your path and,
+~~~ 2.  You built an up-to-date Wasp-hls bundle through the \`build\` npm script.`,
+  );
+  console.log();
+
+  if (!browser) {
+    console.info("Note: No browser specified, running on " + DEFAULT_BROWSER);
+    console.log();
+    browser = DEFAULT_BROWSER;
+  }
+
+  logWdioRuntimeConfig(browser);
+
+  try {
+    await runVitestsWithManagedExit(
+      {
+        watch: shouldWatch,
+        browser,
+      },
+      filters,
+    );
+  } catch (err) {
+    console.error(`ERROR: ${err}\n`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Display through `console.log` an helping message relative to how to run this
+ * script.
+ */
+function displayHelp() {
+  console.log(
+    `run_integration_tests.mjs: Run the integration test suite.
+
+Usage: node run_integration_tests.mjs [OPTIONS]
+
+Available options:
+  -h, --help                          Display this help message.
+  -f <FILTER>, --filter <FILTER>      A string that will serve as a filter.
+                                      Only test files containing this string will run.
+                                      This flag can be set multiple times, in which case
+                                      tests containing **either** of those strings will run.
+  -b <BROWSER>, --browser <BROWSER>   The browser to run those tests on.
+                                      Can be set to either "chrome", "firefox" or "edge".
+                                      "chrome" by default.
+  -w, --watch                         Re-run tests if any of its depended file has changed.`,
+  );
+}
+
+/**
+ * @param {string} browser
+ */
+function logWdioRuntimeConfig(browser) {
+  console.info("WebdriverIO mode: local driver management");
+  console.info(`WebdriverIO cache dir: ${WDIO_CACHE_DIR}`);
+  console.info(`Browser under test: ${browser}`);
+  console.log();
+}

--- a/scripts/tasks/build.mjs
+++ b/scripts/tasks/build.mjs
@@ -4,9 +4,11 @@
 
 import { copyFileSync, mkdirSync, readFileSync, rmSync } from "fs";
 import { dirname, join } from "path";
-import { exec } from "../utils/exec.mjs";
+import { exec, npmExecCommand } from "../utils/exec.mjs";
 import { checkPackageExports } from "./check-package-exports.mjs";
 import { reportStep } from "./report.mjs";
+
+const NODE = process.execPath;
 
 /**
  * @param {string} root
@@ -48,10 +50,10 @@ export async function buildWasm(root, { release, skipGenerate = false }) {
     copyFileSync(source, destination);
   }
   reportStep("BUILD", "Checking ABI correctness...");
-  await exec("node", ["./scripts/check_wasm_abi.mjs"], { cwd: root });
+  await exec(NODE, ["./scripts/check_wasm_abi.mjs"], { cwd: root });
   if (release) {
     reportStep("BUILD", "Stripping WASM debug symbols...");
-    await exec("node", ["./scripts/wasm-strip.js", "build/wasp_hls_bg.wasm"], {
+    await exec(NODE, ["./scripts/wasm-strip.js", "build/wasp_hls_bg.wasm"], {
       cwd: root,
     });
   }
@@ -72,7 +74,8 @@ export async function buildWorker(root, { release }) {
     args.push("--minify");
   }
   reportStep("BUILD", "building worker file...");
-  await exec("esbuild", args, { cwd: root });
+  const esbuild = npmExecCommand("esbuild", args);
+  await exec(esbuild.command, esbuild.args, { cwd: root });
 }
 
 /**
@@ -90,7 +93,8 @@ export async function buildMain(root, { release }) {
     args.push("--minify");
   }
   reportStep("BUILD", "building main file bundle...");
-  await exec("esbuild", args, { cwd: root });
+  const esbuild = npmExecCommand("esbuild", args);
+  await exec(esbuild.command, esbuild.args, { cwd: root });
 }
 
 /**
@@ -108,7 +112,8 @@ export async function buildDemoBundle(root, { release }) {
     args.push("--minify");
   }
   reportStep("BUILD", "building demo bundle...");
-  await exec("esbuild", args, { cwd: root });
+  const esbuild = npmExecCommand("esbuild", args);
+  await exec(esbuild.command, esbuild.args, { cwd: root });
 }
 
 /**
@@ -123,26 +128,23 @@ export async function buildAll(root, { release }) {
   rmSync(join(root, "build", "es6"), { force: true, recursive: true });
   rmSync(join(root, "build", "embedded"), { force: true, recursive: true });
   reportStep("BUILD", "generating ES6 build...");
-  await exec(
-    "tsc",
-    [
-      "-p",
-      join(root, "src/ts-main/tsconfig.json"),
-      "--rootDir",
-      join(root, "src"),
-      "--outDir",
-      "./build/es6",
-    ],
-    { cwd: root },
-  );
+  const tsc = npmExecCommand("tsc", [
+    "-p",
+    join(root, "src/ts-main/tsconfig.json"),
+    "--rootDir",
+    join(root, "src"),
+    "--outDir",
+    "./build/es6",
+  ]);
+  await exec(tsc.command, tsc.args, { cwd: root });
   copyFileSync(
     join(root, "src", "wasm", "wasp_hls_bg.wasm"),
     join(root, "build", "es6", "wasm", "wasp_hls_bg.wasm"),
   );
   reportStep("BUILD", "generating Embedded WASM JS file...");
-  await exec("node", ["./scripts/generate_embedded_wasm.js"], { cwd: root });
+  await exec(NODE, ["./scripts/generate_embedded_wasm.js"], { cwd: root });
   reportStep("BUILD", "generating Embedded Worker JS file...");
-  await exec("node", ["./scripts/generate_embedded_worker.js"], { cwd: root });
+  await exec(NODE, ["./scripts/generate_embedded_worker.js"], { cwd: root });
   reportStep("BUILD", "checking all exports...");
   await checkPackageExports(root);
 }
@@ -158,13 +160,17 @@ export async function buildDocs(root) {
     readFileSync(join(root, "package.json"), "utf8"),
   );
   const version = packageJson.version;
-  await exec(
-    "readme.doc",
-    ["--input", "doc", "--output", "build/doc", "-p", version],
-    {
-      cwd: root,
-    },
-  );
+  const readmeDoc = npmExecCommand("readme.doc", [
+    "--input",
+    "doc",
+    "--output",
+    "build/doc",
+    "-p",
+    version,
+  ]);
+  await exec(readmeDoc.command, readmeDoc.args, {
+    cwd: root,
+  });
 }
 
 /**
@@ -172,5 +178,5 @@ export async function buildDocs(root) {
  */
 export async function generateWasmAbi(root) {
   reportStep("BUILD", "Generating ABI enums...");
-  await exec("node", ["./scripts/generate_wasm_abi_enums.mjs"], { cwd: root });
+  await exec(NODE, ["./scripts/generate_wasm_abi_enums.mjs"], { cwd: root });
 }

--- a/scripts/tasks/check-package-exports.mjs
+++ b/scripts/tasks/check-package-exports.mjs
@@ -54,6 +54,7 @@ export async function checkPackageExports(root) {
     const packagedFiles = new Set(
       execOutsideRepo("tar", ["-tzf", repoTarballPath], root, npmCacheDir)
         .split("\n")
+        .map((entry) => entry.trim())
         .filter((entry) => entry.startsWith("package/"))
         .map((entry) => entry.slice("package/".length))
         .filter(Boolean),
@@ -153,8 +154,9 @@ function getPackedFilename(expectedTarballName, npmPackOutput) {
  * @returns {string}
  */
 function execOutsideRepo(command, args, cwd, npmCacheDir) {
+  const resolved = resolveCommand(command, args);
   try {
-    return execFileSync(command, args, {
+    return execFileSync(resolved.command, resolved.args, {
       cwd,
       encoding: "utf8",
       env: {
@@ -177,6 +179,39 @@ function execOutsideRepo(command, args, cwd, npmCacheDir) {
     }
     throw error;
   }
+}
+
+/**
+ * Resolve commands that need platform-specific launching behavior.
+ * In particular, invoking `npm` directly is unreliable on Windows without
+ * either reusing npm's JS entrypoint or going through `cmd.exe`.
+ *
+ * @param {string} command
+ * @param {string[]} args
+ * @returns {{ command: string, args: string[] }}
+ */
+function resolveCommand(command, args) {
+  if (command !== "npm") {
+    return { command, args };
+  }
+
+  if (process.env.npm_execpath) {
+    return {
+      command: process.execPath,
+      args: [process.env.npm_execpath, ...args],
+    };
+  }
+
+  if (process.platform === "win32") {
+    return {
+      command: "cmd.exe",
+      // `/d` disables AutoRun hooks, `/s` preserves quoting for the command
+      // string passed to `cmd`, and `/c` runs it then exits.
+      args: ["/d", "/s", "/c", "npm", ...args],
+    };
+  }
+
+  return { command: "npm", args };
 }
 
 /**

--- a/scripts/tasks/check.mjs
+++ b/scripts/tasks/check.mjs
@@ -3,7 +3,7 @@
  */
 
 import { join } from "path";
-import { exec } from "../utils/exec.mjs";
+import { exec, npmExecCommand } from "../utils/exec.mjs";
 import { generateWasmAbi } from "./build.mjs";
 import { reportStep } from "./report.mjs";
 
@@ -22,35 +22,60 @@ export async function checkAll(root) {
 /** @param {string} root */
 export async function checkMain(root) {
   reportStep("CHECK", "typechecking ts-main...");
-  await exec("tsc", ["--project", "./src/ts-main", "--noEmit"], { cwd: root });
+  const tsc = npmExecCommand("tsc", ["--project", "./src/ts-main", "--noEmit"]);
+  await exec(tsc.command, tsc.args, {
+    cwd: root,
+  });
   reportStep("CHECK", "linting ts-main...");
-  await exec("eslint", ["."], { cwd: join(root, "src", "ts-main") });
+  const eslint = npmExecCommand("eslint", ["."]);
+  await exec(eslint.command, eslint.args, {
+    cwd: join(root, "src", "ts-main"),
+  });
 }
 
 /** @param {string} root */
 export async function checkWorker(root) {
   reportStep("CHECK", "typechecking ts-worker...");
-  await exec("tsc", ["--project", "./src/ts-worker", "--noEmit"], {
+  const tsc = npmExecCommand("tsc", [
+    "--project",
+    "./src/ts-worker",
+    "--noEmit",
+  ]);
+  await exec(tsc.command, tsc.args, {
     cwd: root,
   });
   reportStep("CHECK", "linting ts-worker...");
-  await exec("eslint", ["."], { cwd: join(root, "src", "ts-worker") });
+  const eslint = npmExecCommand("eslint", ["."]);
+  await exec(eslint.command, eslint.args, {
+    cwd: join(root, "src", "ts-worker"),
+  });
   reportStep("CHECK", "linting ts-transmux...");
-  await exec("eslint", ["."], { cwd: join(root, "src", "ts-transmux") });
+  await exec(eslint.command, eslint.args, {
+    cwd: join(root, "src", "ts-transmux"),
+  });
 }
 
 /** @param {string} root */
 export async function checkCommon(root) {
   reportStep("CHECK", "linting ts-common...");
-  await exec("eslint", ["."], { cwd: join(root, "src", "ts-common") });
+  const eslint = npmExecCommand("eslint", ["."]);
+  await exec(eslint.command, eslint.args, {
+    cwd: join(root, "src", "ts-common"),
+  });
 }
 
 /** @param {string} root */
 export async function checkDemo(root) {
   reportStep("CHECK", "typechecking demo...");
-  await exec("tsc", ["--project", "./demo", "--noEmit"], { cwd: root });
+  const tsc = npmExecCommand("tsc", ["--project", "./demo", "--noEmit"]);
+  await exec(tsc.command, tsc.args, {
+    cwd: root,
+  });
   reportStep("CHECK", "linting demo...");
-  await exec("eslint", ["src/**/*"], { cwd: join(root, "demo") });
+  const eslint = npmExecCommand("eslint", ["src/**/*"]);
+  await exec(eslint.command, eslint.args, {
+    cwd: join(root, "demo"),
+  });
 }
 
 /** @param {string} root */

--- a/scripts/tasks/index.mjs
+++ b/scripts/tasks/index.mjs
@@ -27,8 +27,15 @@ import {
 import { exec } from "../utils/exec.mjs";
 import { cleanBuildDirectory } from "../utils/fs.mjs";
 import launchStaticServer from "../launch_static_server.mjs";
+import {
+  testAll,
+  testIntegration,
+  testRust as runRustTests,
+  testTransmux,
+} from "./test.mjs";
 import { watchDemo } from "./watch.mjs";
 import { reportSuccess } from "./report.mjs";
+import { npmExecCommand } from "../utils/exec.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const rawArgs = process.argv.slice(2);
@@ -140,16 +147,61 @@ async function run() {
       const { flags } = parseArgs(rest, ["--check"]);
       if (flags.has("--check")) {
         await exec("cargo", ["fmt", "--check"], { cwd: ROOT });
-        await exec("prettier", [".", "--check"], { cwd: ROOT });
+        const prettier = npmExecCommand("prettier", [".", "--check"]);
+        await exec(prettier.command, prettier.args, {
+          cwd: ROOT,
+        });
         reportSuccess("Code formatting checks");
       } else {
         await exec("cargo", ["fmt"], { cwd: ROOT });
-        await exec("prettier", ["--write", ".", "--loglevel", "warn"], {
+        const prettier = npmExecCommand("prettier", [
+          "--write",
+          ".",
+          "--loglevel",
+          "warn",
+        ]);
+        await exec(prettier.command, prettier.args, {
           cwd: ROOT,
         });
         reportSuccess("Code formatting");
       }
       return;
+    }
+    case "test": {
+      const options = parseTestArgs(rest);
+      switch (options.scope ?? "all") {
+        case "all":
+          ensureNoTestOptions(options, "all");
+          await testAll(ROOT);
+          reportSuccess("All tests");
+          return;
+        case "integration":
+          await testIntegration(ROOT, {
+            browser: options.browser,
+            filters: options.filters,
+            watch: options.watch,
+          });
+          reportSuccess("Integration tests");
+          return;
+        case "transmux":
+          assertNoBrowserOption(options, "transmux");
+          await testTransmux(ROOT, {
+            filters: options.filters,
+            watch: options.watch,
+          });
+          reportSuccess("Transmux tests");
+          return;
+        case "rust":
+          assertNoBrowserOption(options, "rust");
+          assertNoWatchOption(options, "rust");
+          await runRustTests(ROOT, { filters: options.filters });
+          reportSuccess("Rust unit tests");
+          return;
+        default:
+          throw new Error(
+            `Unknown test scope "${options.scope}".\n\n${helpText()}`,
+          );
+      }
     }
     case "generate":
       ensureNoArgs(rest);
@@ -239,12 +291,83 @@ function ensureNoArgs(args) {
   }
 }
 
+function parseTestArgs(args) {
+  let scope;
+  let watch = false;
+  let browser;
+  const filters = [];
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    switch (arg) {
+      case "--watch":
+        watch = true;
+        break;
+      case "--browser":
+        index++;
+        browser = args[index];
+        if (browser == null) {
+          throw new Error(`Missing value for "${arg}".\n\n${helpText()}`);
+        }
+        break;
+      case "--filter":
+        index++;
+        {
+          const filter = args[index];
+          if (filter == null) {
+            throw new Error(`Missing value for "${arg}".\n\n${helpText()}`);
+          }
+          filters.push(filter);
+        }
+        break;
+      default:
+        if (arg.startsWith("--")) {
+          throw new Error(`Unsupported flag "${arg}".\n\n${helpText()}`);
+        }
+        if (scope != null) {
+          throw new Error(`Too many test arguments.\n\n${helpText()}`);
+        }
+        scope = arg;
+        break;
+    }
+  }
+
+  return {
+    browser,
+    filters,
+    scope,
+    watch,
+  };
+}
+
 function assertNoFlag(flags, flag, message) {
   if (flags.has(flag)) throw new Error(message);
 }
 
 function assertNoFlags(flags, message) {
   if (flags.size !== 0) throw new Error(message);
+}
+
+function ensureNoTestOptions(options, scope) {
+  if (options.watch || options.browser != null || options.filters.length > 0) {
+    throw new Error(
+      `Extra options are not supported for "test ${scope}". Select a specific scope instead.\n\n${helpText()}`,
+    );
+  }
+}
+
+function assertNoBrowserOption(options, scope) {
+  if (options.browser != null) {
+    throw new Error(
+      `"--browser" is only supported for "test integration", not "test ${scope}".`,
+    );
+  }
+}
+
+function assertNoWatchOption(options, scope) {
+  if (options.watch) {
+    throw new Error(`"--watch" is not supported for "test ${scope}".`);
+  }
 }
 
 function helpText() {
@@ -266,6 +389,15 @@ Commands
     common      Check common TypeScript
     demo        Check demo TypeScript
     rust        Run cargo clippy
+
+  test [scope] [--filter <value>] [--watch] [--browser <name>]
+    all         Run every test suite: Rust, transmux, and integration (default)
+    rust        Run Rust unit tests
+    transmux    Run Node-based transmux tests
+    integration Run browser integration tests
+               --filter is repeatable for scoped test runs
+               --watch is supported for integration and transmux
+               --browser is supported for integration only
 
   fmt [--check]   Format Rust and JS/TS/Markdown
   generate        Regenerate wasm ABI enums

--- a/scripts/tasks/test.mjs
+++ b/scripts/tasks/test.mjs
@@ -1,0 +1,135 @@
+/**
+ * Unified test helpers for Node, browser integration, and Rust unit tests.
+ */
+
+import { readdir } from "fs/promises";
+import { join, relative } from "path";
+import { exec } from "../utils/exec.mjs";
+import { reportStep } from "./report.mjs";
+
+const TESTS_DIRECTORY = "tests";
+const TRANSMUX_DIRECTORY = join(TESTS_DIRECTORY, "transmux");
+const NODE_TEST_FILE_PATTERN = /\.test\.(?:mjs|js)$/;
+const NODE = process.execPath;
+
+/** @param {string} root */
+export async function testAll(root) {
+  await testRust(root, { filters: [] });
+  await testTransmux(root, { filters: [], watch: false });
+  await testIntegration(root, {
+    browser: undefined,
+    filters: [],
+    watch: false,
+  });
+}
+
+/**
+ * @param {string} root
+ * @param {{ filters: string[] }} options
+ */
+export async function testRust(root, { filters }) {
+  reportStep("TEST", "running Rust unit tests...");
+  const args = ["test"];
+  if (filters.length > 0) {
+    args.push("--", ...filters);
+  }
+  await exec("cargo", args, { cwd: root });
+}
+
+/**
+ * @param {string} root
+ * @param {{ filters: string[], watch: boolean }} options
+ */
+export async function testTransmux(root, { filters, watch }) {
+  const allTests = await collectNodeTestFiles(
+    root,
+    join(root, TRANSMUX_DIRECTORY),
+  );
+  const selectedTests = selectTests(allTests, filters);
+
+  if (selectedTests.length === 0) {
+    throw new Error("No transmux test files matched the requested filters.");
+  }
+
+  reportStep(
+    "TEST",
+    watch ? "watching transmux tests..." : "running transmux tests...",
+  );
+
+  const args = ["--test"];
+  if (watch) {
+    args.push("--watch");
+  }
+  args.push(...selectedTests);
+  await exec(NODE, args, { cwd: root });
+}
+
+/**
+ * @param {string} root
+ * @param {{ browser?: string, filters: string[], watch: boolean }} options
+ */
+export async function testIntegration(root, { browser, filters, watch }) {
+  reportStep(
+    "TEST",
+    watch
+      ? "watching browser integration tests..."
+      : "running browser integration tests...",
+  );
+
+  const args = ["./scripts/run_integration_tests.mjs"];
+  if (browser != null) {
+    args.push("--browser", browser);
+  }
+  if (watch) {
+    args.push("--watch");
+  }
+  for (const filter of filters) {
+    args.push("--filter", filter);
+  }
+  await exec(NODE, args, { cwd: root });
+}
+
+/**
+ * @param {string} testsDirectory
+ * @returns {Promise<string[]>}
+ */
+async function collectNodeTestFiles(root, testsDirectory) {
+  const discoveredFiles = [];
+  await walkTestsDirectory(root, testsDirectory, discoveredFiles);
+  return discoveredFiles.sort();
+}
+
+/**
+ * @param {string[]} files
+ * @param {string[]} filters
+ * @returns {string[]}
+ */
+function selectTests(files, filters) {
+  if (filters.length === 0) {
+    return files;
+  }
+  return files.filter((file) =>
+    filters.some((filter) => file.includes(filter)),
+  );
+}
+
+/**
+ * @param {string} directory
+ * @param {string[]} output
+ * @returns {Promise<void>}
+ */
+async function walkTestsDirectory(root, directory, output) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const absolutePath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      await walkTestsDirectory(root, absolutePath, output);
+      continue;
+    }
+
+    if (!NODE_TEST_FILE_PATTERN.test(entry.name)) {
+      continue;
+    }
+    output.push(relative(root, absolutePath));
+  }
+}

--- a/scripts/tasks/watch.mjs
+++ b/scripts/tasks/watch.mjs
@@ -6,7 +6,7 @@ import { spawn } from "child_process";
 import { existsSync, readdirSync, watch } from "fs";
 import { join } from "path";
 import { cleanBuildDirectory } from "../utils/fs.mjs";
-import { spawnEnv } from "../utils/exec.mjs";
+import { npmExecCommand } from "../utils/exec.mjs";
 import {
   buildWasm,
   buildWorker,
@@ -24,18 +24,18 @@ export async function watchDemo(root, { release }) {
   await buildWasm(root, { release, skipGenerate: true });
   await buildWorker(root, { release });
 
-  const demoWatcher = spawn(
-    "esbuild",
-    [
-      "demo/src/index.tsx",
-      "--bundle",
-      "--outfile=build/demo.js",
-      "--tsconfig=demo/tsconfig.json",
-      ...(release ? ["--minify"] : []),
-      "--watch",
-    ],
-    { cwd: root, env: spawnEnv(root), stdio: "inherit" },
-  );
+  const esbuild = npmExecCommand("esbuild", [
+    "demo/src/index.tsx",
+    "--bundle",
+    "--outfile=build/demo.js",
+    "--tsconfig=demo/tsconfig.json",
+    ...(release ? ["--minify"] : []),
+    "--watch",
+  ]);
+  const demoWatcher = spawn(esbuild.command, esbuild.args, {
+    cwd: root,
+    stdio: "inherit",
+  });
 
   let buildQueue = Promise.resolve();
   const enqueue = (label, task) => {

--- a/scripts/utils/exec.mjs
+++ b/scripts/utils/exec.mjs
@@ -3,7 +3,6 @@
  */
 
 import { spawn } from "child_process";
-import { delimiter, join } from "path";
 
 /**
  * @param {string} commandName
@@ -14,7 +13,6 @@ export function exec(commandName, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(commandName, args, {
       cwd: options.cwd,
-      env: spawnEnv(options.cwd),
       stdio: options.stdio ?? "inherit",
     });
     child.on("error", reject);
@@ -31,18 +29,33 @@ export function exec(commandName, args, options = {}) {
 }
 
 /**
- * Ensure locally installed CLIs remain resolvable even when the task runner is
- * invoked directly through `node` instead of `npm run`.
+ * Build a command tuple for `npm exec -- <tool> ...args` without relying on
+ * PATH shims. When the current process was launched by npm, reuse npm's own JS
+ * entrypoint through the current runtime.
  *
- * @param {string | undefined} cwd
- * @returns {NodeJS.ProcessEnv}
+ * @param {string} toolName
+ * @param {string[]} args
+ * @returns {{ command: string, args: string[] }}
  */
-export function spawnEnv(cwd) {
-  const env = { ...process.env };
-  const nodeModulesBin = join(cwd ?? process.cwd(), "node_modules", ".bin");
-  env.PATH =
-    env.PATH == null
-      ? nodeModulesBin
-      : `${nodeModulesBin}${delimiter}${env.PATH}`;
-  return env;
+export function npmExecCommand(toolName, args = []) {
+  if (process.env.npm_execpath) {
+    return {
+      command: process.execPath,
+      args: [process.env.npm_execpath, "exec", "--", toolName, ...args],
+    };
+  }
+
+  if (process.platform === "win32") {
+    return {
+      command: "cmd.exe",
+      // `/d` disables AutoRun hooks, `/s` preserves quoting for the command
+      // string passed to `cmd`, and `/c` runs it then exits.
+      args: ["/d", "/s", "/c", "npm", "exec", "--", toolName, ...args],
+    };
+  }
+
+  return {
+    command: "npm",
+    args: ["exec", "--", toolName, ...args],
+  };
 }

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -1000,6 +1000,10 @@ impl Dispatcher {
             Err(x) => {
                 let media_type = x.media_type();
                 let message = x.to_string();
+                Logger::warn(&format!(
+                    "Core: {} media segment push failed start:{} end:{} err:{}",
+                    media_type, segment_start, segment_end, message
+                ));
                 jsSendSegmentParsingError(true, x.into(), Some(media_type), &message);
                 self.stop_current_content();
             }
@@ -1021,6 +1025,10 @@ impl Dispatcher {
             Err(x) => {
                 let media_type = x.media_type();
                 let message = x.to_string();
+                Logger::warn(&format!(
+                    "Core: {} init segment push failed id:{} err:{}",
+                    media_type, init_id, message
+                ));
                 jsSendSegmentParsingError(true, x.into(), Some(media_type), &message);
                 self.stop_current_content();
             }

--- a/src/rs-core/media_element/mod.rs
+++ b/src/rs-core/media_element/mod.rs
@@ -765,17 +765,19 @@ impl MediaElementReference {
     ///
     /// Returns `true` if a seek has been performed
     fn check_queued_seek(&mut self) -> bool {
-        if self.queued_seek.is_some() && self.last_observation.as_ref().unwrap().ready_state() >= 1
+        if let (Some(queued_seek), Some(observation)) =
+            (self.queued_seek, self.last_observation.as_ref())
         {
-            let queued_seek = self.queued_seek.unwrap();
             if let Some(media_pos) = self.playlist_pos_to_media_pos(queued_seek) {
-                Logger::info(&format!(
-                    "Perform awaited seek to {} ({})",
-                    queued_seek, media_pos
-                ));
-                jsSeek(media_pos);
-                self.queued_seek = None;
-                return true;
+                if should_perform_queued_seek(observation, media_pos) {
+                    Logger::info(&format!(
+                        "Perform awaited seek to {} ({})",
+                        queued_seek, media_pos
+                    ));
+                    jsSeek(media_pos);
+                    self.queued_seek = None;
+                    return true;
+                }
             }
         }
         false
@@ -802,6 +804,11 @@ impl MediaElementReference {
     }
 }
 
+fn should_perform_queued_seek(observation: &MediaObservation, media_pos: f64) -> bool {
+    // TODO: even if media_pos is not in `buffered`?
+    observation.ready_state() >= 1 || observation.buffered().range_for(media_pos).is_some()
+}
+
 #[cfg(test)]
 mod tests {
     use super::MediaElementReference;
@@ -821,6 +828,42 @@ mod tests {
             discontinuity_sequence: 0,
             context: SegmentQualityContext::new(1.0, 1),
         }
+    }
+
+    #[test]
+    fn queued_seek_can_start_when_target_is_buffered_even_if_ready_state_is_zero() {
+        let observation = MediaObservation::new(
+            PlaybackTickReason::Init,
+            0.0,
+            0,
+            JsTimeRanges::new(vec![1.912, 3.896]),
+            false,
+            false,
+            false,
+            f64::MAX,
+            None,
+            None,
+        );
+
+        assert!(super::should_perform_queued_seek(&observation, 1.912));
+    }
+
+    #[test]
+    fn queued_seek_stays_blocked_without_ready_state_or_target_buffer() {
+        let observation = MediaObservation::new(
+            PlaybackTickReason::Init,
+            0.0,
+            0,
+            JsTimeRanges::new(vec![1.912, 3.896]),
+            false,
+            false,
+            false,
+            f64::MAX,
+            None,
+            None,
+        );
+
+        assert!(!super::should_perform_queued_seek(&observation, 0.5));
     }
 
     #[test]

--- a/src/ts-main/api.ts
+++ b/src/ts-main/api.ts
@@ -962,18 +962,21 @@ export default class WaspHlsPlayer extends EventEmitter<WaspHlsPlayerEvents> {
     if (this.__worker__ === null) {
       return;
     }
+    const worker = this.__worker__;
     if (this.__contentMetadata__ !== null) {
       requestStopForContent(
         this.__contentMetadata__,
         this.videoElement,
-        this.__worker__,
+        worker,
       );
+      for (const sourceBuffer of this.__contentMetadata__.sourceBuffers) {
+        sourceBuffer.queuedSourceBuffer.dispose();
+      }
+      this.__contentMetadata__.disposeMediaSource?.();
+      this.__contentMetadata__.disposeMediaSource = null;
+      this.__contentMetadata__.sourceBuffers = [];
     }
-    // NOTE: is this still needed? What about GC once it is set to `null`?
-    postMessageToWorker(this.__worker__, {
-      type: MainMessageType.DisposePlayer,
-      value: null,
-    });
+    worker.terminate();
     this.__worker__ = null;
     if (this.__logLevelChangeListener__ !== null) {
       logger.removeEventListener(

--- a/src/ts-main/worker-message-handlers.ts
+++ b/src/ts-main/worker-message-handlers.ts
@@ -92,6 +92,7 @@ export function onAttachMediaSourceMessage(
     contentMetadata.playbackObserver.stop();
     contentMetadata.playbackObserver = null;
   }
+  disposeContentSourceBuffers(contentMetadata);
 
   if (msg.value.handle !== undefined) {
     mediaElement.srcObject = msg.value.handle as unknown as MediaProvider;
@@ -222,6 +223,7 @@ export function onCreateMediaSourceMessage(
         contentMetadata.playbackObserver.stop();
         contentMetadata.playbackObserver = null;
       }
+      disposeContentSourceBuffers(contentMetadata);
 
       const mediaSource = new MediaSource();
 
@@ -310,6 +312,7 @@ export function onClearMediaSourceMessage(
       contentMetadata.disposeMediaSource();
       contentMetadata.disposeMediaSource = null;
     }
+    disposeContentSourceBuffers(contentMetadata);
     clearElementSrc(mediaElement);
   } catch (err) {
     const error = err instanceof Error ? err : "Unknown Error";
@@ -766,6 +769,7 @@ export function onErrorMessage(
     contentMetadata.disposeMediaSource();
     contentMetadata.disposeMediaSource = null;
   }
+  disposeContentSourceBuffers(contentMetadata);
   if (contentMetadata.playbackObserver !== null) {
     contentMetadata.playbackObserver.stop();
     contentMetadata.playbackObserver = null;
@@ -1125,6 +1129,18 @@ function bindMediaSource(
     videoElement.src = "";
     videoElement.removeAttribute("src");
   };
+}
+
+function disposeContentSourceBuffers(
+  contentMetadata: ContentMetadata | null,
+): void {
+  if (contentMetadata === null || contentMetadata.sourceBuffers.length === 0) {
+    return;
+  }
+  for (const sourceBuffer of contentMetadata.sourceBuffers) {
+    sourceBuffer.queuedSourceBuffer.dispose();
+  }
+  contentMetadata.sourceBuffers = [];
 }
 
 /**

--- a/src/ts-worker/bindings.ts
+++ b/src/ts-worker/bindings.ts
@@ -465,6 +465,10 @@ export function doFetch(
       }
       const dispatcher = playerInstance.getDispatcher();
       if (res.status >= 300) {
+        logger.warn(
+          `Worker: fetch failed id=${currentRequestId} status=${res.status} elapsed=${(timerFn() - timestampBef).toFixed(1)}ms url=${res.url || url}`,
+        );
+        requestsStore.delete(currentRequestId);
         dispatcher?.on_request_failed(currentRequestId, false, res.status);
         return;
       }
@@ -488,12 +492,18 @@ export function doFetch(
       requestsStore.delete(currentRequestId);
       const dispatcher = playerInstance.getDispatcher();
       if (timeouted) {
+        logger.warn(
+          `Worker: fetch timeout id=${currentRequestId} timeout=${timeout}ms url=${url}`,
+        );
         dispatcher?.on_request_failed(currentRequestId, true, undefined);
         return;
       }
       if (err instanceof Error && err.name === "AbortError") {
         return;
       }
+      logger.warn(
+        `Worker: fetch error id=${currentRequestId} elapsed=${(timerFn() - timestampBef).toFixed(1)}ms url=${url} err=${formatErrMessage(err, "Unknown fetch error")}`,
+      );
       dispatcher?.on_request_failed(currentRequestId, false, undefined);
     });
   return currentRequestId;
@@ -682,8 +692,16 @@ export function removeMediaSource(): RemoveMediaSourceResult {
   }
 
   if (contentInfo.mediaSourceObj.type === "worker") {
-    const { mediaSource, removeEventListeners } = contentInfo.mediaSourceObj;
+    const {
+      mediaSource,
+      removeEventListeners,
+      sourceBuffers: sourceBufferInfos,
+    } = contentInfo.mediaSourceObj;
     removeEventListeners();
+    for (const sourceBuffer of sourceBufferInfos) {
+      sourceBuffer.sourceBuffer.dispose();
+    }
+    contentInfo.mediaSourceObj.sourceBuffers = [];
 
     if (mediaSource !== null && mediaSource.readyState !== "closed") {
       const { readyState } = mediaSource;
@@ -1039,6 +1057,9 @@ export function appendBuffer(
             logger.info("Worker: Ignoring cancelled appendBuffer operation");
             return;
           }
+          logger.warn(
+            `Worker: appendBuffer failed sb=${sourceBufferId} mediaType=${sourceBufferObj.mediaType} resource=${resourceId} bytes=${transferableSegment.byteLength} err=${formatErrMessage(err, "Unknown appendBuffer error")}`,
+          );
           try {
             let buffered;
             try {
@@ -1412,7 +1433,11 @@ function getTimeInformationFromMp4(
   segment: Uint8Array,
   initTrackInfoByTrackId: Map<
     number,
-    { timescale: number; type: "audio" | "video" | "other" }
+    {
+      timescale: number;
+      type: "audio" | "video" | "other";
+      defaultSampleDuration: number | undefined;
+    }
   >,
 ): { time: number; duration: number | undefined; timescale: number } | null {
   return getIsobmfTimeInfo(segment, initTrackInfoByTrackId);

--- a/src/ts-worker/globals.ts
+++ b/src/ts-worker/globals.ts
@@ -45,7 +45,9 @@ class PlayerInstance {
   public dispose(): void {
     this._instanceInfo?.dispatcher.free();
     jsMemoryResources.freeEverything();
-    requestsStore.freeEverything();
+    requestsStore.freeEverything((request) => {
+      request.abortController.abort();
+    });
   }
 
   public changeContent(content: ContentInfo) {
@@ -56,7 +58,9 @@ class PlayerInstance {
       return;
     }
     jsMemoryResources.freeEverything();
-    requestsStore.freeEverything();
+    requestsStore.freeEverything((request) => {
+      request.abortController.abort();
+    });
     this._instanceInfo.content = content;
   }
 
@@ -95,7 +99,14 @@ class GenericStore<T> {
     return this._store[id];
   }
 
-  public freeEverything(): void {
+  public freeEverything(disposeItem?: (item: T) => void): void {
+    if (disposeItem !== undefined) {
+      for (const item of Object.values(this._store)) {
+        if (item !== undefined) {
+          disposeItem(item);
+        }
+      }
+    }
     this._store = {};
   }
 }
@@ -111,7 +122,14 @@ export interface RequestObject {
 export interface SourceBufferInstanceInfo<HasMseInWorker extends boolean> {
   id: SourceBufferId;
   lastInitTrackInfoByTrackId:
-    | Map<number, { timescale: number; type: "audio" | "video" | "other" }>
+    | Map<
+        number,
+        {
+          timescale: number;
+          type: "audio" | "video" | "other";
+          defaultSampleDuration: number | undefined;
+        }
+      >
     | undefined;
   mediaType: MediaType;
   sourceBuffer: HasMseInWorker extends true ? QueuedSourceBuffer : null;

--- a/src/ts-worker/globals.ts
+++ b/src/ts-worker/globals.ts
@@ -57,10 +57,6 @@ class PlayerInstance {
       );
       return;
     }
-    jsMemoryResources.freeEverything();
-    requestsStore.freeEverything((request) => {
-      request.abortController.abort();
-    });
     this._instanceInfo.content = content;
   }
 

--- a/src/ts-worker/isobmff-utils.ts
+++ b/src/ts-worker/isobmff-utils.ts
@@ -35,7 +35,7 @@ function getDurationFromTrun(buffer: Uint8Array): number | undefined {
       return undefined;
     }
     for (const trun of truns) {
-      const duration = getDurationFromSingleTrun(traf, trun);
+      const duration = getDurationFromSingleTrun(traf, trun, undefined);
       if (duration === undefined) {
         return undefined;
       }
@@ -45,10 +45,15 @@ function getDurationFromTrun(buffer: Uint8Array): number | undefined {
   return completeDuration;
 }
 
-function getInitTrackInfo(
-  buffer: Uint8Array,
-):
-  | Map<number, { timescale: number; type: "audio" | "video" | "other" }>
+function getInitTrackInfo(buffer: Uint8Array):
+  | Map<
+      number,
+      {
+        timescale: number;
+        type: "audio" | "video" | "other";
+        defaultSampleDuration: number | undefined;
+      }
+    >
   | undefined {
   const moov = getBoxContent(buffer, 0x6d6f6f76 /* moov */);
   if (moov === null) {
@@ -60,9 +65,15 @@ function getInitTrackInfo(
     return undefined;
   }
 
+  const defaultSampleDurationByTrackId =
+    getDefaultSampleDurationFromTREXByTrackId(moov);
   const trackInfo = new Map<
     number,
-    { timescale: number; type: "audio" | "video" | "other" }
+    {
+      timescale: number;
+      type: "audio" | "video" | "other";
+      defaultSampleDuration: number | undefined;
+    }
   >();
   for (const trak of traks) {
     const trackId = getTrackIdFromTRAK(trak);
@@ -75,6 +86,7 @@ function getInitTrackInfo(
       trackInfo.set(trackId, {
         timescale,
         type: getTrackTypeFromTRAK(trak),
+        defaultSampleDuration: defaultSampleDurationByTrackId.get(trackId),
       });
     }
   }
@@ -100,7 +112,11 @@ function getIsobmfTimeInfo(
   buffer: Uint8Array,
   initTrackInfoByTrackId: Map<
     number,
-    { timescale: number; type: "audio" | "video" | "other" }
+    {
+      timescale: number;
+      type: "audio" | "video" | "other";
+      defaultSampleDuration: number | undefined;
+    }
   >,
 ): { time: number; duration: number | undefined; timescale: number } | null {
   const trafs = getTRAFs(buffer);
@@ -119,7 +135,10 @@ function getIsobmfTimeInfo(
       if (initTrackInfo === undefined) {
         return null;
       }
-      const duration = getDurationFromTRAF(traf);
+      const duration = getDurationFromTRAF(
+        traf,
+        initTrackInfo.defaultSampleDuration,
+      );
       if (duration === undefined) {
         return null;
       }
@@ -692,7 +711,31 @@ function getDefaultDurationFromTFHDInTRAF(
   return defaultDuration;
 }
 
-function getDurationFromTRAF(traf: Uint8Array): number | undefined {
+function getDefaultSampleDurationFromTREXByTrackId(
+  moov: Uint8Array,
+): Map<number, number> {
+  const mvex = getBoxContent(moov, 0x6d766578 /* mvex */);
+  if (mvex === null) {
+    return new Map();
+  }
+
+  const trexBoxes = getBoxesContent(mvex, 0x74726578 /* trex */);
+  const defaultDurations = new Map<number, number>();
+  for (const trex of trexBoxes) {
+    if (trex.length < 24) {
+      continue;
+    }
+    const trackId = be4toi(trex, 4);
+    const defaultSampleDuration = be4toi(trex, 12);
+    defaultDurations.set(trackId, defaultSampleDuration);
+  }
+  return defaultDurations;
+}
+
+function getDurationFromTRAF(
+  traf: Uint8Array,
+  defaultSampleDurationFromInit: number | undefined,
+): number | undefined {
   const truns = getBoxesContent(traf, 0x7472756e /* trun */);
   if (truns.length === 0) {
     return undefined;
@@ -700,7 +743,11 @@ function getDurationFromTRAF(traf: Uint8Array): number | undefined {
 
   let totalDuration = 0;
   for (const trun of truns) {
-    const duration = getDurationFromSingleTrun(traf, trun);
+    const duration = getDurationFromSingleTrun(
+      traf,
+      trun,
+      defaultSampleDurationFromInit,
+    );
     if (duration === undefined) {
       return undefined;
     }
@@ -712,6 +759,7 @@ function getDurationFromTRAF(traf: Uint8Array): number | undefined {
 function getDurationFromSingleTrun(
   traf: Uint8Array,
   trun: Uint8Array,
+  defaultSampleDurationFromInit: number | undefined,
 ): number | undefined {
   let cursor = 0;
   const version = trun[cursor];
@@ -727,6 +775,9 @@ function getDurationFromSingleTrun(
   let defaultDuration: number | undefined = 0;
   if (!hasSampleDuration) {
     defaultDuration = getDefaultDurationFromTFHDInTRAF(traf);
+    if (defaultDuration === undefined) {
+      defaultDuration = defaultSampleDurationFromInit;
+    }
     if (defaultDuration === undefined) {
       return undefined;
     }

--- a/tests/contents/server.mjs
+++ b/tests/contents/server.mjs
@@ -1,0 +1,834 @@
+/* eslint-env node */
+
+/* eslint-disable no-console */
+
+import { createServer } from "http";
+import { spawn, spawnSync } from "child_process";
+import * as path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import * as fs from "fs";
+import urls from "./static/urls.mjs";
+
+/** To activate if you're having content packaging issues. */
+const ACTIVATE_PACKAGER_LOGS = false;
+
+/** Path of the current file. */
+const __filename = fileURLToPath(import.meta.url);
+/** Directory of the current file. */
+const __dirname = path.dirname(__filename);
+
+/** Live contents are lazily packaged in this directory. */
+const DEFAULT_PACKAGED_LIVE_OS_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "tmp",
+  "testcontents",
+  "live",
+);
+
+// Transform `urls` array into an Object where the key is the url of each
+// element.
+const routeObj = urls.reduce((acc, elt) => {
+  acc[elt.url] = elt;
+  return acc;
+}, {});
+
+const DEFAULT_CONTENT_SERVER_PORT = 3000;
+
+/** Global variable to track the "content packaging" process */
+let packagingProcessInfo = null;
+// Windows publication swaps can briefly leave the public pathname missing.
+// Keep the live server tolerant enough that slow CI machines do not surface
+// that transient gap as a fake 404.
+const LIVE_FILE_OPEN_RETRY_COUNT = 20;
+const LIVE_FILE_OPEN_RETRY_DELAY_MS = 25;
+
+function attachPackagerLogDrain(proc) {
+  proc.stdout?.on("data", (data) => {
+    if (ACTIVATE_PACKAGER_LOGS) {
+      console.log("Content packaging script stdout:", data.toString());
+    }
+  });
+  proc.stderr?.on("data", (data) => {
+    if (ACTIVATE_PACKAGER_LOGS) {
+      console.error("Content packaging script stderr:", data.toString());
+    }
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function forceKillProcessTree(proc) {
+  if (!proc || proc.pid === undefined) {
+    return;
+  }
+  try {
+    if (process.platform === "win32") {
+      spawnSync("taskkill", ["/pid", String(proc.pid), "/t", "/f"], {
+        stdio: "ignore",
+      });
+    } else {
+      process.kill(-proc.pid);
+    }
+  } catch (_err) {
+    try {
+      proc.kill("SIGKILL");
+    } catch (_innerErr) {
+      /* process already exited */
+    }
+  }
+}
+
+async function stopPackagingProcess() {
+  const processInfo = packagingProcessInfo;
+  if (!processInfo || processInfo.process.killed) {
+    packagingProcessInfo = null;
+    return false;
+  }
+
+  const proc = processInfo.process;
+  const exitPromise = new Promise((resolve) => {
+    proc.once("exit", () => resolve(true));
+    proc.once("error", () => resolve(true));
+  });
+
+  try {
+    proc.kill("SIGINT");
+  } catch (_err) {
+    forceKillProcessTree(proc);
+  }
+
+  const forceKillTimer = setTimeout(() => {
+    forceKillProcessTree(proc);
+  }, 5000);
+  forceKillTimer.unref?.();
+
+  await Promise.race([exitPromise, sleep(6500)]);
+  clearTimeout(forceKillTimer);
+  if (packagingProcessInfo?.process === proc) {
+    packagingProcessInfo = null;
+  }
+  return true;
+}
+
+/**
+ * Create simple HTTP server specifically designed to serve the contents defined
+ * in this directory.
+ * @param {Object} params
+ * @param {number} params.port
+ * @returns {Object}
+ */
+export default function createContentServer({
+  port = DEFAULT_CONTENT_SERVER_PORT,
+} = {}) {
+  const activeSockets = new Set();
+  const server = createServer(function (req, res) {
+    const requestUrl = new URL(req.url, "http://127.0.0.1");
+
+    if (req.url === "/") {
+      if (req.method.toUpperCase() === "OPTIONS") {
+        answerWithCORS(res, 200);
+        res.end();
+        return;
+      }
+      if (req.method.toUpperCase() !== "GET") {
+        res.setHeader("Content-Type", "text/plain");
+        answerWithCORS(res, 405, "405 Method Not Allowed");
+        return;
+      }
+
+      const html = generateUrlListHtml(
+        urls,
+        "http://127.0.0.1:" + String(port),
+      );
+      answerWithCORS(res, 200, html);
+      return;
+    }
+
+    if (req.url.startsWith("/live/")) {
+      handlePackagedLiveRequest(res, req, "/live/");
+      return;
+    }
+
+    if (req.url.startsWith("/live-alt/")) {
+      handlePackagedLiveRequest(res, req, "/live-alt/");
+      return;
+    }
+
+    if (requestUrl.pathname === "/start_packager") {
+      if (req.method.toUpperCase() === "OPTIONS") {
+        answerWithCORS(res, 200);
+        res.end();
+        return;
+      }
+      if (
+        req.method.toUpperCase() !== "POST" &&
+        req.method.toUpperCase() !== "GET"
+      ) {
+        res.setHeader("Content-Type", "text/plain");
+        answerWithCORS(res, 405, "405 Method Not Allowed");
+        return;
+      }
+      handleStartPackager(res, requestUrl);
+      return;
+    }
+
+    if (requestUrl.pathname === "/packager_status") {
+      if (req.method.toUpperCase() === "OPTIONS") {
+        answerWithCORS(res, 200);
+        res.end();
+        return;
+      }
+      if (req.method.toUpperCase() !== "GET") {
+        res.setHeader("Content-Type", "text/plain");
+        answerWithCORS(res, 405, "405 Method Not Allowed");
+        return;
+      }
+
+      res.setHeader("Content-Type", "application/json");
+      const jsonResponse =
+        packagingProcessInfo === null
+          ? {
+              active: false,
+              info: null,
+            }
+          : {
+              active: true,
+              info: {
+                pid: packagingProcessInfo.process.pid,
+                playlistPath: packagingProcessInfo.playlistPath,
+                timeShiftBufferDepth: packagingProcessInfo.timeShiftBufferDepth,
+                segmentDuration: packagingProcessInfo.segmentDuration,
+                publishStrategy: packagingProcessInfo.publishStrategy,
+              },
+            };
+      answerWithCORS(res, 200, JSON.stringify(jsonResponse));
+      return;
+    }
+
+    if (requestUrl.pathname === "/stop_packager") {
+      if (req.method.toUpperCase() === "OPTIONS") {
+        answerWithCORS(res, 200);
+        res.end();
+        return;
+      }
+      if (
+        req.method.toUpperCase() !== "POST" &&
+        req.method.toUpperCase() !== "GET"
+      ) {
+        res.setHeader("Content-Type", "text/plain");
+        answerWithCORS(res, 405, "405 Method Not Allowed");
+        return;
+      }
+
+      handleStopPackager(res);
+      return;
+    }
+
+    // Handle regular routes
+    if (routeObj[req.url] == null) {
+      res.setHeader("Content-Type", "text/plain");
+      answerWithCORS(res, 404, "404 Page Not Found");
+      return;
+    }
+    if (req.method.toUpperCase() === "OPTIONS") {
+      answerWithCORS(res, 200);
+      res.end();
+      return;
+    }
+    if (req.method.toUpperCase() !== "GET") {
+      res.setHeader("Content-Type", "text/plain");
+      answerWithCORS(res, 405, "405 Method Not Allowed");
+      return;
+    }
+
+    const urlObj = routeObj[req.url];
+    let data;
+    if (typeof urlObj.path === "string") {
+      try {
+        data = fs.readFileSync(urlObj.path);
+      } catch (_err) {
+        res.setHeader("Content-Type", "text/plain");
+        answerWithCORS(res, 404, "404 Page Not Found");
+        return;
+      }
+    } else {
+      data = urlObj.data;
+      try {
+        data = Buffer.from(data);
+      } catch (_e) {}
+      answerWithCORS(res, 200, data);
+      return;
+    }
+
+    const rangeHeader = req.headers["Range"] || req.headers["range"];
+    let isPartial = false;
+    if (typeof rangeHeader === "string" && rangeHeader.startsWith("bytes=")) {
+      const dataLength = data.byteLength;
+      const ranges = parseRangeHeader(rangeHeader, dataLength);
+      data = data.slice(ranges[0], ranges[1] + 1);
+      res.setHeader(
+        "Content-Range",
+        `bytes ${ranges[0]}-${ranges[1]}/${dataLength}`,
+      );
+      isPartial = true;
+    }
+    if (typeof urlObj.postProcess === "function") {
+      data = urlObj.postProcess(data);
+    }
+    if (typeof urlObj.contentType === "string") {
+      res.setHeader("Content-Type", urlObj.contentType);
+    }
+    const responseBody = Buffer.from(data);
+    const delayMs = typeof urlObj.delayMs === "number" ? urlObj.delayMs : 0;
+    if (delayMs > 0) {
+      setTimeout(() => {
+        answerWithCORS(res, isPartial ? 206 : 200, responseBody);
+      }, delayMs);
+      return;
+    }
+    answerWithCORS(res, isPartial ? 206 : 200, responseBody);
+  });
+
+  server.on("connection", (socket) => {
+    activeSockets.add(socket);
+    socket.on("close", () => {
+      activeSockets.delete(socket);
+    });
+  });
+
+  const listeningPromise = new Promise((res) => {
+    server.listen(port, function () {
+      console.log(
+        `Test Content Server started: http://localhost:${port ?? DEFAULT_CONTENT_SERVER_PORT}`,
+      );
+      console.log("");
+      console.log(
+        "You can request that URL directly to see the list of static contents served by this server.",
+      );
+      console.log("");
+      console.log(
+        "NOTE: You can start packaging a live content by POSTing to:\n " +
+          "     /start_packager",
+      );
+      console.log("      Only one content packaging at a time is supported.\n");
+      console.log(
+        "      A text track can be added by adding enableTextTrack=1 to its query string.\n",
+      );
+      console.log(
+        "      Stop packaging operations by POSTing to:\n      /stop_packager\n",
+      );
+      console.log(
+        "      To check if there's a packaging process going on, and its properties, do a GET at:\n" +
+          "      /packager_status",
+      );
+      console.log("");
+      console.log(
+        "You can inspect or update the server logic in its file:\n" +
+          __filename,
+      );
+      console.log("");
+      res();
+    });
+  });
+
+  return {
+    listeningPromise,
+    async close() {
+      await stopPackagingProcess();
+      const wasOpen = server.listening;
+      server.closeIdleConnections?.();
+      server.closeAllConnections?.();
+      await new Promise((resolve) => {
+        server.close(() => resolve());
+      });
+      for (const socket of activeSockets) {
+        socket.destroy();
+      }
+      activeSockets.clear();
+      if (wasOpen) {
+        console.log("Test Content Server stopped");
+      }
+    },
+  };
+}
+
+function handlePackagedLiveRequest(res, req, basePath) {
+  if (req.method.toUpperCase() === "OPTIONS") {
+    answerWithCORS(res, 200);
+    res.end();
+    return;
+  }
+  if (req.method.toUpperCase() !== "GET") {
+    res.setHeader("Content-Type", "text/plain");
+    answerWithCORS(res, 405, "405 Method Not Allowed");
+    return;
+  }
+
+  const baseDir = DEFAULT_PACKAGED_LIVE_OS_PATH;
+  const relativeUrl = req.url.substring(basePath.length);
+  prepareStaticFile(baseDir, relativeUrl).then(
+    (file) => {
+      if (file === null) {
+        answerWithCORS(res, 404, "404 Not Found");
+        return;
+      }
+      const mimeType =
+        file.ext === "m3u8"
+          ? "application/vnd.apple.mpegurl"
+          : "application/octet-stream";
+      res.writeHead(200, {
+        "Content-Type": mimeType,
+        Connection: "close",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "*",
+        "Access-Control-Allow-Credentials": true,
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+      });
+      file.stream.on("error", (err) => {
+        console.error(
+          `Live stream error ${req.url}:`,
+          err instanceof Error ? (err.stack ?? err.message) : err,
+        );
+      });
+      file.stream.pipe(res);
+    },
+    (err) => {
+      console.error(
+        `Live request failed ${req.url}:`,
+        err instanceof Error ? (err.stack ?? err.message) : err,
+      );
+      res.setHeader("Content-Type", "text/plain");
+      answerWithCORS(
+        res,
+        500,
+        "Error: " + (err instanceof Error ? err.toString() : "Unknown Error"),
+      );
+    },
+  );
+}
+
+/**
+ * Handle the /start_packager endpoint
+ * @param {Response} res
+ */
+async function handleStartPackager(res, requestUrl) {
+  try {
+    if (packagingProcessInfo && !packagingProcessInfo.process.killed) {
+      await stopPackagingProcess();
+    }
+
+    const scriptPath = path.join(
+      __dirname,
+      "..",
+      "..",
+      "scripts",
+      "packager",
+      "main.mjs",
+    );
+    const publishStrategyFromRequest =
+      requestUrl.searchParams.get("publishStrategy");
+    const publishStrategy =
+      publishStrategyFromRequest === "atomic" ||
+      publishStrategyFromRequest === "direct"
+        ? publishStrategyFromRequest
+        : process.env.WASP_HLS_PACKAGER_PUBLISH_STRATEGY === "direct"
+          ? "direct"
+          : "atomic";
+    const proc = spawn(
+      process.execPath,
+      [
+        scriptPath,
+        "--no-confirmation",
+        "--segment-duration",
+        "2",
+        "--timeshift-buffer-depth",
+        "40",
+        "--base-port",
+        "35951",
+        "--output-dir",
+        DEFAULT_PACKAGED_LIVE_OS_PATH,
+        "--publish-strategy",
+        publishStrategy,
+      ],
+      {
+        stdio: ["ignore", "pipe", "pipe"], // Don't inherit stdio, capture output
+        cwd: __dirname,
+      },
+    );
+
+    packagingProcessInfo = {
+      process: proc,
+      timeShiftBufferDepth: 40,
+      segmentDuration: 2,
+      playlistPath: "/live/master.m3u8",
+      publishStrategy,
+    };
+    attachPackagerLogDrain(packagingProcessInfo.process);
+
+    packagingProcessInfo.process.on("error", (error) => {
+      console.error("ERROR: Content packaging script error:", error);
+      packagingProcessInfo = null;
+    });
+
+    packagingProcessInfo.process.on("exit", () => {
+      packagingProcessInfo = null;
+    });
+
+    res.setHeader("Content-Type", "application/json");
+    answerWithCORS(
+      res,
+      200,
+      JSON.stringify({
+        success: true,
+        message: "Content packaging script started",
+        info: {
+          playlistPath: packagingProcessInfo.playlistPath,
+          timeShiftBufferDepth: packagingProcessInfo.timeShiftBufferDepth,
+          segmentDuration: packagingProcessInfo.segmentDuration,
+          publishStrategy: packagingProcessInfo.publishStrategy,
+        },
+      }),
+    );
+  } catch (error) {
+    console.error("ERROR: Failed to start content packaging script:", error);
+    res.setHeader("Content-Type", "application/json");
+    answerWithCORS(
+      res,
+      500,
+      JSON.stringify({
+        success: false,
+        message: "Failed to start content packaging script",
+        error: error.message,
+      }),
+    );
+  }
+}
+
+/**
+ * Handle the /stop_packager endpoint
+ * @param {Response} res
+ */
+async function handleStopPackager(res) {
+  try {
+    if (packagingProcessInfo && !packagingProcessInfo.process.killed) {
+      await stopPackagingProcess();
+
+      res.setHeader("Content-Type", "application/json");
+      answerWithCORS(
+        res,
+        200,
+        JSON.stringify({
+          success: true,
+          message: "content packaging script stopped",
+        }),
+      );
+    } else {
+      res.setHeader("Content-Type", "application/json");
+      answerWithCORS(
+        res,
+        200,
+        JSON.stringify({
+          success: true,
+          message: "No content packaging script running",
+        }),
+      );
+    }
+  } catch (error) {
+    console.error("ERROR: Failed to stop content packaging script:", error);
+    res.setHeader("Content-Type", "application/json");
+    answerWithCORS(
+      res,
+      500,
+      JSON.stringify({
+        success: false,
+        message: "Failed to stop content packaging script",
+        error: error.message,
+      }),
+    );
+  }
+}
+
+/**
+ * Add CORS headers, Content-Length, body, HTTP status and answer with the
+ * Response Object given.
+ * @param {Response} res
+ * @param {number} status
+ * @param {*} body
+ */
+function answerWithCORS(res, status, body) {
+  if (Buffer.isBuffer(body)) {
+    res.setHeader("Content-Length", body.byteLength);
+  } else if (typeof body === "string") {
+    res.setHeader("Content-Length", Buffer.byteLength(body));
+  }
+  res.writeHead(status, {
+    Connection: "close",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "*",
+    "Access-Control-Allow-Credentials": true,
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  });
+  if (body !== undefined) {
+    res.end(body);
+  } else {
+    res.end();
+  }
+  return;
+}
+
+/**
+ * Parse value of the "Range" header into an array of two numbers, which are
+ * specifically the start and end range wanted included.
+ * @param {string} rangeHeader
+ * @param {number} dataLength
+ * @returns {Array.<number>}
+ */
+function parseRangeHeader(rangeHeader, dataLength) {
+  const rangesStr = rangeHeader.substring(6).split("-");
+  if (
+    (rangesStr[0] != "" && Number.isNaN(+rangesStr[0])) ||
+    (rangesStr[1] != "" && Number.isNaN(+rangesStr[1]))
+  ) {
+    throw new Error("Invalid range request");
+  }
+  const rangesNb = rangesStr.map((x) => (x === "" ? null : +x));
+  if (rangesNb[1] == null) {
+    return [rangesNb[0], dataLength - 1];
+  }
+  if (rangesNb[1] <= rangesNb[0]) {
+    return [0, 0];
+  }
+  if (rangesNb[0] == null || rangesNb[0] === 0) {
+    if (rangesNb[1] == null) {
+      return [0, dataLength - 1];
+    }
+    return [0, rangesNb[1]];
+  }
+  return [rangesNb[0], rangesNb[1]];
+}
+
+/**
+ * Generate default HTML page listing the URL statically served.
+ * @param {Array.<Object>} urls - Information on URLs statically served.
+ * @param {string} baseUrl - Root URL where those are served.
+ * @returns {string} - HTML page where those URL can be inspected and browsed.
+ */
+function generateUrlListHtml(urls, baseUrl) {
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+    <title>URLs exposed by our content server (${urls.length} items)</title>
+    <style>
+        body { font-family: monospace; margin: 20px; }
+        .search { margin-bottom: 20px; }
+        .search input { width: 300px; padding: 5px; }
+        .search select { padding: 5px; margin-left: 10px; }
+        .item { border: 1px solid #ccc; margin: 10px 0; padding: 10px; }
+        .url { font-weight: bold; }
+        .path { color: #666; }
+        .type { background: #f0f0f0; padding: 2px 5px; font-size: 0.8em; }
+        .extra { margin-top: 5px; font-size: 0.9em; color: #333; }
+    </style>
+</head>
+<body>
+    <h1>Pre-registered URLs (${urls.length} items)</h1>
+    <p>This Website lists the URL of static assets served by our content server.<br>
+       Note that many of those assets may be unplayable as they're originally intended for specific integration tests which may not even need to have the correspoding content playing.<br>
+       PS: This page only includes URLs to static VoD contents. Assets dynamically created, even by this server, are not listed here.</p>
+
+    <div class="search">
+        <input type="text" id="search" placeholder="Search...">
+        <select id="typeFilter">
+            <option value="">All types</option>
+        </select>
+        <span id="count"></span>
+    </div>
+
+    <div id="results"></div>
+
+    <script>
+        const data = ${JSON.stringify(urls)};
+        let filtered = data;
+
+        // Populate content type filter
+        const types = [...new Set(data.map(i => i.contentType))].sort();
+        const typeFilter = document.getElementById('typeFilter');
+        types.forEach(type => {
+            if (!type) {
+              return;
+            }
+            const option = document.createElement('option');
+            option.value = type;
+            option.textContent = type;
+            typeFilter.appendChild(option);
+        });
+
+        function render() {
+            const results = document.getElementById('results');
+            const count = document.getElementById('count');
+
+            count.textContent = \`(\${filtered.length} shown)\`;
+
+            results.innerHTML = filtered.map(item => {
+                const extra = Object.keys(item)
+                    .filter(k => !['url', 'path', 'contentType'].includes(k))
+                    .map(k => \`<div class="extra"><strong>\${k}:</strong> \${JSON.stringify(item[k])}</div>\`)
+                    .join('');
+
+                return \`<div class="item">
+                    <div class="url"><a href="${baseUrl}\${item.url}">\${item.url}</a></div>
+                    <div class="path">\${item.path || 'N/A'}</div>
+                    <span class="type">\${item.contentType || 'unknown'}</span>
+                    \${extra}
+                </div>\`;
+            }).join('');
+        }
+
+        function filter() {
+            const search = document.getElementById('search').value.toLowerCase();
+            const type = document.getElementById('typeFilter').value;
+
+            filtered = data.filter(item => {
+                const matchSearch = !search ||
+                    (item.url && item.url.toLowerCase().includes(search)) ||
+                    (item.path && item.path.toLowerCase().includes(search)) ||
+                    (item.contentType && item.contentType.toLowerCase().includes(search));
+
+                const matchType = !type || item.contentType === type;
+
+                return matchSearch && matchType;
+            });
+
+            render();
+        }
+
+        document.getElementById('search').addEventListener('input', filter);
+        document.getElementById('typeFilter').addEventListener('change', filter);
+
+        render();
+    </script>
+</body>
+</html>`;
+
+  return html;
+}
+
+async function prepareStaticFile(baseDir, url) {
+  const filePath = path.resolve(baseDir, url);
+  const normalizedBase = path.resolve(baseDir);
+  const relative = path.relative(normalizedBase, filePath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return null;
+  }
+  for (let attempt = 0; attempt < LIVE_FILE_OPEN_RETRY_COUNT; attempt++) {
+    let fileHandle;
+    try {
+      fileHandle = await fs.promises.open(filePath, "r");
+      const stats = await fileHandle.stat();
+      if (stats.isDirectory()) {
+        await fileHandle.close();
+        return null;
+      }
+      const ext = path.extname(filePath).substring(1).toLowerCase();
+      const stream = fileHandle.createReadStream();
+      return {
+        ext,
+        stream,
+        filePath,
+        size: stats.size,
+        mtimeMs: stats.mtimeMs,
+      };
+    } catch (error) {
+      if (fileHandle !== undefined) {
+        try {
+          await fileHandle.close();
+        } catch {
+          // Ignore cleanup failures on transient file races.
+        }
+      }
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        if (attempt + 1 >= LIVE_FILE_OPEN_RETRY_COUNT) {
+          return null;
+        }
+        await sleep(LIVE_FILE_OPEN_RETRY_DELAY_MS);
+        continue;
+      }
+      throw error;
+    }
+  }
+  return null;
+}
+
+// If true, this script is called directly
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = process.argv.slice(2);
+  let port;
+  for (let argOffset = 0; argOffset < args.length; argOffset++) {
+    const currentArg = args[argOffset];
+    switch (currentArg) {
+      case "-h":
+      case "--help":
+        displayHelp();
+        process.exit(0);
+        break;
+
+      case "-p":
+      case "--port":
+        {
+          argOffset++;
+          port = +args[argOffset];
+          if (isNaN(port)) {
+            console.error("ERROR: Given port option is not a number\n");
+            displayHelp();
+            process.exit(1);
+          }
+        }
+        break;
+
+      case "--":
+        argOffset = args.length;
+        break;
+      default: {
+        console.error('ERROR: unknown option: "' + currentArg + '"\n');
+        displayHelp();
+        process.exit(1);
+      }
+    }
+  }
+  try {
+    createContentServer({
+      port,
+    }).listeningPromise.catch((err) => {
+      console.error(`ERROR: ${err}\n`);
+      process.exit(1);
+    });
+  } catch (err) {
+    console.error(`ERROR: ${err}\n`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Display through `console.log` an helping message relative to how to run this
+ * script.
+ */
+function displayHelp() {
+  console.log(
+    `server.mjs: Run the content server for integration tests.
+
+Usage: node server.mjs [OPTIONS]
+
+Options:
+  -p, --port  Port on which served contents are available.`,
+  );
+}

--- a/tests/contents/static/urls.mjs
+++ b/tests/contents/static/urls.mjs
@@ -1,0 +1,21 @@
+/* eslint-env node */
+
+// Every URLs served by our server. For test purposes.
+
+/**
+ * @typedef StaticUrlItem
+ * @property {string} url - Absolute URL to reach that resource. Resource may be
+ * a playlist, a segment etc.
+ * @property {path} path - Corresponding absolute path to the filesystem asset
+ * behind it.
+ * @property {string} contentType - Expected Content-type when serving that
+ * resource.
+ * @property {((buffer: ArrayBuffer) => ArrayBuffer)|undefined} [postProcess] - If
+ * set, it takes the filesystem asset in ArrayBuffer form and give back the actual
+ * resource to serve. This is often used e.g. to do storage-saving tricks useful
+ * for tests like repeating the same fmp4 segment while just updating its tfdt.
+ */
+
+// TODO:
+/** Array<StaticUrlItem> */
+export default [];

--- a/tests/globalSetup.mjs
+++ b/tests/globalSetup.mjs
@@ -1,0 +1,24 @@
+import createContentServer from "./contents/server.mjs";
+
+let contentServer;
+
+let started = false;
+
+/**
+ * Peform actions we want to setup before tests.
+ */
+export async function setup() {
+  if (started) {
+    return; // already started
+  }
+  started = true;
+  contentServer = createContentServer();
+}
+
+/**
+ * Peform actions to clean-up after tests.
+ */
+export async function teardown() {
+  await contentServer?.close();
+  started = false;
+}

--- a/tests/helpers/transmux-type-test-entry.ts
+++ b/tests/helpers/transmux-type-test-entry.ts
@@ -1,7 +1,0 @@
-import {
-  getFmp4Type,
-  getTransmuxedType,
-} from "../../src/ts-worker/transmux.ts";
-import { MediaType } from "../../src/wasm/index.ts";
-
-export { getFmp4Type, getTransmuxedType, MediaType };

--- a/tests/integration/scenarios/dash_live_packaged.test.js
+++ b/tests/integration/scenarios/dash_live_packaged.test.js
@@ -1,0 +1,163 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import WaspHlsPlayer from "../../../build/es6/ts-main/index.js";
+import EmbeddedWorker from "../../../build/embedded/worker.js";
+import EmbeddedWasm from "../../../build/embedded/wasm.js";
+import {
+  startLivePackager,
+  stopLivePackager,
+  waitForPackagerReady,
+} from "../utils/live_packager.js";
+import sleep from "../../utils/sleep.js";
+import { waitForLoadedStateAfterLoad } from "../../utils/waitForPlayerState";
+
+const LIVE_PACKAGER_PUBLISH_STRATEGY =
+  globalThis.__WASP_HLS_TEST_PUBLISH_STRATEGY__ === "direct" ||
+  globalThis.__WASP_HLS_TEST_PUBLISH_STRATEGY__ === "atomic"
+    ? globalThis.__WASP_HLS_TEST_PUBLISH_STRATEGY__
+    : "atomic";
+
+const PLAYER_LOAD_TIMEOUT_MS = 90_000;
+const LIVE_PLAYBACK_ASSERTION_WINDOW_S = 100;
+const LIVE_PLAYBACK_TEST_TIMEOUT_MS = 240_000;
+
+function getPlayerStateSnapshot(player, videoElement, lastPlayerError) {
+  return {
+    playerState: player.getPlayerState(),
+    playerError: player.getError() ?? lastPlayerError,
+    position: player.getPosition(),
+    minimumPosition: player.getMinimumPosition(),
+    maximumPosition: player.getMaximumPosition(),
+    currentTime: videoElement.currentTime,
+    readyState: videoElement.readyState,
+    networkState: videoElement.networkState,
+    paused: videoElement.paused,
+    ended: videoElement.ended,
+  };
+}
+
+async function waitForLoadedState(player, videoElement, lastPlayerErrorRef) {
+  const timeoutPromise = sleep(PLAYER_LOAD_TIMEOUT_MS).then(() => {
+    throw new Error(
+      "Player did not reach Loaded in time: " +
+        JSON.stringify(
+          getPlayerStateSnapshot(player, videoElement, lastPlayerErrorRef()),
+        ),
+    );
+  });
+
+  try {
+    await Promise.race([waitForLoadedStateAfterLoad(player), timeoutPromise]);
+  } catch (error) {
+    throw new Error(
+      "Player failed before reaching Loaded: " +
+        JSON.stringify({
+          error,
+          snapshot: getPlayerStateSnapshot(
+            player,
+            videoElement,
+            lastPlayerErrorRef(),
+          ),
+        }),
+    );
+  }
+
+  if (player.getPlayerState() !== "Loaded") {
+    throw new Error(
+      "Player did not settle in Loaded state: " +
+        JSON.stringify(
+          getPlayerStateSnapshot(player, videoElement, lastPlayerErrorRef()),
+        ),
+    );
+  }
+}
+
+describe("Live packaged content", function () {
+  let player;
+  let playlistUrl;
+  let segmentDuration;
+  let timeShiftBufferDepth;
+  let lastPlayerError = null;
+  const videoElement = document.createElement("video");
+
+  beforeAll(
+    async () => {
+      document.body.appendChild(videoElement);
+      await startLivePackager(LIVE_PACKAGER_PUBLISH_STRATEGY);
+
+      const readyInfos = await waitForPackagerReady();
+      playlistUrl = readyInfos.playlistUrl;
+      segmentDuration = readyInfos.segmentDuration;
+      timeShiftBufferDepth = readyInfos.timeShiftBufferDepth;
+    },
+    (3600 / 2) * 1000,
+  );
+
+  afterAll(async () => {
+    document.body.removeChild(videoElement);
+    await stopLivePackager();
+  });
+
+  beforeEach(() => {
+    lastPlayerError = null;
+    player = new WaspHlsPlayer(videoElement);
+    player.initialize({
+      workerUrl: EmbeddedWorker,
+      wasmUrl: EmbeddedWasm,
+    });
+    player.addEventListener("error", (error) => {
+      lastPlayerError = error;
+    });
+  });
+
+  afterEach(() => {
+    player.dispose();
+  });
+
+  it(
+    "should fetch, update and play the Manifest",
+    { timeout: LIVE_PLAYBACK_TEST_TIMEOUT_MS },
+    async function () {
+      player.addEventListener("playerStateChange", (state) => {
+        if (state === "Loaded") {
+          player.resume();
+        }
+      });
+
+      player.load(playlistUrl);
+      await waitForLoadedState(player, videoElement, () => lastPlayerError);
+
+      expect(player.isLive()).toEqual(true);
+
+      const basePos = player.getPosition();
+      const baseMin = player.getMinimumPosition();
+      const baseMax = player.getMaximumPosition();
+      const baseGap = baseMax - basePos;
+
+      expect(baseGap).toBeGreaterThan(5);
+      expect(baseGap).toBeLessThan(20);
+
+      const secondsWaiting = LIVE_PLAYBACK_ASSERTION_WINDOW_S;
+      await sleep(secondsWaiting * 1000);
+
+      const newPos = player.getPosition();
+      const newMin = player.getMinimumPosition();
+      const newMax = player.getMaximumPosition();
+
+      expect(newMax - baseMax).toBeGreaterThanOrEqual(secondsWaiting * 0.8);
+      expect(newMin - baseMin).toBeGreaterThanOrEqual(secondsWaiting * 0.8);
+      expect(newMax - newPos).toBeGreaterThan(5);
+      expect(newMax - newPos).toBeLessThan(20);
+      expect(newPos - basePos).toBeGreaterThanOrEqual(secondsWaiting * 0.8);
+      expect(segmentDuration).toBeGreaterThan(0);
+      expect(timeShiftBufferDepth).toBeGreaterThan(0);
+    },
+  );
+});

--- a/tests/integration/utils/live_packager.js
+++ b/tests/integration/utils/live_packager.js
@@ -1,0 +1,187 @@
+import sleep from "../../utils/sleep.js";
+
+const PACKAGER_READY_TIMEOUT_MS = 120_000;
+const PACKAGER_STOP_TIMEOUT_MS = 10_000;
+const PACKAGER_STOP_POLL_INTERVAL_MS = 200;
+
+function getBaseUrl() {
+  return (
+    "http://" + __TEST_CONTENT_SERVER__.URL + ":" + __TEST_CONTENT_SERVER__.PORT
+  );
+}
+
+function getStartPackagerUrl() {
+  return getBaseUrl() + "/start_packager";
+}
+
+function getStopPackagerUrl() {
+  return getBaseUrl() + "/stop_packager";
+}
+
+function getPackagerStatusUrl() {
+  return getBaseUrl() + "/packager_status";
+}
+
+function extractPlaylistReferences(playlistText) {
+  return playlistText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+}
+
+function extractMediaTagUris(playlistText) {
+  return playlistText
+    .split("\n")
+    .map((line) => {
+      const trimmedLine = line.trim();
+      if (!trimmedLine.startsWith("#EXT-X-MEDIA:")) {
+        return null;
+      }
+      const match = /URI="([^"]+)"/.exec(trimmedLine);
+      return match === null ? null : match[1];
+    })
+    .filter((uri) => uri !== null);
+}
+
+async function fetchText(url) {
+  const response = await fetch(url);
+  return {
+    status: response.status,
+    ok: response.ok,
+    text: await response.text(),
+  };
+}
+
+async function fetchBinary(url) {
+  const response = await fetch(url);
+  await response.arrayBuffer();
+  return {
+    ok: response.ok,
+  };
+}
+
+async function consumeFetchResponse(responsePromise) {
+  const response = await responsePromise;
+  await response.arrayBuffer();
+  return response;
+}
+
+async function fetchCurrentPackagerStatus() {
+  const response = await fetch(getPackagerStatusUrl());
+  return await response.json();
+}
+
+async function waitForPackagerStop() {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < PACKAGER_STOP_TIMEOUT_MS) {
+    const status = await fetchCurrentPackagerStatus();
+    if (!status.active) {
+      return;
+    }
+    await sleep(PACKAGER_STOP_POLL_INTERVAL_MS);
+  }
+
+  throw new Error("Timed out waiting for live packager shutdown");
+}
+
+async function waitForStableLiveOutput(playlistUrl) {
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const master = await fetchText(playlistUrl);
+    if (!master.ok) {
+      await sleep(1000);
+      continue;
+    }
+
+    const variantUrl = extractPlaylistReferences(master.text)
+      .filter((line) => line.endsWith(".m3u8"))
+      .map((line) => new URL(line, playlistUrl).href)[0];
+    const audioUrl = extractMediaTagUris(master.text).map(
+      (line) => new URL(line, playlistUrl).href,
+    )[0];
+    if (variantUrl == null || audioUrl == null) {
+      await sleep(1000);
+      continue;
+    }
+
+    const variantPlaylist = await fetchText(variantUrl);
+    const audioPlaylist = await fetchText(audioUrl);
+    if (!variantPlaylist.ok || !audioPlaylist.ok) {
+      await sleep(1000);
+      continue;
+    }
+
+    const variantSegmentRef = extractPlaylistReferences(
+      variantPlaylist.text,
+    )[0];
+    const audioSegmentRef = extractPlaylistReferences(audioPlaylist.text)[0];
+    if (variantSegmentRef == null || audioSegmentRef == null) {
+      await sleep(1000);
+      continue;
+    }
+
+    const [variantSegment, audioSegment] = await Promise.all([
+      fetchBinary(new URL(variantSegmentRef, variantUrl).href),
+      fetchBinary(new URL(audioSegmentRef, audioUrl).href),
+    ]);
+    if (variantSegment.ok && audioSegment.ok) {
+      return;
+    }
+
+    await sleep(1000);
+  }
+
+  throw new Error("Live packager output did not become fetchable");
+}
+
+export async function startLivePackager(publishStrategy) {
+  await consumeFetchResponse(
+    fetch(
+      `${getStartPackagerUrl()}?enableTextTrack=1&publishStrategy=${publishStrategy}`,
+      { method: "POST" },
+    ),
+  );
+}
+
+export async function stopLivePackager() {
+  await consumeFetchResponse(fetch(getStopPackagerUrl(), { method: "POST" }));
+  await waitForPackagerStop();
+}
+
+export async function waitForPackagerReady() {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < PACKAGER_READY_TIMEOUT_MS) {
+    await sleep(1500);
+    const status = await fetchCurrentPackagerStatus();
+
+    if (!status.active) {
+      throw new Error("Live packager stopped before it became ready");
+    }
+
+    const playlistUrl = getBaseUrl() + status.info.playlistPath;
+    const segmentDuration = status.info.segmentDuration;
+    const timeShiftBufferDepth = status.info.timeShiftBufferDepth;
+
+    const playlistResponse = await fetchText(playlistUrl);
+    if (playlistResponse.status === 404) {
+      continue;
+    }
+    if (!playlistResponse.ok) {
+      throw new Error(
+        `Unexpected status while requesting generated playlist: ${playlistResponse.status}`,
+      );
+    }
+
+    await sleep((timeShiftBufferDepth ?? 1) * 1000);
+    await waitForStableLiveOutput(playlistUrl);
+
+    return {
+      playlistUrl,
+      segmentDuration,
+      timeShiftBufferDepth,
+    };
+  }
+
+  throw new Error("Timed out waiting for live packager readiness");
+}

--- a/tests/transmux/helpers/transmux-test-entry.ts
+++ b/tests/transmux/helpers/transmux-test-entry.ts
@@ -1,10 +1,10 @@
-import Transmuxer from "../../src/ts-transmux/index.ts";
+import Transmuxer from "../../../src/ts-transmux/index.ts";
 import {
   getMDHDTimescale,
   getInitTrackInfo,
   getIsobmfTimeInfo,
   getTrackFragmentDecodeTime,
-} from "../../src/ts-worker/isobmff-utils.ts";
+} from "../../../src/ts-worker/isobmff-utils.ts";
 
 function getMDHDTimescales(buffer: Uint8Array) {
   return getInitTrackInfo(buffer);
@@ -14,7 +14,11 @@ function getSegmentTimeInformation(
   buffer: Uint8Array,
   initTrackInfoByTrackId: Map<
     number,
-    { timescale: number; type: "audio" | "video" | "other" }
+    {
+      timescale: number;
+      type: "audio" | "video" | "other";
+      defaultSampleDuration: number | undefined;
+    }
   >,
 ) {
   const info = getIsobmfTimeInfo(buffer, initTrackInfoByTrackId);

--- a/tests/transmux/helpers/transmux-type-test-entry.ts
+++ b/tests/transmux/helpers/transmux-type-test-entry.ts
@@ -1,0 +1,7 @@
+import {
+  getFmp4Type,
+  getTransmuxedType,
+} from "../../../src/ts-worker/transmux.ts";
+import { MediaType } from "../../../src/wasm/index.ts";
+
+export { getFmp4Type, getTransmuxedType, MediaType };

--- a/tests/transmux/mp4-muxed-timing.test.mjs
+++ b/tests/transmux/mp4-muxed-timing.test.mjs
@@ -10,7 +10,9 @@ import { build } from "esbuild";
 async function bundleWorkerMp4Utils(tmpRoot) {
   const outfile = join(tmpRoot, "mp4-utils-test-bundle.mjs");
   await build({
-    entryPoints: [join(process.cwd(), "tests/helpers/transmux-test-entry.ts")],
+    entryPoints: [
+      join(process.cwd(), "tests/transmux/helpers/transmux-test-entry.ts"),
+    ],
     bundle: true,
     format: "esm",
     platform: "node",
@@ -72,6 +74,11 @@ function makeInitSegment() {
   return box("moov", makeTrak(1, 90000), makeTrak(2, 48000));
 }
 
+function makeInitSegmentWithTrex() {
+  const trex = fullBox("trex", 0, 0, u32(2), u32(1), u32(1024), u32(0), u32(0));
+  return box("moov", makeTrak(2, 48000), box("mvex", trex));
+}
+
 function makeTfhd(trackId) {
   return fullBox("tfhd", 0, 0, u32(trackId));
 }
@@ -107,6 +114,16 @@ function makeMediaSegment() {
   return box("moof", videoTraf, audioTraf);
 }
 
+function makeMediaSegmentUsingTrexDefaultDuration() {
+  const audioTraf = box(
+    "traf",
+    makeTfhd(2),
+    makeTfdt(480000),
+    fullBox("trun", 0, 0, u32(2)),
+  );
+  return box("moof", audioTraf);
+}
+
 test("worker MP4 timing normalizes muxed tracks with distinct timescales", async () => {
   const tmpRoot = await mkdtemp(join(tmpdir(), "wasp-hls-mp4-utils-"));
   try {
@@ -123,6 +140,28 @@ test("worker MP4 timing normalizes muxed tracks with distinct timescales", async
     assert.ok(
       Math.abs(info.duration - 6000 / 90000) < 1e-6,
       "expected duration to span the longest normalized track run",
+    );
+  } finally {
+    await rm(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("worker MP4 timing falls back to trex default sample duration", async () => {
+  const tmpRoot = await mkdtemp(join(tmpdir(), "wasp-hls-mp4-utils-"));
+  try {
+    const mod = await bundleWorkerMp4Utils(tmpRoot);
+    const initTimescales = mod.getMDHDTimescales(makeInitSegmentWithTrex());
+    assert.ok(initTimescales instanceof Map, "expected init timescales map");
+
+    const info = mod.getSegmentTimeInformation(
+      makeMediaSegmentUsingTrexDefaultDuration(),
+      initTimescales,
+    );
+    assert.ok(info, "expected timing with trex fallback");
+    assert.ok(Math.abs(info.time - 10) < 1e-6, "expected a 10s segment start");
+    assert.ok(
+      Math.abs(info.duration - 2048 / 48000) < 1e-6,
+      "expected duration from trex default sample duration",
     );
   } finally {
     await rm(tmpRoot, { recursive: true, force: true });

--- a/tests/transmux/transmux-discontinuity-reset.test.mjs
+++ b/tests/transmux/transmux-discontinuity-reset.test.mjs
@@ -21,7 +21,9 @@ function hasFfmpeg() {
 async function bundleTransmuxSource(tmpRoot) {
   const outfile = join(tmpRoot, "transmux-test-bundle.mjs");
   await build({
-    entryPoints: [join(process.cwd(), "tests/helpers/transmux-test-entry.ts")],
+    entryPoints: [
+      join(process.cwd(), "tests/transmux/helpers/transmux-test-entry.ts"),
+    ],
     bundle: true,
     format: "esm",
     platform: "node",
@@ -127,7 +129,7 @@ if (!hasFfmpeg()) {
 
       const withoutReset = new mod.default();
       withoutReset.transmuxSegment(segmentFromA, {
-        baseMediaDecodeTime: {
+        baseMediaDecodeTimeSeed: {
           value: 0,
           timescale: 90000,
         },
@@ -136,7 +138,7 @@ if (!hasFfmpeg()) {
         midGopSegmentFromB,
         {
           reset: true,
-          baseMediaDecodeTime: {
+          baseMediaDecodeTimeSeed: {
             value: 2 * 90000,
             timescale: 90000,
           },
@@ -145,7 +147,7 @@ if (!hasFfmpeg()) {
 
       const fresh = new mod.default();
       const expectedAfterReset = fresh.transmuxSegment(midGopSegmentFromB, {
-        baseMediaDecodeTime: {
+        baseMediaDecodeTimeSeed: {
           value: 2 * 90000,
           timescale: 90000,
         },

--- a/tests/transmux/transmux-state-precedence.test.mjs
+++ b/tests/transmux/transmux-state-precedence.test.mjs
@@ -12,7 +12,9 @@ const VIDEO_TIMESCALE = 90_000;
 async function bundleTransmuxSource(tmpRoot) {
   const outfile = join(tmpRoot, "transmux-test-bundle.mjs");
   await build({
-    entryPoints: [join(process.cwd(), "tests/helpers/transmux-test-entry.ts")],
+    entryPoints: [
+      join(process.cwd(), "tests/transmux/helpers/transmux-test-entry.ts"),
+    ],
     bundle: true,
     format: "esm",
     platform: "node",

--- a/tests/transmux/transmux-timeline-anchor.test.mjs
+++ b/tests/transmux/transmux-timeline-anchor.test.mjs
@@ -20,7 +20,9 @@ function hasFfmpeg() {
 async function bundleTransmuxSource(tmpRoot) {
   const outfile = join(tmpRoot, "transmux-test-bundle.mjs");
   await build({
-    entryPoints: [join(process.cwd(), "tests/helpers/transmux-test-entry.ts")],
+    entryPoints: [
+      join(process.cwd(), "tests/transmux/helpers/transmux-test-entry.ts"),
+    ],
     bundle: true,
     format: "esm",
     platform: "node",
@@ -103,7 +105,7 @@ async function transmuxSequence(mod, segments) {
   const values = [];
   for (const { data, start, duration } of segments) {
     const out = transmuxer.transmuxSegment(data, {
-      baseMediaDecodeTime: {
+      baseMediaDecodeTimeSeed: {
         value: Math.round(start * 90000),
         timescale: 90000,
       },

--- a/tests/transmux/transmux-type-normalization.test.mjs
+++ b/tests/transmux/transmux-type-normalization.test.mjs
@@ -11,7 +11,7 @@ async function bundleTransmuxTypeHelpers(tmpRoot) {
   const outfile = join(tmpRoot, "transmux-type-test-bundle.mjs");
   await build({
     entryPoints: [
-      join(process.cwd(), "tests/helpers/transmux-type-test-entry.ts"),
+      join(process.cwd(), "tests/transmux/helpers/transmux-type-test-entry.ts"),
     ],
     bundle: true,
     format: "esm",

--- a/tests/utils/checkAfterSleepWithBackoff.js
+++ b/tests/utils/checkAfterSleepWithBackoff.js
@@ -1,0 +1,77 @@
+import sleep from "./sleep";
+
+/**
+ * Performs a check after a given delay (starting at either `minTimeMs`
+ * milliseconds or just after a `setTimeout` of `0` if not set).
+ * If that check fails, re-run it recursively after waiting until either:
+ *   - `stepMs` milliseconds if one has been indicated
+ *   - two times the previous delay
+ *   - `maxTimeMs` milliseconds if any of the preceding methods would have lead
+ *     to a longer delay.
+ *
+ * Once `maxTimeMs` milliseconds have passed (or 4 seconds if not set) since
+ * this function was called and if the check still fails, throw the
+ * corresponding failure.
+ *
+ * This util is useful for asynchronous tests which pass after some delay but
+ * how much is not certain. Instead of setting a very high delay which will
+ * lead to your test taking too much time, you may use this util instead to give
+ * a range from a short to a longer delay.
+ *
+ * @param {Object|null|undefined} [configuration]
+ * @param {number|null|undefined} [configuration.minTimeMs]
+ * @param {number|null|undefined} [configuration.maxTimeMs]
+ * @param {number|null|undefined} [configuration.stepMs]
+ * @param {function|Object} checks
+ * @returns {Promise}
+ */
+export async function checkAfterSleepWithBackoff(configuration, checks) {
+  const minTimeMs = configuration?.minTimeMs;
+  const maxTimeMs = configuration?.maxTimeMs;
+  const stepMs = configuration?.stepMs;
+  const checkFn = typeof checks === "function" ? checks : checks.resolveWhen;
+  const onFailure =
+    typeof checks === "function"
+      ? () => {
+          /* noop */
+        }
+      : checks.untilSuccess;
+  let sleepTime = minTimeMs ?? 0;
+  try {
+    await sleep(sleepTime);
+    const result = checkFn();
+    if (result instanceof Promise) {
+      await result;
+    }
+  } catch (err) {
+    onFailure();
+    const usedMax = maxTimeMs ?? 4000;
+    const remainingMax = usedMax - sleepTime;
+    if (remainingMax <= 0) {
+      throw err;
+    }
+
+    if (sleepTime === 0) {
+      return checkAfterSleepWithBackoff(
+        {
+          minTimeMs: Math.min(5, maxTimeMs),
+          maxTimeMs,
+        },
+        checks,
+      );
+    } else {
+      if (stepMs !== undefined) {
+        sleepTime = stepMs;
+      } else {
+        sleepTime += sleepTime;
+      }
+      if (sleepTime > remainingMax) {
+        sleepTime = remainingMax;
+      }
+      return checkAfterSleepWithBackoff(
+        { minTimeMs: sleepTime, maxTimeMs: remainingMax },
+        checks,
+      );
+    }
+  }
+}

--- a/tests/utils/create_lock.js
+++ b/tests/utils/create_lock.js
@@ -1,0 +1,48 @@
+/**
+ * Create Object allowing to create a "lock" which can be `await`ed, alongside
+ * `unlock`/`lock` functions allowing respectively to resolve the awaited
+ * promise or to create a new one.
+ *
+ * Optionally, a value can be given to `unlock` which will be communicated
+ * through the `Promise` returned by `awaitCurrentLock` as it resolves.
+ *
+ * @example
+ * ```js
+ * const lock = createLock();
+ * lock.awaitCurrentLock().then(() => console.log("DONE 1"));
+ *
+ * // Lead to a logged `"DONE 1"` (asynchronous after this call, Promise
+ * // resolution is always in a microtask)
+ * lock.unlock();
+ *
+ * // `"DONE 2"` will be logged (still asynchronously) as the lock is already
+ * // "unlocked"
+ * lock.awaitCurrentLock().then(() => console.log("DONE 2"));
+ *
+ * // Reset the lock, already-resolved Promise are not affected.
+ * lock.lock();
+ *
+ * // This one won't log until `unlock` is called again
+ * lock.awaitCurrentLock().then(() => console.log("DONE 3"));
+ * ```
+ * @returns {Object}
+ */
+export default function createLock() {
+  let unlockFn;
+  let waitForUnlock = new Promise((res) => {
+    unlockFn = res;
+  });
+  return {
+    awaitCurrentLock() {
+      return waitForUnlock;
+    },
+    unlock(val) {
+      unlockFn(val);
+    },
+    lock() {
+      waitForUnlock = new Promise((res) => {
+        unlockFn = res;
+      });
+    },
+  };
+}

--- a/tests/utils/is_null_or_undefined.js
+++ b/tests/utils/is_null_or_undefined.js
@@ -1,0 +1,11 @@
+/**
+ * Returns true if the argument given is either null or undefined.
+ * This function was added to have a clearer alternative to `== null` which is
+ * not always understood by newcomers to the code, and which can be overused when
+ * only one of the possibility can arise.
+ * @param {*} x
+ * @returns {boolean}
+ */
+export default function isNullOrUndefined(x) {
+  return x === null || x === undefined;
+}

--- a/tests/utils/sleep.js
+++ b/tests/utils/sleep.js
@@ -1,0 +1,14 @@
+/**
+ * Convert a setTimeout to a Promise.
+ *
+ * You can use it to have a much more readable blocking code with async/await
+ * in some asynchronous tests.
+ *
+ * @param {number} timeInMs
+ * @returns {Promise}
+ */
+export default function sleep(timeInMs) {
+  return new Promise((res) => {
+    setTimeout(res, timeInMs);
+  });
+}

--- a/tests/utils/try_test_multiple_times.js
+++ b/tests/utils/try_test_multiple_times.js
@@ -1,0 +1,51 @@
+/**
+ * Try the test behind the `runTest` callback which should return a
+ * resolving Promise when it succeed and should throw when it fails.
+ *
+ * This callback will also be given a callback in argument, `cancelTest`,
+ * that you can call when you want the test to be retried in cases of
+ * failure (you can call it right away if you want to retry the test if it
+ * fails in any case of failure.
+ *
+ * @param {Function} runTest - The test itself, returning a Promise which
+ * resolves when the test passes and reject if the test thrown.
+ * This function is also given a callback in argument which SHOULD be called
+ * before failure if you may want to retry it.
+ * @param {number} maxAttempts - The maximum number of attempts to run the
+ * test behind the `runTest` function. Once this number of attemps is
+ * reached, tests will be stopped in any case.
+ * @param {Function|undefined} cleanUp - If set, this callback will be
+ * called immediately after the Promise returned by `runTest` resolves or
+ * rejects.
+ * @returns {Promise} - Returns the same Promise than the last test
+ * performed by this function.
+ */
+export default async function tryTestMultipleTimes(
+  runTest,
+  maxAttempts,
+  cleanUp,
+) {
+  let attemptNb = 0;
+  return await reCheck();
+
+  async function reCheck() {
+    let stopCondition = false;
+    try {
+      const res = await runTest(() => {
+        stopCondition = true;
+      });
+      if (cleanUp !== undefined) {
+        cleanUp();
+      }
+      return res;
+    } catch (err) {
+      if (cleanUp !== undefined) {
+        cleanUp();
+      }
+      if (stopCondition && ++attemptNb <= maxAttempts) {
+        return await reCheck();
+      }
+      throw err;
+    }
+  }
+}

--- a/tests/utils/waitForPlayerState.js
+++ b/tests/utils/waitForPlayerState.js
@@ -1,0 +1,50 @@
+/**
+ * Wait for the "Loaded" state just after ``load`` is called.
+ * Reject if the state is neither "Loading" nor "Loaded".
+ * @param {WaspHlsPlayer} player
+ * @returns {Promise}
+ */
+export async function waitForLoadedStateAfterLoad(player) {
+  try {
+    await waitForState(player, "Loaded", ["Loading"]);
+  } catch (err) {
+    if (player.getPlayerState() !== "Stopped") {
+      return;
+    }
+    const playerError = player.getError();
+    if (playerError !== null) {
+      throw playerError;
+    }
+  }
+}
+
+/**
+ * Wait for the given state on the player.
+ *
+ * If a whitelist is set, reject if the state is not in it. You do not have to
+ * put the wanted state in that list.
+ * @param {WaspHlsPlayer} player
+ * @param {string} state
+ * @param {Array.<string>} [whitelist]
+ * @returns {Promise}
+ */
+export default function waitForState(player, wantedState, whitelist) {
+  return new Promise((resolve, reject) => {
+    function onPlayerStateChange(state) {
+      if (wantedState === state) {
+        player.removeEventListener("playerStateChange", onPlayerStateChange);
+        resolve();
+      } else if (whitelist && !whitelist.includes(state)) {
+        if (state === "Stopped") {
+          const playerError = player.getError();
+          if (playerError !== null) {
+            reject(playerError);
+            return;
+          }
+        }
+        reject(new Error("invalid state: " + state));
+      }
+    }
+    player.addEventListener("playerStateChange", onPlayerStateChange);
+  });
+}


### PR DESCRIPTION
I'm planning to make some evolution on this project after a long break.

To ensure I'm not breaking anything, a layer of integration tests would be nice.

I base myself on the same strategies that worked with other players I work on:

- I plan to write many integration tests relying on actual contents.

  Some created at test-time with the `shaka-packager`, others static projects embedded in the project (with tricks to heavily reduce storage space, like just using one segment and modifying its container at request time with the right timestamps)

- The player already has a few unit tests, but I'll for now mainly focus on integration tests, which just interface with the player through its public API. Their ratio `issues they catch / time to write it` has historically been much higher than other kinds

- I had some experience with this with other players, and it basically does not deviate much in principle (we're trying to load a content, calling a few API and look at the effect on playback, requests etc.) so I may have a good base quickly (or not, we'll see!).

The main issue I'm thinking of right now is that the in-worker nature may prevent us from being able to mock / spy on core matters such as network requests, MSE-in-Worker etc.
I'll have to find a solution here, perhaps a whole API dedicated to allow worker-side code injection, which is what we did end up doing with the RxPlayer which had similar constraints (though it was done there for another reasons, the test advantage was a bonus).

In the meantime though I could still do a few pertinent tests without that granularity into what goes on.