### PR TITLE
[WIP] Handle top-level media playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Features
 
+- It is now possible to play media playlists directly instead of always going through a multivariant playlist URL
 - Add parsing of `#EXT-X-DEFINE` tags
+- Add `NotAPlaylist` error code: a new `WaspOtherError` for when the given resource URL does not seem to be a valid HLS playlist URL
 - Add `MultivariantPlaylistVariableDefinitionError` and `MediaPlaylistVariableDefinitionError` error codes for when an `#EXT-X-DEFINE` tag or usage is not compliant to the HLS specification respectively on the MultiVariant Playlist or the Media Playlist.
 - Add `SourceBufferEmptyMimeType`, `SourceBufferMediaSourceIsClosed`, `SourceBufferNoMediaSourceAttached` and `SourceBufferQuotaExceededError` error codes on a `WaspSourceBufferCreationError` error type.
 - Add optional `bitDepth` and `sampleRate` properties to `getAudioTrackList`, `getCurrentAudioTrack`methods plus `audioTrackUpdate` and `audioTrackListUpdate` events reflecting respectively the bit depth of audio samples and the audio audio sample rate for the corresponding audio tracks if they're invariant for all renditions of that track.

--- a/README.md
+++ b/README.md
@@ -195,8 +195,9 @@ It already has a lot of features but there's still some left work:
 
 Type of contents:
 
-- [x] Play HLS VoD contents
-- [x] Play HLS live contents
+- [x] Support MultiVariant playlists
+- [x] Support media playlist URL directly
+- [x] Play HLS VoD/Live/Event contents
 - [ ] Proper support of HLS low-latency contents.
       _Priority: average_
 
@@ -251,6 +252,7 @@ Media demuxing:
 - [x] Transmux MPEG-2 Transport Streams to fmp4 on platforms not supporting the
       former like mostChrome or Firefox (through JS for now, Rust implementation
       pending).
+- [x] Infer mime-type and codec from container if missing from playlist (only for direct media playlist for now - not when a multivariant playlist is present but has missing information).
 - [ ] WebAssembly-based mpeg2-ts transmuxer.
       _Priority: average_
 - [ ] Media Segment Format: Packed Audio MP3

--- a/doc/API/Audio_Track_Selection/getAudioTrackList.md
+++ b/doc/API/Audio_Track_Selection/getAudioTrackList.md
@@ -4,11 +4,15 @@
 
 Returns the list of available "audio tracks" for the currently loaded content.
 
-Audio tracks are one or multiple renditions (e.g. when there's multiple audio
-qualities) associated to a given set of characteristics: a language,
-accessibility concepts etc..
+Audio tracks group one or more renditions sharing the same characteristics:
+language, accessibility role, etc. Multiple renditions may exist under one track
+when, for example, several audio quality levels are available.
 
-This method will returns an array of objects, each object containing the
+These correspond to distinctly selectable tracks, not just to the presence of
+audio samples in the content: muxed media playlists containing video and audio
+combined will generally not be exposed as a separate audio track.
+
+This method will return an array of objects, each object containing the
 information available for a particular audio track.
 
 Each of those objects should contain the following keys (same than for the
@@ -23,8 +27,8 @@ Each of those objects should contain the following keys (same than for the
 
   `undefined` if unknown or if there's no language involved.
 
-- `assocLanguage` (`string | undefined`): A secondary language associated to the
-  audio track, as a [language tag](https://datatracker.ietf.org/doc/html/rfc5646).
+- `assocLanguage` (`string | undefined`): A secondary language associated with
+  the audio track, as a [language tag](https://datatracker.ietf.org/doc/html/rfc5646).
   Such language is often used in a different role than the language specified
   through the `language` property (e.g., written versus spoken, or a fallback
   dialect).

--- a/doc/API/Audio_Track_Selection/getCurrentAudioTrack.md
+++ b/doc/API/Audio_Track_Selection/getCurrentAudioTrack.md
@@ -6,6 +6,10 @@ Returns the information on the currently loaded audio track.
 Returns `undefined` if unknown, if no content is loaded or if the content
 has no audio track.
 
+Note that an audio track is only declared through this API if it is distinctly
+selectable. If you currently rely on a muxed media playlists containing video
+and audio combined, it generally will return `undefined`.
+
 When set, the returned object has the following properties (same than for a
 `getAudioTrackList` call):
 

--- a/doc/API/Basic_Methods/load.md
+++ b/doc/API/Basic_Methods/load.md
@@ -18,8 +18,9 @@ player.load(url, {
 ```
 
 - **arguments**:
-  1. _url_ `string`: Url to the Multivariant Playlist of the content you want to
+  1. _url_ `string`: Url to the top-level playlist of the content you want to
      play.
+     That playlist can be either a Multivariant Playlist or a Media Playlist.
 
   2. _options_ `Object`: Optional argument to configure how the content will be
      loaded.

--- a/doc/API/Loading_a_content.md
+++ b/doc/API/Loading_a_content.md
@@ -6,17 +6,17 @@ Loading a content through the `WaspHlsPlayer` can only be done once it has been
 [instantiated](./Instantiation.md) and once [`initialize`](./Initialization.md)
 has been called (it is not necessary to await the returned Promise).
 
-This is the step where the URL of the Multivariant Playlist (before known as the
-"Master Playlist") is provided to the `WaspHlsPlayer`, that takes care of media
-playback.
+This is the step where the URL of the top-level playlist is provided to the
+`WaspHlsPlayer`, that takes care of media playback.
+That top-level playlist can be either a Multivariant Playlist (before known as
+the "Master Playlist") or a Media Playlist directly.
 
 That step is done through the `load` method, through a very straightforward
 call:
 
 ```js
-// Here `MultivariantPlaylistUrl` is the HTTP(S) URL to the Multivariant
-// Playlist
-player.load(MultivariantPlaylistUrl);
+// Here `playlistUrl` is the HTTP(S) URL to the top-level playlist.
+player.load(playlistUrl);
 ```
 
 You can then be notified of where the load operation is at (whether it is still

--- a/doc/API/Player_Errors.md
+++ b/doc/API/Player_Errors.md
@@ -494,5 +494,8 @@ values:
 - `"UnfoundLockedVariant"`:
   The variant locked through the `lockVariant` API was not found.
 
+- `"NotAPlaylist"`:
+  The loaded resource does not seem to be an HLS playlist.
+
 - `"Unknown"`:
   An unknown error arised.

--- a/doc/API/Player_Errors.md
+++ b/doc/API/Player_Errors.md
@@ -472,7 +472,7 @@ Its `name` property is set to `"WaspOtherError"`:
 
 ```js
 player.addEventlistener("error", (error) => {
-  if (error.name === "WaspSourceBufferCreationError") {
+  if (error.name === "WaspOtherError") {
     // An uncategorized error happened
   }
 });
@@ -480,7 +480,7 @@ player.addEventlistener("error", (error) => {
 
 ### Error codes
 
-A `WaspSegmentParsingError`'s `code` property can be set to any of the following
+A `WaspOtherError`'s `code` property can be set to any of the following
 values:
 
 - `"MediaSourceAttachmentError"`:
@@ -488,7 +488,8 @@ values:
   to attach it to the `MediaSource` HTMLMediaElement.
 
 - `"NoSupportedVariant"`:
-  No supported variant was found in the Multivariant Playlist.
+  No supported startup stream was found for the current content.
+  This is generally due to insufficient codec support on the current platform.
 
 - `"UnfoundLockedVariant"`:
   The variant locked through the `lockVariant` API was not found.

--- a/doc/API/Player_Events.md
+++ b/doc/API/Player_Events.md
@@ -419,10 +419,13 @@ You can also know at any time the list of available variants by calling the
 The `"audioTrackUpdate` event is sent when the currently-loaded audio track has
 changed.
 
-Note that what we call "audio track" here may actually be a set of multiple
-audio qualities (generally dispatched in various variants) all with the same
-characteristics (same language, same name, same accessibility, same number of
-channels etc.).
+Audio tracks group one or more renditions sharing the same characteristics:
+language, accessibility role, etc. Multiple renditions may exist under one track
+when, for example, several audio quality levels are available.
+
+These correspond to distinctly selectable tracks, not just to the presence of
+audio samples in the content: muxed media playlists containing video and audio
+combined will generally not be exposed as a separate audio track.
 
 The payload of that event contains the information available on that audio track
 if known, or `undefined` either if the characteristics of the audio track is
@@ -479,6 +482,10 @@ method.
 
 The `"audioTrackListUpdate` event is sent when the list of available audio
 tracks has changed.
+
+Only selectable audio tracks are listed through that event. Muxed media
+playlists containing video and audio combined will not generally lead to an
+audio track being exposed through this API
 
 The payload of that event contains an array object, each object containing the
 information available for a particular audio track.

--- a/doc/Getting_Started/Welcome.md
+++ b/doc/Getting_Started/Welcome.md
@@ -50,11 +50,12 @@ player
   .catch((err) => {
     console.error("Could not initialize WaspHlsPlayer:", err);
   });
-player.load(HLS_MULTIVARIANT_PLAYLIST_URL);
+player.load(HLS_PLAYLIST_URL);
 ```
 
-Where `HLS_MULTIVARIANT_PLAYLIST_URL` is the URL to the main playlist (called
-either the Multivariant Playlist or the Master Playlist) of your HLS content.
+Where `HLS_PLAYLIST_URL` is the URL to the top-level playlist of your HLS
+content, whether that is a Multivariant Playlist (also called Master Playlist)
+or a Media Playlist directly.
 
 Of course, once `initialize` has succeeded, you can play any HLS content you
 want on that `WaspHlsPlayer` instance.

--- a/src/rs-core/bindings/abi_types.rs
+++ b/src/rs-core/bindings/abi_types.rs
@@ -24,7 +24,8 @@ pub enum OtherErrorCode {
     NoSupportedVariant = 0,
     UnfoundLockedVariant = 1,
     MediaSourceAttachmentError = 2,
-    Unknown = 3,
+    NotAPlaylist = 3,
+    Unknown = 4,
 }
 
 impl OtherErrorCode {
@@ -33,7 +34,8 @@ impl OtherErrorCode {
             0 => Self::NoSupportedVariant,
             1 => Self::UnfoundLockedVariant,
             2 => Self::MediaSourceAttachmentError,
-            3 => Self::Unknown,
+            3 => Self::NotAPlaylist,
+            4 => Self::Unknown,
             _ => Self::Unknown,
         }
     }

--- a/src/rs-core/bindings/formatters.rs
+++ b/src/rs-core/bindings/formatters.rs
@@ -4,6 +4,9 @@ use crate::{
 };
 
 static NULL_RESOLUTION: VideoResolution = VideoResolution::new(0, 0);
+pub(crate) const DIRECT_MEDIA_VARIANT_ID: u32 = 0;
+pub(crate) const DIRECT_MEDIA_AUDIO_TRACK_ID: u32 = 0;
+static DIRECT_MEDIA_TRACK_NAME: &str = "main";
 
 pub(crate) unsafe fn format_variants_info_for_js(variants: &[&VariantStream]) -> Vec<u32> {
     let mut ret: Vec<u32> = vec![];
@@ -24,6 +27,19 @@ pub(crate) unsafe fn format_variants_info_for_js(variants: &[&VariantStream]) ->
         ret.push(video_range.as_ptr() as u32);
     });
     ret
+}
+
+pub(crate) unsafe fn format_direct_media_variants_info_for_js() -> Vec<u32> {
+    vec![
+        1,
+        DIRECT_MEDIA_VARIANT_ID,
+        0,
+        0,
+        0,
+        0,
+        0,
+        "".as_ptr() as u32,
+    ]
 }
 
 pub(crate) fn format_range_for_js(original: Option<&ByteRange>) -> (Option<usize>, Option<usize>) {
@@ -111,5 +127,29 @@ pub(crate) unsafe fn format_audio_tracks_for_js(tracks: &[AudioTrack]) -> Vec<u3
             .iter()
             .for_each(|sample_rate| ret.push(*sample_rate));
     });
+    ret
+}
+
+pub(crate) unsafe fn format_direct_media_audio_tracks_for_js(has_audio_track: bool) -> Vec<u32> {
+    let mut ret: Vec<u32> = vec![];
+    ret.push(if has_audio_track { 1 } else { 0 });
+    if has_audio_track {
+        ret.push(DIRECT_MEDIA_AUDIO_TRACK_ID);
+
+        ret.push(0);
+        ret.push("".as_ptr() as u32);
+
+        ret.push(0);
+        ret.push("".as_ptr() as u32);
+
+        ret.push(DIRECT_MEDIA_TRACK_NAME.len() as u32);
+        ret.push(DIRECT_MEDIA_TRACK_NAME.as_ptr() as u32);
+
+        ret.push(0);
+        ret.push(0);
+        ret.push(0);
+        ret.push(0);
+        ret.push(0);
+    }
     ret
 }

--- a/src/rs-core/bindings/js_functions.rs
+++ b/src/rs-core/bindings/js_functions.rs
@@ -65,8 +65,9 @@ unsafe extern "C" {
     fn __js_func__is_type_supported(media_type: u32, typ_ptr: *const u8, typ_len: u32) -> i32;
     fn __js_func__inspect_segment(
         segment_id: ResourceId,
-        mime_type_ptr: *const u8,
-        mime_type_len: u32,
+        media_type_out: *mut u32,
+        parsed_mime_type_ptr_out: *mut u32,
+        parsed_mime_type_len_out: *mut u32,
         codec_ptr_out: *mut u32,
         codec_len_out: *mut u32,
         err_code_out: *mut u32,
@@ -452,13 +453,12 @@ pub fn jsIsTypeSupported(media_type: MediaType, typ: &str) -> Option<bool> {
 
 /// Recuperate more information on a segment, identified by its `ResourceId`.
 ///
-/// This can generally be relied on to e.g. obtain the `codec` directly from
-/// segment metadata.
+/// This can generally be relied on to e.g. obtain the `codec` and mime-type
+/// directly from segment metadata.
 ///
 /// # Arguments
 ///
 /// * `segment_id` - `ResourceId` of the segment you want more metadata from
-/// * `mime_type` - The identified `mime-type` of this segment.
 ///
 /// # Returns
 ///
@@ -469,16 +469,19 @@ pub fn jsIsTypeSupported(media_type: MediaType, typ: &str) -> Option<bool> {
 ///   and an optional description as a `String`.
 pub fn jsInspectSegment(
     segment_id: ResourceId,
-    mime_type: &str,
 ) -> Result<InspectedSegmentMetadata, (SegmentParsingErrorCode, Option<String>)> {
+    let mut media_type = 0;
+    let mut parsed_mime_type_ptr = 0;
+    let mut parsed_mime_type_len = 0;
     let mut codec_ptr = 0;
     let mut codec_len = 0;
     let mut out = JsErrorOut::default();
     let success = unsafe {
         __js_func__inspect_segment(
             segment_id,
-            mime_type.as_ptr(),
-            mime_type.len() as u32,
+            &mut media_type,
+            &mut parsed_mime_type_ptr,
+            &mut parsed_mime_type_len,
             &mut codec_ptr,
             &mut codec_len,
             &mut out.code,
@@ -490,6 +493,8 @@ pub fn jsInspectSegment(
         return Err(take_js_error_out(out, SegmentParsingErrorCode::from_raw));
     }
     Ok(InspectedSegmentMetadata {
+        media_type: MediaType::from_raw(media_type),
+        mime_type: owned_string_from_abi(parsed_mime_type_ptr, parsed_mime_type_len),
         codec: owned_string_from_abi(codec_ptr, codec_len),
     })
 }
@@ -974,6 +979,10 @@ pub struct ParsedSegmentInfo {
 
 /// Result of a segment inspection (e.g. when calling `jsInspectSegment`)
 pub struct InspectedSegmentMetadata {
+    /// The container-level mime-type inferred from the segment's metadata itself.
+    pub mime_type: String,
+    /// The media type associated to the inspected segment.
+    pub media_type: MediaType,
     /// The identified codec string from the segment's metadata itself.
     /// e.g. `mp4a.40.2` or `avc1.4D401F` etc.
     pub codec: String,

--- a/src/rs-core/bindings/js_functions.rs
+++ b/src/rs-core/bindings/js_functions.rs
@@ -63,6 +63,16 @@ unsafe extern "C" {
         err_desc_len_out: *mut u32,
     ) -> u32;
     fn __js_func__is_type_supported(media_type: u32, typ_ptr: *const u8, typ_len: u32) -> i32;
+    fn __js_func__inspect_segment(
+        segment_id: ResourceId,
+        mime_type_ptr: *const u8,
+        mime_type_len: u32,
+        codec_ptr_out: *mut u32,
+        codec_len_out: *mut u32,
+        err_code_out: *mut u32,
+        err_desc_ptr_out: *mut u32,
+        err_desc_len_out: *mut u32,
+    ) -> u32;
     fn __js_func__append_buffer(
         source_buffer_id: SourceBufferId,
         segment_id: ResourceId,
@@ -438,6 +448,50 @@ pub fn jsIsTypeSupported(media_type: MediaType, typ: &str) -> Option<bool> {
         0 => Some(false),
         _ => Some(true),
     }
+}
+
+/// Recuperate more information on a segment, identified by its `ResourceId`.
+///
+/// This can generally be relied on to e.g. obtain the `codec` directly from
+/// segment metadata.
+///
+/// # Arguments
+///
+/// * `segment_id` - `ResourceId` of the segment you want more metadata from
+/// * `mime_type` - The identified `mime-type` of this segment.
+///
+/// # Returns
+///
+/// A result:
+///
+/// - When `Ok`, transports the parsed metadata from the segment
+/// - When `Err`, transports both the error code that prevented the inspection,
+///   and an optional description as a `String`.
+pub fn jsInspectSegment(
+    segment_id: ResourceId,
+    mime_type: &str,
+) -> Result<InspectedSegmentMetadata, (SegmentParsingErrorCode, Option<String>)> {
+    let mut codec_ptr = 0;
+    let mut codec_len = 0;
+    let mut out = JsErrorOut::default();
+    let success = unsafe {
+        __js_func__inspect_segment(
+            segment_id,
+            mime_type.as_ptr(),
+            mime_type.len() as u32,
+            &mut codec_ptr,
+            &mut codec_len,
+            &mut out.code,
+            &mut out.desc_ptr,
+            &mut out.desc_len,
+        )
+    };
+    if success == 0 {
+        return Err(take_js_error_out(out, SegmentParsingErrorCode::from_raw));
+    }
+    Ok(InspectedSegmentMetadata {
+        codec: owned_string_from_abi(codec_ptr, codec_len),
+    })
 }
 
 /// Append media data to the given SourceBuffer.
@@ -916,6 +970,13 @@ impl From<MediaPlaylistParsingError> for MediaPlaylistParsingErrorCode {
 pub struct ParsedSegmentInfo {
     pub start: Option<f64>,
     pub duration: Option<f64>,
+}
+
+/// Result of a segment inspection (e.g. when calling `jsInspectSegment`)
+pub struct InspectedSegmentMetadata {
+    /// The identified codec string from the segment's metadata itself.
+    /// e.g. `mp4a.40.2` or `avc1.4D401F` etc.
+    pub codec: String,
 }
 
 impl From<PushSegmentError> for SegmentParsingErrorCode {

--- a/src/rs-core/bindings/js_functions.rs
+++ b/src/rs-core/bindings/js_functions.rs
@@ -736,7 +736,7 @@ pub fn jsSendSegmentRequestError(
     url: &str,
     is_init: bool,
     time_info: Option<(f64, f64)>,
-    media_type: MediaType,
+    media_type: Option<MediaType>,
     reason: RequestErrorReason,
     status: Option<u32>,
 ) {
@@ -748,7 +748,7 @@ pub fn jsSendSegmentRequestError(
             url.as_ptr(),
             url.len() as u32,
             bool_to_raw(is_init),
-            media_type as u32,
+            opt_u32_to_raw(media_type.map(|m| m as u32)),
             opt_f64_to_raw_ptr(start),
             opt_f64_to_raw_ptr(duration),
             reason as u32,
@@ -851,14 +851,14 @@ pub fn jsSendMediaPlaylistParsingError(
 pub fn jsSendSegmentParsingError(
     fatal: bool,
     code: SegmentParsingErrorCode,
-    media_type: MediaType,
+    media_type: Option<MediaType>,
     message: &str,
 ) {
     unsafe {
         __js_func__send_segment_parsing_error(
             bool_to_raw(fatal),
             code as u32,
-            media_type as u32,
+            opt_u32_to_raw(media_type.map(|m| m as u32)),
             message.as_ptr(),
             message.len() as u32,
         )

--- a/src/rs-core/bindings/js_functions.rs
+++ b/src/rs-core/bindings/js_functions.rs
@@ -3,9 +3,9 @@
 use super::{
     AddSourceBufferErrorCode, AttachMediaSourceErrorCode, EndOfStreamErrorCode, LogLevel,
     MediaPlaylistParsingErrorCode, MediaSourceDurationUpdateErrorCode, MediaType,
-    MultivariantPlaylistParsingErrorCode, OtherErrorCode, PlaylistNature, PushedSegmentErrorCode,
-    RemoveBufferErrorCode, RemoveMediaSourceErrorCode, RequestErrorReason, SegmentParsingErrorCode,
-    SourceBufferCreationErrorCode, TimerReason,
+    MultivariantPlaylistParsingErrorCode, OtherErrorCode, PlaylistNature, PlaylistType,
+    PushedSegmentErrorCode, RemoveBufferErrorCode, RemoveMediaSourceErrorCode, RequestErrorReason,
+    SegmentParsingErrorCode, SourceBufferCreationErrorCode, TimerReason,
 };
 use crate::{
     media_element::PushSegmentError,
@@ -103,6 +103,7 @@ unsafe extern "C" {
         playlist_nat: u32,
     );
     fn __js_func__announce_fetched_content(
+        playlist_type: u32,
         variant_info_ptr: *const u32,
         variant_info_len: u32,
         audio_tracks_info_ptr: *const u32,
@@ -623,9 +624,14 @@ pub fn jsUpdateContentInfo(
     }
 }
 
-pub fn jsAnnounceFetchedContent(variant_info: Vec<u32>, audio_tracks_info: Vec<u32>) {
+pub fn jsAnnounceFetchedContent(
+    playlist_type: PlaylistType,
+    variant_info: Vec<u32>,
+    audio_tracks_info: Vec<u32>,
+) {
     unsafe {
         __js_func__announce_fetched_content(
+            playlist_type as u32,
             variant_info.as_ptr(),
             variant_info.len() as u32,
             audio_tracks_info.as_ptr(),
@@ -768,14 +774,14 @@ pub fn jsSendMultivariantPlaylistParsingError(
 pub fn jsSendMediaPlaylistParsingError(
     fatal: bool,
     code: MediaPlaylistParsingErrorCode,
-    media_type: MediaType,
+    media_type: Option<MediaType>,
     message: &str,
 ) {
     unsafe {
         __js_func__send_media_playlist_parsing_error(
             bool_to_raw(fatal),
             code as u32,
-            media_type as u32,
+            opt_u32_to_raw(media_type.map(|m| m as u32)),
             message.as_ptr(),
             message.len() as u32,
         )
@@ -898,6 +904,12 @@ impl From<MediaPlaylistUpdateError> for MediaPlaylistParsingErrorCode {
             ) => MediaPlaylistParsingErrorCode::VariableDefinitionError,
             MediaPlaylistUpdateError::NotFound => MediaPlaylistParsingErrorCode::Unknown,
         }
+    }
+}
+
+impl From<MediaPlaylistParsingError> for MediaPlaylistParsingErrorCode {
+    fn from(value: MediaPlaylistParsingError) -> Self {
+        MediaPlaylistUpdateError::ParsingError(value).into()
     }
 }
 

--- a/src/rs-core/dispatcher/api/mod.rs
+++ b/src/rs-core/dispatcher/api/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     adaptive::AdaptiveQualitySelector,
     bindings::{jsSendOtherError, OtherErrorCode},
+    dispatcher::segment_action_tracker::SegmentActionTracker,
     media_element::MediaElementReference,
     requester::{PlaylistFileType, Requester},
     segment_selector::NextSegmentSelectors,
@@ -29,8 +30,9 @@ impl Dispatcher {
             last_position: 0.,
             buffer_goal: 30.,
             segment_selectors: NextSegmentSelectors::new(0., 30.),
+            segment_action_tracker: SegmentActionTracker::new(),
             playlist_refresh_timers: vec![],
-            direct_media_probe: None,
+            ready_probe_segment: None,
         }
     }
 

--- a/src/rs-core/dispatcher/api/mod.rs
+++ b/src/rs-core/dispatcher/api/mod.rs
@@ -42,7 +42,7 @@ impl Dispatcher {
         };
         let content_url = Url::new(content_url);
         self.requester
-            .fetch_playlist(content_url, PlaylistFileType::MultivariantPlaylist);
+            .fetch_playlist(content_url, PlaylistFileType::TopLevelPlaylist);
         Logger::info("Attaching MediaSource");
         if let Err(x) = self.media_element_ref.attach_media_source() {
             jsSendOtherError(

--- a/src/rs-core/dispatcher/api/mod.rs
+++ b/src/rs-core/dispatcher/api/mod.rs
@@ -30,6 +30,7 @@ impl Dispatcher {
             buffer_goal: 30.,
             segment_selectors: NextSegmentSelectors::new(0., 30.),
             playlist_refresh_timers: vec![],
+            direct_media_probe: None,
         }
     }
 

--- a/src/rs-core/dispatcher/api/mod.rs
+++ b/src/rs-core/dispatcher/api/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     adaptive::AdaptiveQualitySelector,
     bindings::{jsSendOtherError, OtherErrorCode},
-    dispatcher::segment_action_tracker::SegmentActionTracker,
+    dispatcher::{segment_request_contexts::SegmentRequestContexts, PlaylistRefreshTimers},
     media_element::MediaElementReference,
     requester::{PlaylistFileType, Requester},
     segment_selector::NextSegmentSelectors,
@@ -30,8 +30,8 @@ impl Dispatcher {
             last_position: 0.,
             buffer_goal: 30.,
             segment_selectors: NextSegmentSelectors::new(0., 30.),
-            segment_action_tracker: SegmentActionTracker::new(),
-            playlist_refresh_timers: vec![],
+            segment_request_contexts: SegmentRequestContexts::new(),
+            playlist_refresh_timers: PlaylistRefreshTimers::new(),
             ready_probe_segment: None,
         }
     }
@@ -40,7 +40,7 @@ impl Dispatcher {
     pub fn load_content(&mut self, content_url: String, starting_pos: Option<StartingPosition>) {
         Logger::info("load_content called");
         self.stop();
-        self.ready_state = PlayerReadyState::Loading {
+        self.ready_state = PlayerReadyState::AwaitingPlaylistInfo {
             starting_position: starting_pos,
         };
         let content_url = Url::new(content_url);

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -15,11 +15,11 @@ use crate::{
         jsSendRemoveBufferError, jsSendSegmentParsingError, jsSendSegmentRequestError,
         jsSendSourceBufferCreationError, jsSetMediaSourceDuration, jsStartObservingPlayback,
         jsStopObservingPlayback, jsTimer, jsUpdateContentInfo, AddSourceBufferErrorCode, MediaType,
-        MultivariantPlaylistParsingErrorCode, OtherErrorCode, PlaylistNature,
+        MultivariantPlaylistParsingErrorCode, OtherErrorCode, PlaylistNature, PlaylistType,
         PushedSegmentErrorCode, RequestId, SourceBufferId, TimerId, TimerReason,
     },
     media_element::{SegmentQualityContext, SourceBufferCreationError},
-    parser::{MultivariantPlaylist, SegmentTimeInfo},
+    parser::{SegmentTimeInfo, TopLevelPlaylist, TopLevelPlaylistParsingError},
     playlist_store::{
         LockVariantResponse, MediaPlaylistPermanentId, PlaylistStore, PlaylistStoreError,
         SetAudioTrackResponse, VariantUpdateResult,
@@ -116,7 +116,7 @@ impl Dispatcher {
             let (_, playlist_type) = self.playlist_refresh_timers.remove(idx);
             if let Some(playlist_store) = &self.playlist_store {
                 match playlist_type {
-                    PlaylistFileType::MultivariantPlaylist => self
+                    PlaylistFileType::TopLevelPlaylist => self
                         .requester
                         .fetch_playlist(playlist_store.url().clone(), playlist_type),
                     PlaylistFileType::MediaPlaylist { ref id, .. } => {
@@ -222,7 +222,7 @@ impl Dispatcher {
                             status,
                         );
                     }
-                    PlaylistFileType::MultivariantPlaylist => {
+                    PlaylistFileType::TopLevelPlaylist => {
                         jsSendMultivariantPlaylistRequestError(
                             true,
                             x.url.get_ref(),
@@ -255,7 +255,7 @@ impl Dispatcher {
                 reason,
                 status,
             } => match request_info.playlist_type {
-                PlaylistFileType::MultivariantPlaylist => jsSendMultivariantPlaylistRequestError(
+                PlaylistFileType::TopLevelPlaylist => jsSendMultivariantPlaylistRequestError(
                     false,
                     request_info.url.get_ref(),
                     reason,
@@ -418,7 +418,8 @@ impl Dispatcher {
 
     /// Method to call when a new codec support report has been received.
     pub(super) fn on_codecs_support_update_core(&mut self) {
-        self.check_ready_to_load_media_playlists();
+        // XXX TODO: name bad
+        self.check_ready_after_top_level_playlist_loaded();
     }
 
     /// For each media type, check if segment need to be requested, and if that's the case, perform
@@ -526,26 +527,33 @@ impl Dispatcher {
         if let PlaylistFileType::MediaPlaylist { id, media_type } = playlist_type {
             self.on_media_playlist_loaded(id, result, media_type, final_url);
         } else {
-            self.on_multivariant_playlist_loaded(result, final_url);
+            self.on_top_level_playlist_loaded(result, final_url);
         }
     }
 
-    /// Method called once a Multivariant Playlist was loaded with success, with its response data
+    /// Method called once the top-level Playlist was loaded with success, with its response data
     /// and url as argument.
-    fn on_multivariant_playlist_loaded(&mut self, data: Vec<u8>, playlist_url: Url) {
-        match MultivariantPlaylist::parse(data.as_ref(), playlist_url) {
-            Err(e) => {
-                let message = e.to_string();
-                jsSendMultivariantPlaylistParsingError(true, e.into(), &message);
+    fn on_top_level_playlist_loaded(&mut self, data: Vec<u8>, playlist_url: Url) {
+        match TopLevelPlaylist::parse(data.as_ref(), playlist_url) {
+            Err(err) => {
+                let message = err.to_string();
+                match err {
+                    TopLevelPlaylistParsingError::Multivariant(err) => {
+                        jsSendMultivariantPlaylistParsingError(true, err.into(), &message);
+                    }
+                    TopLevelPlaylistParsingError::Media(err) => {
+                        jsSendMediaPlaylistParsingError(true, err.into(), None, &message);
+                    }
+                }
                 self.stop_current_content();
             }
             Ok(pl) => {
-                Logger::info("Core: Multivariant Playlist parsed successfully");
+                Logger::info("Core: Top-level playlist parsed successfully");
                 let estimate = self.adaptive_selector.get_estimate();
                 match PlaylistStore::try_new(pl, estimate) {
                     Ok(pl_store) => {
                         self.playlist_store = Some(pl_store);
-                        self.check_ready_to_load_media_playlists();
+                        self.check_ready_after_top_level_playlist_loaded();
                     }
                     Err(err) => {
                         match err {
@@ -584,7 +592,7 @@ impl Dispatcher {
             match playlist_store.update_media_playlist(&playlist_id, data.as_ref(), playlist_url) {
                 Err(e) => {
                     let err_message = e.to_string();
-                    jsSendMediaPlaylistParsingError(true, e.into(), media_type, &err_message);
+                    jsSendMediaPlaylistParsingError(true, e.into(), Some(media_type), &err_message);
                     self.stop_current_content();
                 }
                 Ok(p) => {
@@ -625,17 +633,17 @@ impl Dispatcher {
             jsSendOtherError(
                 true,
                 crate::bindings::OtherErrorCode::Unknown,
-                "Media playlist loaded but no MultivariantPlaylist",
+                "Media playlist loaded but no top-level playlist",
             );
             self.stop_current_content();
         }
     }
 
-    fn check_ready_to_load_media_playlists(&mut self) {
+    fn check_ready_after_top_level_playlist_loaded(&mut self) {
         let playlist_store = if let Some(playlist_store) = self.playlist_store.as_mut() {
             playlist_store
         } else {
-            // No PlaylistStore == no loaded Multivariant Playlist yet
+            // No PlaylistStore == no loaded top-level playlist yet
             return;
         };
 
@@ -661,7 +669,9 @@ impl Dispatcher {
             _ => {}
         }
 
-        if playlist_store.supported_variants().is_empty() {
+        if playlist_store.playlist_kind() == PlaylistType::MultivariantPlaylist
+            && playlist_store.supported_variants().is_empty()
+        {
             jsSendOtherError(
                 true,
                 crate::bindings::OtherErrorCode::NoSupportedVariant,
@@ -705,9 +715,20 @@ impl Dispatcher {
         } else {
             playlist_store.curr_audio_track_id()
         };
-        jsAnnounceFetchedContent(variants_info, audio_tracks_info);
-        jsAnnounceVariantUpdate(playlist_store.curr_variant().map(|v| v.id()));
-        jsAnnounceTrackUpdate(MediaType::Audio, curr_audio_track, is_selected);
+        jsAnnounceFetchedContent(
+            playlist_store.playlist_kind(),
+            variants_info,
+            audio_tracks_info,
+        );
+        // NOTE: We could also "invent" a variant id / audio track id from this point on?
+        if playlist_store.playlist_kind() == PlaylistType::MultivariantPlaylist {
+            jsAnnounceVariantUpdate(playlist_store.curr_variant().map(|v| v.id()));
+            jsAnnounceTrackUpdate(MediaType::Audio, curr_audio_track, is_selected);
+        }
+
+        if playlist_store.are_playlists_ready() {
+            self.check_ready_to_load_segments();
+        }
     }
 
     fn init_source_buffer(

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -1,7 +1,7 @@
 use super::{
     event_listeners::JsTimeRanges, DirectMediaProbeState, Dispatcher, JsMemoryBlob,
     MediaObservation, MediaSourceReadyState, PlaybackTickReason, PlayerReadyState,
-    ProbeSegmentContext, ProbeSegmentRequest, StartingPositionType,
+    StartingPositionType,
 };
 use crate::{
     bindings::{
@@ -20,15 +20,15 @@ use crate::{
         PushedSegmentErrorCode, RequestId, SourceBufferId, TimerId, TimerReason,
     },
     media_element::{SegmentQualityContext, SourceBufferCreationError},
-    parser::{
-        ProbeSegmentPayload, SegmentTimeInfo, TopLevelPlaylist, TopLevelPlaylistParsingError,
-    },
+    parser::{SegmentTimeInfo, TopLevelPlaylist, TopLevelPlaylistParsingError},
     playlist_store::{
         LockVariantResponse, MediaPlaylistPermanentId, PlaylistStore, PlaylistStoreError,
-        SetAudioTrackResponse, VariantUpdateResult,
+        ProbeSegmentContext, ProbeSegmentMetadata, SetAudioTrackResponse, StartupStatus,
+        VariantUpdateResult,
     },
     requester::{
-        FinishedRequestType, PlaylistFileType, PlaylistRequestInfo, RetryResult, SegmentRequestInfo,
+        FinishedRequestType, PlaylistFileType, PlaylistRequestInfo, RetryResult,
+        SegmentRequestContext, SegmentRequestInfo,
     },
     utils::url::Url,
     Logger,
@@ -425,8 +425,7 @@ impl Dispatcher {
 
     /// Method to call when a new codec support report has been received.
     pub(super) fn on_codecs_support_update_core(&mut self) {
-        // XXX TODO: Might need to rename that one
-        self.check_ready_after_top_level_playlist_loaded();
+        self.check_playlists_ready();
     }
 
     /// For each media type, check if segment need to be requested, and if that's the case, perform
@@ -448,91 +447,136 @@ impl Dispatcher {
         }
     }
 
-    /// If not enough information is known about the playlist (this happens when a Media
-    /// playlist was given directly instead of a multivariant playlist), we might want to
-    /// perform an initial request to a "probe segment" first, just to extract such
-    /// metadata from its container.
-    ///
-    /// This method allows to try kickstarting that probe process.
+    /// Start a startup probe request if not already in progress.
     ///
     /// # Returns
     ///
     /// Returns `true` if the probe process has been started, or `false` if we
     /// cannot do that.
-    fn try_probe_segment_request(&mut self) -> bool {
+    fn start_probe_segment_request(&mut self, probe_segment: ProbeSegmentMetadata) -> bool {
         if self.direct_media_probe.is_some() {
             return true; // probe already going on
         }
 
-        let Some(playlist_store) = self.playlist_store.as_ref() else {
-            return false; // No playlist associated to the content
-        };
-        let wanted_position = self.media_element_ref.wanted_position();
-        let Some(direct_media_playlist) = playlist_store.direct_media() else {
-            return false; // This is not a direct media playlist. Here the probe segment would be
-                          // ambiguous
-        };
-        let Some(probe_segment) = direct_media_playlist.probe_segment_for(wanted_position) else {
-            return false; // No segment available
-        };
-        let media_type = match (
-            playlist_store.has_media_type(MediaType::Audio),
-            playlist_store.has_media_type(MediaType::Video),
-        ) {
-            (true, false) => MediaType::Audio,
-            _ => MediaType::Video,
-        };
-
-        // We're not relying on a Multivariant Playlist, so no point of getting
-        // Adaptive metadata setup, just create a default one.
-        // XXX TODO: optional?
-        let probe_segment_context = SegmentQualityContext::new(0., 0);
-        let context = match probe_segment.payload {
-            ProbeSegmentPayload::Init => ProbeSegmentContext::InitSegment,
-            ProbeSegmentPayload::Media { time_info } => {
-                let context = probe_segment_context.clone();
-                ProbeSegmentContext::MediaSegment { time_info, context }
-            }
-        };
-        let request = ProbeSegmentRequest {
-            media_type,
-            url: probe_segment.url,
-            byte_range: probe_segment.byte_range,
-            context,
-        };
-
-        match &request.context {
-            ProbeSegmentContext::InitSegment => self.requester.request_init_segment(
-                request.media_type,
-                request.url.clone(),
-                request.byte_range.as_ref(),
-                probe_segment_context,
+        match &probe_segment.context {
+            ProbeSegmentContext::Init => self.requester.request_segment_unlocked(
+                MediaType::Video,
+                probe_segment.url.clone(),
+                probe_segment.byte_range.as_ref(),
+                None,
+                SegmentRequestContext::Probe,
             ),
-            ProbeSegmentContext::MediaSegment { time_info, context } => {
-                self.requester.request_probe_media_segment(
-                    request.media_type,
-                    request.url.clone(),
-                    request.byte_range.as_ref(),
-                    time_info.clone(),
-                    context.clone(),
-                )
-            }
+            ProbeSegmentContext::Media { time_info } => self.requester.request_segment_unlocked(
+                MediaType::Video,
+                probe_segment.url.clone(),
+                probe_segment.byte_range.as_ref(),
+                Some(time_info.clone()),
+                SegmentRequestContext::Probe,
+            ),
         }
-        self.direct_media_probe = Some(DirectMediaProbeState::Pending(request));
+        self.direct_media_probe = Some(DirectMediaProbeState::Pending(probe_segment));
         true
     }
 
-    // Returns `true` if all currently-chosen playlists have a known codec.
-    // If `false`, you may have to "probe" a segment first before knowing it.
-    fn are_codecs_known(&self) -> bool {
-        [MediaType::Audio, MediaType::Video]
-            .into_iter()
-            .all(|media_type| {
-                self.playlist_store
-                    .as_ref()
-                    .and_then(|playlist_store| playlist_store.current_codec(media_type))
-                    .is_some()
-            })
+    fn startup_wanted_position(&self, playlist_store: &PlaylistStore) -> f64 {
+        // XXX TODO: duplicated?
+        match self.ready_state {
+            PlayerReadyState::Loading {
+                ref starting_position,
+            } => {
+                if let Some(starting_pos) = starting_position {
+                    match starting_pos.start_type {
+                        StartingPositionType::Absolute => starting_pos.position,
+                        StartingPositionType::FromBeginning => {
+                            playlist_store.curr_min_position().unwrap_or(0.) + starting_pos.position
+                        }
+                        StartingPositionType::FromEnd => playlist_store
+                            .curr_max_position()
+                            .map(|max| max - starting_pos.position)
+                            .unwrap_or(playlist_store.expected_start_time()),
+                    }
+                } else {
+                    playlist_store.expected_start_time()
+                }
+            }
+            _ => self.media_element_ref.wanted_position(),
+        }
+    }
+
+    fn handle_playlist_store_error(&mut self, err: PlaylistStoreError) {
+        match err {
+            PlaylistStoreError::NoSupportedVariant => {
+                jsSendOtherError(true, OtherErrorCode::NoSupportedVariant, &err.to_string())
+            }
+            PlaylistStoreError::NoInitialVariant => jsSendMultivariantPlaylistParsingError(
+                true,
+                MultivariantPlaylistParsingErrorCode::MultivariantPlaylistWithoutVariant,
+                &err.to_string(),
+            ),
+            PlaylistStoreError::NoProbeSegment => jsSendSegmentParsingError(
+                true,
+                crate::bindings::SegmentParsingErrorCode::UnknownError,
+                MediaType::Video,
+                &err.to_string(),
+            ),
+            PlaylistStoreError::MissingSelectedStreamMetadata
+            | PlaylistStoreError::UnsupportedStartupStream => {
+                // XXX TODO: Should Unsupported be `NoSupportedVariant`?
+                jsSendOtherError(true, OtherErrorCode::Unknown, &err.to_string())
+            }
+        }
+    }
+
+    /// Returns `true` if startup should stop progressing for now.
+    fn handle_startup_status(&mut self) -> bool {
+        let wanted_position = {
+            let Some(playlist_store) = self.playlist_store.as_ref() else {
+                return false;
+            };
+            self.startup_wanted_position(playlist_store)
+        };
+
+        let startup_status = {
+            let Some(playlist_store) = self.playlist_store.as_mut() else {
+                return false;
+            };
+            playlist_store.startup_status(wanted_position)
+        };
+
+        match startup_status {
+            Ok(StartupStatus::Ready) => false,
+            Ok(StartupStatus::AwaitingSupportCheck) => true,
+            Ok(StartupStatus::NeedsProbe(probe_segment)) => {
+                if self.start_probe_segment_request(probe_segment) {
+                    true
+                } else {
+                    jsSendSegmentParsingError(
+                        true,
+                        crate::bindings::SegmentParsingErrorCode::UnknownError,
+                        MediaType::Video,
+                        "No probe segment was available to determine startup metadata",
+                    );
+                    self.stop_current_content();
+                    true
+                }
+            }
+            Err(err) => {
+                self.handle_playlist_store_error(err);
+                self.stop_current_content();
+                true
+            }
+        }
+    }
+
+    fn direct_media_media_type(&self) -> Option<MediaType> {
+        let playlist_store = self.playlist_store.as_ref()?;
+        if playlist_store.has_media_type(MediaType::Audio) {
+            Some(MediaType::Audio)
+        } else if playlist_store.has_media_type(MediaType::Video) {
+            Some(MediaType::Video)
+        } else {
+            None
+        }
     }
 
     /// Returns `true` if the given segment request is the one associated to a current
@@ -542,8 +586,7 @@ impl Dispatcher {
         matches!(
             self.direct_media_probe.as_ref(),
             Some(DirectMediaProbeState::Pending(request))
-                if request.media_type == segment_req.media_type()
-                    && request.url == *segment_req.url()
+                if request.url == *segment_req.url()
                     && request.byte_range.as_ref() == segment_req.byte_range()
         )
     }
@@ -557,21 +600,8 @@ impl Dispatcher {
         segment_req: &SegmentRequestInfo,
         data: JsMemoryBlob,
     ) {
-        // XXX TODO: Shouldn't the mime-type also be just inferred from the segment?
-        // Do we even need the mime-type at all initially in a Direct media context?
-        let mime_type = self
-            .playlist_store
-            .as_ref()
-            .and_then(|playlist_store| {
-                playlist_store
-                    .curr_media_playlist(segment_req.media_type())
-                    .and_then(|playlist| playlist.mime_type(segment_req.media_type()))
-            })
-            .unwrap_or("");
-        let inspection = jsInspectSegment(data.id(), mime_type);
-
-        let codec = match inspection {
-            Ok(inspection) => inspection.codec,
+        let inspection = match jsInspectSegment(data.id()) {
+            Ok(inspection) => inspection,
             Err((code, message)) => {
                 jsSendSegmentParsingError(
                     true,
@@ -587,7 +617,11 @@ impl Dispatcher {
         };
 
         if let Some(playlist_store) = self.playlist_store.as_mut() {
-            playlist_store.set_direct_media_codec(codec.clone());
+            playlist_store.set_direct_media_info(crate::parser::DirectMediaInfo {
+                mime_type: inspection.mime_type,
+                media_type: inspection.media_type,
+                codec: inspection.codec,
+            });
         }
         if let Some(DirectMediaProbeState::Pending(request)) = self.direct_media_probe.take() {
             self.direct_media_probe = Some(DirectMediaProbeState::Ready { request, data });
@@ -605,13 +639,35 @@ impl Dispatcher {
         else {
             return;
         };
+        let Some(media_type) = self.direct_media_media_type() else {
+            jsSendOtherError(
+                true,
+                OtherErrorCode::Unknown,
+                "No direct-media type could be resolved after probing",
+            );
+            self.stop_current_content();
+            return;
+        };
 
         match request.context {
-            ProbeSegmentContext::InitSegment => {
-                self.on_init_segment_loaded(data, request.media_type);
+            ProbeSegmentContext::Init => {
+                self.on_init_segment_loaded(data, media_type);
             }
-            ProbeSegmentContext::MediaSegment { time_info, context } => {
-                self.on_media_segment_loaded(data, request.media_type, time_info, context);
+            ProbeSegmentContext::Media { time_info } => {
+                let Some((_, context)) = self
+                    .playlist_store
+                    .as_ref()
+                    .and_then(|store| store.curr_media_playlist_segment_info(media_type))
+                else {
+                    jsSendOtherError(
+                        true,
+                        OtherErrorCode::Unknown,
+                        "No direct-media context could be resolved after probing",
+                    );
+                    self.stop_current_content();
+                    return;
+                };
+                self.on_media_segment_loaded(data, media_type, time_info, context);
             }
         }
     }
@@ -675,20 +731,6 @@ impl Dispatcher {
                 Logger::warn("Core: Unknown content duration");
             }
 
-            if !self.are_codecs_known() {
-                if self.try_probe_segment_request() {
-                    return;
-                }
-                jsSendSegmentParsingError(
-                    true,
-                    crate::bindings::SegmentParsingErrorCode::UnknownError,
-                    MediaType::Video,
-                    "No probe segment was available to determine direct-media codec metadata",
-                );
-                self.stop_current_content();
-                return;
-            }
-
             if let Some(Err(e)) = self.init_source_buffer(MediaType::Audio) {
                 let (code, msg) = format_source_buffer_creation_err_for_js(e);
                 jsSendSourceBufferCreationError(true, code, MediaType::Audio, &msg);
@@ -743,21 +785,10 @@ impl Dispatcher {
                 match PlaylistStore::try_new(pl, estimate) {
                     Ok(pl_store) => {
                         self.playlist_store = Some(pl_store);
-                        self.check_ready_after_top_level_playlist_loaded();
+                        self.check_playlists_ready();
                     }
                     Err(err) => {
-                        match err {
-                            PlaylistStoreError::NoSupportedVariant => jsSendOtherError(
-                                true,
-                                OtherErrorCode::NoSupportedVariant,
-                                &err.to_string(),
-                            ),
-                            PlaylistStoreError::NoInitialVariant => jsSendMultivariantPlaylistParsingError(
-                                true,
-                                MultivariantPlaylistParsingErrorCode::MultivariantPlaylistWithoutVariant,
-                                &err.to_string(),
-                            ),
-                        };
+                        self.handle_playlist_store_error(err);
                         self.stop_current_content();
                     }
                 }
@@ -829,36 +860,18 @@ impl Dispatcher {
         }
     }
 
-    fn check_ready_after_top_level_playlist_loaded(&mut self) {
-        let playlist_store = if let Some(playlist_store) = self.playlist_store.as_mut() {
-            playlist_store
-        } else {
-            // No PlaylistStore == no loaded top-level playlist yet
-            return;
-        };
-
-        match playlist_store.check_codecs() {
-            Ok(false) => {
-                // Awaiting query about codecs support.
-                return;
-            }
-            Err(err) => {
-                match err {
-                    PlaylistStoreError::NoSupportedVariant => {
-                        jsSendOtherError(true, OtherErrorCode::NoSupportedVariant, &err.to_string())
-                    }
-                    PlaylistStoreError::NoInitialVariant => jsSendMultivariantPlaylistParsingError(
-                        true,
-                        MultivariantPlaylistParsingErrorCode::MultivariantPlaylistWithoutVariant,
-                        &err.to_string(),
-                    ),
-                };
-                self.stop_current_content();
-                return;
-            }
-            _ => {}
+    fn check_playlists_ready(&mut self) {
+        if self.playlist_store.is_none() {
+            return; // No PlaylistStore == no loaded top-level playlist yet
         }
 
+        if self.handle_startup_status() {
+            return;
+        }
+
+        let playlist_store = self.playlist_store.as_mut().unwrap();
+
+        // Ensure there's at least one variant that is supported here
         if playlist_store.playlist_kind() == PlaylistType::MultivariantPlaylist
             && playlist_store.supported_variants().is_empty()
         {
@@ -871,6 +884,9 @@ impl Dispatcher {
             return;
         }
 
+        // -- The top level playlist is considered "ready" --
+
+        // Start fetching initial media playlists if needed
         use PlaylistFileType::*;
         [MediaType::Video, MediaType::Audio]
             .into_iter()
@@ -887,6 +903,8 @@ impl Dispatcher {
                     }
                 }
             });
+
+        // Now "Announce" lifecycle events if needed
 
         // SAFETY: The following lines are unsafe because they may actually define raw pointers
         // to point to Rust's heap memory and put it in the returned values.
@@ -929,12 +947,12 @@ impl Dispatcher {
         media_type: MediaType,
     ) -> Option<Result<(), SourceBufferCreationError>> {
         let content = self.playlist_store.as_mut()?;
-        let media_playlist = content.curr_media_playlist(media_type)?;
-        let mime_type = media_playlist.mime_type(media_type).unwrap_or("");
+        content.curr_media_playlist(media_type)?;
+        let mime_type = content.current_mime_type(media_type)?;
         let codec = content.current_codec(media_type)?;
         Some(
             self.media_element_ref
-                .create_source_buffer(media_type, mime_type, &codec),
+                .create_source_buffer(media_type, &mime_type, &codec),
         )
     }
 
@@ -1187,16 +1205,19 @@ impl Dispatcher {
 
         if self.is_probe_segment_request(&segment_req) {
             self.do_probe_segment_inspection(&segment_req, result);
-            self.check_ready_to_load_segments();
+            self.check_playlists_ready();
             return;
         }
 
         let media_type = segment_req.media_type();
         let (_, _, time_info, context) = segment_req.deconstruct();
-        if let Some(time_info) = time_info {
-            self.on_media_segment_loaded(result, media_type, time_info, context);
-        } else {
-            self.on_init_segment_loaded(result, media_type);
+        match (time_info, context) {
+            (Some(time_info), SegmentRequestContext::Playback(context)) => {
+                self.on_media_segment_loaded(result, media_type, time_info, context);
+            }
+            (None, SegmentRequestContext::Playback(_)) | (_, SegmentRequestContext::Probe) => {
+                self.on_init_segment_loaded(result, media_type);
+            }
         }
     }
 

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -1,6 +1,7 @@
 use super::{
-    event_listeners::JsTimeRanges, Dispatcher, JsMemoryBlob, MediaObservation,
-    MediaSourceReadyState, PlaybackTickReason, PlayerReadyState, StartingPositionType,
+    event_listeners::JsTimeRanges, DirectMediaProbeState, Dispatcher, JsMemoryBlob,
+    MediaObservation, MediaSourceReadyState, PlaybackTickReason, PlayerReadyState,
+    ProbeSegmentContext, ProbeSegmentRequest, StartingPositionType,
 };
 use crate::{
     bindings::{
@@ -9,7 +10,7 @@ use crate::{
             format_variants_info_for_js,
         },
         jsAnnounceFetchedContent, jsAnnounceTrackUpdate, jsAnnounceVariantLockStatusChange,
-        jsAnnounceVariantUpdate, jsClearTimer, jsSendMediaPlaylistParsingError,
+        jsAnnounceVariantUpdate, jsClearTimer, jsInspectSegment, jsSendMediaPlaylistParsingError,
         jsSendMediaPlaylistRequestError, jsSendMultivariantPlaylistParsingError,
         jsSendMultivariantPlaylistRequestError, jsSendOtherError, jsSendPushedSegmentError,
         jsSendRemoveBufferError, jsSendSegmentParsingError, jsSendSegmentRequestError,
@@ -19,7 +20,9 @@ use crate::{
         PushedSegmentErrorCode, RequestId, SourceBufferId, TimerId, TimerReason,
     },
     media_element::{SegmentQualityContext, SourceBufferCreationError},
-    parser::{SegmentTimeInfo, TopLevelPlaylist, TopLevelPlaylistParsingError},
+    parser::{
+        ProbeSegmentPayload, SegmentTimeInfo, TopLevelPlaylist, TopLevelPlaylistParsingError,
+    },
     playlist_store::{
         LockVariantResponse, MediaPlaylistPermanentId, PlaylistStore, PlaylistStoreError,
         SetAudioTrackResponse, VariantUpdateResult,
@@ -41,6 +44,7 @@ impl Dispatcher {
         self.media_element_ref.reset();
         self.segment_selectors.reset_selectors(0.);
         self.playlist_store = None;
+        self.direct_media_probe = None;
         self.last_position = 0.;
         self.clean_up_playlist_refresh_timers();
         self.ready_state = PlayerReadyState::Stopped;
@@ -194,6 +198,9 @@ impl Dispatcher {
                 reason,
                 status,
             } => {
+                if self.is_probe_segment_request(&s) {
+                    self.direct_media_probe = None;
+                }
                 let time_info = s.time_info();
                 jsSendSegmentRequestError(
                     true,
@@ -418,7 +425,7 @@ impl Dispatcher {
 
     /// Method to call when a new codec support report has been received.
     pub(super) fn on_codecs_support_update_core(&mut self) {
-        // XXX TODO: name bad
+        // XXX TODO: Might need to rename that one
         self.check_ready_after_top_level_playlist_loaded();
     }
 
@@ -438,6 +445,174 @@ impl Dispatcher {
             });
         if !was_already_locked {
             self.requester.unlock_segment_requests();
+        }
+    }
+
+    /// If not enough information is known about the playlist (this happens when a Media
+    /// playlist was given directly instead of a multivariant playlist), we might want to
+    /// perform an initial request to a "probe segment" first, just to extract such
+    /// metadata from its container.
+    ///
+    /// This method allows to try kickstarting that probe process.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if the probe process has been started, or `false` if we
+    /// cannot do that.
+    fn try_probe_segment_request(&mut self) -> bool {
+        if self.direct_media_probe.is_some() {
+            return true; // probe already going on
+        }
+
+        let Some(playlist_store) = self.playlist_store.as_ref() else {
+            return false; // No playlist associated to the content
+        };
+        let wanted_position = self.media_element_ref.wanted_position();
+        let Some(direct_media_playlist) = playlist_store.direct_media() else {
+            return false; // This is not a direct media playlist. Here the probe segment would be
+                          // ambiguous
+        };
+        let Some(probe_segment) = direct_media_playlist.probe_segment_for(wanted_position) else {
+            return false; // No segment available
+        };
+        let media_type = match (
+            playlist_store.has_media_type(MediaType::Audio),
+            playlist_store.has_media_type(MediaType::Video),
+        ) {
+            (true, false) => MediaType::Audio,
+            _ => MediaType::Video,
+        };
+
+        // We're not relying on a Multivariant Playlist, so no point of getting
+        // Adaptive metadata setup, just create a default one.
+        // XXX TODO: optional?
+        let probe_segment_context = SegmentQualityContext::new(0., 0);
+        let context = match probe_segment.payload {
+            ProbeSegmentPayload::Init => ProbeSegmentContext::InitSegment,
+            ProbeSegmentPayload::Media { time_info } => {
+                let context = probe_segment_context.clone();
+                ProbeSegmentContext::MediaSegment { time_info, context }
+            }
+        };
+        let request = ProbeSegmentRequest {
+            media_type,
+            url: probe_segment.url,
+            byte_range: probe_segment.byte_range,
+            context,
+        };
+
+        match &request.context {
+            ProbeSegmentContext::InitSegment => self.requester.request_init_segment(
+                request.media_type,
+                request.url.clone(),
+                request.byte_range.as_ref(),
+                probe_segment_context,
+            ),
+            ProbeSegmentContext::MediaSegment { time_info, context } => {
+                self.requester.request_probe_media_segment(
+                    request.media_type,
+                    request.url.clone(),
+                    request.byte_range.as_ref(),
+                    time_info.clone(),
+                    context.clone(),
+                )
+            }
+        }
+        self.direct_media_probe = Some(DirectMediaProbeState::Pending(request));
+        true
+    }
+
+    // Returns `true` if all currently-chosen playlists have a known codec.
+    // If `false`, you may have to "probe" a segment first before knowing it.
+    fn are_codecs_known(&self) -> bool {
+        [MediaType::Audio, MediaType::Video]
+            .into_iter()
+            .all(|media_type| {
+                self.playlist_store
+                    .as_ref()
+                    .and_then(|playlist_store| playlist_store.current_codec(media_type))
+                    .is_some()
+            })
+    }
+
+    /// Returns `true` if the given segment request is the one associated to a current
+    /// "direct media boostrap" operation (the initial loading of a segment to gather more
+    /// metadata about the media).
+    fn is_probe_segment_request(&self, segment_req: &SegmentRequestInfo) -> bool {
+        matches!(
+            self.direct_media_probe.as_ref(),
+            Some(DirectMediaProbeState::Pending(request))
+                if request.media_type == segment_req.media_type()
+                    && request.url == *segment_req.url()
+                    && request.byte_range.as_ref() == segment_req.byte_range()
+        )
+    }
+
+    /// Once a "probe segment" has been loaded, it needs to be inspected so information
+    /// can be extracted from it and the state be updated accordingly.
+    ///
+    /// This is what this method does.
+    fn do_probe_segment_inspection(
+        &mut self,
+        segment_req: &SegmentRequestInfo,
+        data: JsMemoryBlob,
+    ) {
+        // XXX TODO: Shouldn't the mime-type also be just inferred from the segment?
+        // Do we even need the mime-type at all initially in a Direct media context?
+        let mime_type = self
+            .playlist_store
+            .as_ref()
+            .and_then(|playlist_store| {
+                playlist_store
+                    .curr_media_playlist(segment_req.media_type())
+                    .and_then(|playlist| playlist.mime_type(segment_req.media_type()))
+            })
+            .unwrap_or("");
+        let inspection = jsInspectSegment(data.id(), mime_type);
+
+        let codec = match inspection {
+            Ok(inspection) => inspection.codec,
+            Err((code, message)) => {
+                jsSendSegmentParsingError(
+                    true,
+                    code,
+                    segment_req.media_type(),
+                    message
+                        .as_deref()
+                        .unwrap_or("Unknown probe segment parsing error"),
+                );
+                self.stop_current_content();
+                return;
+            }
+        };
+
+        if let Some(playlist_store) = self.playlist_store.as_mut() {
+            playlist_store.set_direct_media_codec(codec.clone());
+        }
+        if let Some(DirectMediaProbeState::Pending(request)) = self.direct_media_probe.take() {
+            self.direct_media_probe = Some(DirectMediaProbeState::Ready { request, data });
+        }
+    }
+
+    /// In certain conditions, a "probe segment" may be fetched initially to gather more
+    /// metadata on the content to play.
+    ///
+    /// As it is usable data and should anyway correspond to the initial segment to load, this
+    /// method allows to both reset that state and to push it to the buffers.
+    fn consume_probe_segment(&mut self) {
+        let Some(DirectMediaProbeState::Ready { request, data, .. }) =
+            self.direct_media_probe.take()
+        else {
+            return;
+        };
+
+        match request.context {
+            ProbeSegmentContext::InitSegment => {
+                self.on_init_segment_loaded(data, request.media_type);
+            }
+            ProbeSegmentContext::MediaSegment { time_info, context } => {
+                self.on_media_segment_loaded(data, request.media_type, time_info, context);
+            }
         }
     }
 
@@ -500,6 +675,20 @@ impl Dispatcher {
                 Logger::warn("Core: Unknown content duration");
             }
 
+            if !self.are_codecs_known() {
+                if self.try_probe_segment_request() {
+                    return;
+                }
+                jsSendSegmentParsingError(
+                    true,
+                    crate::bindings::SegmentParsingErrorCode::UnknownError,
+                    MediaType::Video,
+                    "No probe segment was available to determine direct-media codec metadata",
+                );
+                self.stop_current_content();
+                return;
+            }
+
             if let Some(Err(e)) = self.init_source_buffer(MediaType::Audio) {
                 let (code, msg) = format_source_buffer_creation_err_for_js(e);
                 jsSendSourceBufferCreationError(true, code, MediaType::Audio, &msg);
@@ -513,6 +702,7 @@ impl Dispatcher {
                 return;
             }
             jsStartObservingPlayback();
+            self.consume_probe_segment();
         }
     }
 
@@ -685,6 +875,9 @@ impl Dispatcher {
         [MediaType::Video, MediaType::Audio]
             .into_iter()
             .for_each(|mt| {
+                if playlist_store.curr_media_playlist(mt).is_some() {
+                    return; // Already fetched
+                }
                 if let Some(id) = playlist_store.curr_media_playlist_id(mt) {
                     if let Some(url) = playlist_store.media_playlist_url(id) {
                         let id = id.clone();
@@ -738,13 +931,10 @@ impl Dispatcher {
         let content = self.playlist_store.as_mut()?;
         let media_playlist = content.curr_media_playlist(media_type)?;
         let mime_type = media_playlist.mime_type(media_type).unwrap_or("");
-        let codecs = content
-            .curr_variant()?
-            .codecs(media_type)
-            .unwrap_or_default();
+        let codec = content.current_codec(media_type)?;
         Some(
             self.media_element_ref
-                .create_source_buffer(media_type, mime_type, &codecs),
+                .create_source_buffer(media_type, mime_type, &codec),
         )
     }
 
@@ -994,6 +1184,12 @@ impl Dispatcher {
 
         self.adaptive_selector
             .add_metric(duration_ms, resource_size);
+
+        if self.is_probe_segment_request(&segment_req) {
+            self.do_probe_segment_inspection(&segment_req, result);
+            self.check_ready_to_load_segments();
+            return;
+        }
 
         let media_type = segment_req.media_type();
         let (_, _, time_info, context) = segment_req.deconstruct();

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -6,8 +6,9 @@ use super::{
 use crate::{
     bindings::{
         formatters::{
-            format_audio_tracks_for_js, format_source_buffer_creation_err_for_js,
-            format_variants_info_for_js,
+            format_audio_tracks_for_js, format_direct_media_audio_tracks_for_js,
+            format_direct_media_variants_info_for_js, format_source_buffer_creation_err_for_js,
+            format_variants_info_for_js, DIRECT_MEDIA_AUDIO_TRACK_ID, DIRECT_MEDIA_VARIANT_ID,
         },
         jsAnnounceFetchedContent, jsAnnounceTrackUpdate, jsAnnounceVariantLockStatusChange,
         jsAnnounceVariantUpdate, jsInspectSegment, jsSendMediaPlaylistParsingError,
@@ -1235,14 +1236,29 @@ impl Dispatcher {
         //
         // Because one of the rules of those bindings is to copy all pointed data
         // synchronously on call, we should not encounter any issue.
-        let variants_info =
-            unsafe { format_variants_info_for_js(playlist_store.supported_variants().as_slice()) };
-        let audio_tracks_info =
-            unsafe { format_audio_tracks_for_js(playlist_store.audio_tracks()) };
+        let (variants_info, audio_tracks_info) =
+            if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist {
+                let has_audio_track = playlist_store.has_media_type(MediaType::Audio);
+                (
+                    unsafe { format_direct_media_variants_info_for_js() },
+                    unsafe { format_direct_media_audio_tracks_for_js(has_audio_track) },
+                )
+            } else {
+                (
+                    unsafe {
+                        format_variants_info_for_js(playlist_store.supported_variants().as_slice())
+                    },
+                    unsafe { format_audio_tracks_for_js(playlist_store.audio_tracks()) },
+                )
+            };
         let selected_audio_track = playlist_store.selected_audio_track_id();
         let is_selected = selected_audio_track.is_some();
         let curr_audio_track = if let Some(selected) = selected_audio_track {
             Some(selected)
+        } else if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist
+            && playlist_store.has_media_type(MediaType::Audio)
+        {
+            Some(DIRECT_MEDIA_AUDIO_TRACK_ID)
         } else {
             playlist_store.curr_audio_track_id()
         };
@@ -1252,11 +1268,13 @@ impl Dispatcher {
             audio_tracks_info,
         );
 
-        // NOTE: We could also "invent" a variant id / audio track id from this point on?
-        if playlist_store.playlist_kind() == PlaylistType::MultivariantPlaylist {
-            jsAnnounceVariantUpdate(playlist_store.curr_variant().map(|v| v.id()));
-            jsAnnounceTrackUpdate(MediaType::Audio, curr_audio_track, is_selected);
-        }
+        let curr_variant = if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist {
+            Some(DIRECT_MEDIA_VARIANT_ID)
+        } else {
+            playlist_store.curr_variant().map(|v| v.id())
+        };
+        jsAnnounceVariantUpdate(curr_variant);
+        jsAnnounceTrackUpdate(MediaType::Audio, curr_audio_track, is_selected);
 
         if playlist_store.are_playlists_ready() {
             self.ready_state = PlayerReadyState::AwaitingMediaSource { starting_position };

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    event_listeners::JsTimeRanges, DirectMediaProbeState, Dispatcher, JsMemoryBlob,
-    MediaObservation, MediaSourceReadyState, PlaybackTickReason, PlayerReadyState,
+    event_listeners::JsTimeRanges, Dispatcher, JsMemoryBlob, MediaObservation,
+    MediaSourceReadyState, PlaybackTickReason, PlayerReadyState, ReadyProbeSegment,
     StartingPositionType,
 };
 use crate::{
@@ -19,6 +19,7 @@ use crate::{
         MultivariantPlaylistParsingErrorCode, OtherErrorCode, PlaylistNature, PlaylistType,
         PushedSegmentErrorCode, RequestId, SourceBufferId, TimerId, TimerReason,
     },
+    dispatcher::segment_action_tracker::PendingSegmentAction,
     media_element::{SegmentQualityContext, SourceBufferCreationError},
     parser::{SegmentTimeInfo, TopLevelPlaylist, TopLevelPlaylistParsingError},
     playlist_store::{
@@ -27,8 +28,8 @@ use crate::{
         VariantUpdateResult,
     },
     requester::{
-        FinishedRequestType, PlaylistFileType, PlaylistRequestInfo, RetryResult,
-        SegmentRequestContext, SegmentRequestInfo,
+        FinishedRequestType, PlaylistFileType, PlaylistRequestInfo, RequestLaneTag, RetryResult,
+        SegmentRequestInfo,
     },
     utils::url::Url,
     Logger,
@@ -40,11 +41,12 @@ impl Dispatcher {
     pub(super) fn stop_current_content(&mut self) {
         Logger::info("Core: Stopping current content (if one) and resetting player");
         self.requester.reset();
+        self.segment_action_tracker.clear();
         jsStopObservingPlayback();
         self.media_element_ref.reset();
         self.segment_selectors.reset_selectors(0.);
         self.playlist_store = None;
-        self.direct_media_probe = None;
+        self.ready_probe_segment = None;
         self.last_position = 0.;
         self.clean_up_playlist_refresh_timers();
         self.ready_state = PlayerReadyState::Stopped;
@@ -198,8 +200,12 @@ impl Dispatcher {
                 reason,
                 status,
             } => {
-                if self.is_probe_segment_request(&s) {
-                    self.direct_media_probe = None;
+                if self
+                    .segment_action_tracker
+                    .take(s.action_id())
+                    .is_some_and(|action| action.is_probe())
+                {
+                    self.ready_probe_segment = None;
                 }
                 let time_info = s.time_info();
                 jsSendSegmentRequestError(
@@ -454,27 +460,31 @@ impl Dispatcher {
     /// Returns `true` if the probe process has been started, or `false` if we
     /// cannot do that.
     fn start_probe_segment_request(&mut self, probe_segment: ProbeSegmentMetadata) -> bool {
-        if self.direct_media_probe.is_some() {
+        if self.ready_probe_segment.is_some() || self.segment_action_tracker.has(|a| a.is_probe()) {
             return true; // probe already going on
         }
 
+        let action_id = self
+            .segment_action_tracker
+            .insert(PendingSegmentAction::Probe {
+                probe_segment: probe_segment.clone(),
+            });
         match &probe_segment.context {
-            ProbeSegmentContext::Init => self.requester.request_segment_unlocked(
-                MediaType::Video,
+            ProbeSegmentContext::Init { .. } => self.requester.request_segment_unlocked(
+                RequestLaneTag::Probe,
                 probe_segment.url.clone(),
                 probe_segment.byte_range.as_ref(),
                 None,
-                SegmentRequestContext::Probe,
+                action_id,
             ),
             ProbeSegmentContext::Media { time_info } => self.requester.request_segment_unlocked(
-                MediaType::Video,
+                RequestLaneTag::Probe,
                 probe_segment.url.clone(),
                 probe_segment.byte_range.as_ref(),
                 Some(time_info.clone()),
-                SegmentRequestContext::Probe,
+                action_id,
             ),
         }
-        self.direct_media_probe = Some(DirectMediaProbeState::Pending(probe_segment));
         true
     }
 
@@ -516,7 +526,7 @@ impl Dispatcher {
             PlaylistStoreError::NoProbeSegment => jsSendSegmentParsingError(
                 true,
                 crate::bindings::SegmentParsingErrorCode::UnknownError,
-                MediaType::Video,
+                Some(MediaType::Video),
                 &err.to_string(),
             ),
             PlaylistStoreError::MissingSelectedStreamMetadata
@@ -553,7 +563,7 @@ impl Dispatcher {
                     jsSendSegmentParsingError(
                         true,
                         crate::bindings::SegmentParsingErrorCode::UnknownError,
-                        MediaType::Video,
+                        Some(MediaType::Video),
                         "No probe segment was available to determine startup metadata",
                     );
                     self.stop_current_content();
@@ -579,25 +589,14 @@ impl Dispatcher {
         }
     }
 
-    /// Returns `true` if the given segment request is the one associated to a current
-    /// "direct media boostrap" operation (the initial loading of a segment to gather more
-    /// metadata about the media).
-    fn is_probe_segment_request(&self, segment_req: &SegmentRequestInfo) -> bool {
-        matches!(
-            self.direct_media_probe.as_ref(),
-            Some(DirectMediaProbeState::Pending(request))
-                if request.url == *segment_req.url()
-                    && request.byte_range.as_ref() == segment_req.byte_range()
-        )
-    }
-
     /// Once a "probe segment" has been loaded, it needs to be inspected so information
     /// can be extracted from it and the state be updated accordingly.
     ///
     /// This is what this method does.
     fn do_probe_segment_inspection(
         &mut self,
-        segment_req: &SegmentRequestInfo,
+        probe_segment: ProbeSegmentMetadata,
+        segment_media_type: Option<MediaType>,
         data: JsMemoryBlob,
     ) {
         let inspection = match jsInspectSegment(data.id()) {
@@ -606,7 +605,7 @@ impl Dispatcher {
                 jsSendSegmentParsingError(
                     true,
                     code,
-                    segment_req.media_type(),
+                    segment_media_type,
                     message
                         .as_deref()
                         .unwrap_or("Unknown probe segment parsing error"),
@@ -623,9 +622,10 @@ impl Dispatcher {
                 codec: inspection.codec,
             });
         }
-        if let Some(DirectMediaProbeState::Pending(request)) = self.direct_media_probe.take() {
-            self.direct_media_probe = Some(DirectMediaProbeState::Ready { request, data });
-        }
+        self.ready_probe_segment = Some(ReadyProbeSegment {
+            request: probe_segment,
+            data,
+        });
     }
 
     /// In certain conditions, a "probe segment" may be fetched initially to gather more
@@ -634,9 +634,7 @@ impl Dispatcher {
     /// As it is usable data and should anyway correspond to the initial segment to load, this
     /// method allows to both reset that state and to push it to the buffers.
     fn consume_probe_segment(&mut self) {
-        let Some(DirectMediaProbeState::Ready { request, data, .. }) =
-            self.direct_media_probe.take()
-        else {
+        let Some(ReadyProbeSegment { request, data }) = self.ready_probe_segment.take() else {
             return;
         };
         let Some(media_type) = self.direct_media_media_type() else {
@@ -650,8 +648,8 @@ impl Dispatcher {
         };
 
         match request.context {
-            ProbeSegmentContext::Init => {
-                self.on_init_segment_loaded(data, media_type);
+            ProbeSegmentContext::Init { id } => {
+                self.on_init_segment_loaded(data, media_type, id);
             }
             ProbeSegmentContext::Media { time_info } => {
                 let Some((_, context)) = self
@@ -1042,7 +1040,7 @@ impl Dispatcher {
                 let pl_store = if let Some(playlist_store) = self.playlist_store.as_ref() {
                     playlist_store
                 } else {
-                    self.requester.abort_segments_with_type(mt);
+                    self.abort_segment_requests_with_type(mt);
                     return;
                 };
 
@@ -1062,7 +1060,7 @@ impl Dispatcher {
                             Logger::debug(&format!(
                                 "Core: {mt} init segment request not needed anymore, abort."
                             ));
-                            self.requester.abort_segments_with_type(mt);
+                            self.abort_segment_requests_with_type(mt);
                         } else {
                             Logger::debug(&format!(
                                 "Core: {mt} init segment request still needed."
@@ -1076,14 +1074,14 @@ impl Dispatcher {
                             Logger::debug(&format!(
                                 "Core: {mt} media segment request not needed anymore, abort."
                             ));
-                            self.requester.abort_segments_with_type(mt);
+                            self.abort_segment_requests_with_type(mt);
                         } else {
                             Logger::debug(&format!(
                                 "Core: {mt} media segment request still needed."
                             ));
                         }
                     } else {
-                        self.requester.abort_segments_with_type(mt);
+                        self.abort_segment_requests_with_type(mt);
                     }
                 }
             });
@@ -1103,15 +1101,29 @@ impl Dispatcher {
                     .get_mut(media_type)
                     .most_needed_segment(seg_info.0, &seg_info.1, inventory);
                 if let Some(i) = most_needed_segment.init_segment() {
+                    let action_id =
+                        self.segment_action_tracker
+                            .insert(PendingSegmentAction::Init {
+                                media_type,
+                                init_segment_id: i.id(),
+                            });
                     self.requester.request_init_segment(
                         media_type,
                         i.url().clone(),
                         i.byte_range(),
-                        seg_info.1,
+                        action_id,
                     );
                 } else if let Some(seg) = most_needed_segment.media_segment() {
+                    let action_id =
+                        self.segment_action_tracker
+                            .insert(PendingSegmentAction::Media {
+                                media_type,
+                                time_info: seg.time_info().clone(),
+
+                                quality_context: seg_info.1,
+                            });
                     self.requester
-                        .request_media_segment(media_type, seg, seg_info.1);
+                        .request_media_segment(media_type, seg, action_id);
                 }
             }
         }
@@ -1141,42 +1153,50 @@ impl Dispatcher {
         abort_prev: bool,
         flush: bool,
     ) {
-        if let Some(pl_store) = self.playlist_store.as_mut() {
-            changed_media_types.iter().for_each(|mt| {
-                let mt = *mt;
-                Logger::info(&format!("Core: {} MediaPlaylist changed", mt));
+        if self.playlist_store.is_none() {
+            return;
+        }
 
-                let selector = self.segment_selectors.get_mut(mt);
-                if abort_prev {
-                    self.requester.abort_segments_with_type(mt);
+        for mt in changed_media_types.iter().copied() {
+            Logger::info(&format!("Core: {} MediaPlaylist changed", mt));
+
+            if abort_prev {
+                self.abort_segment_requests_with_type(mt);
+            }
+            if flush {
+                if let Err(e) = self.media_element_ref.flush(mt) {
+                    Logger::warn(&format!(
+                        "Could not remove data from the previous {mt} buffer: {}",
+                        e
+                    ));
                 }
-                if flush {
-                    if let Err(e) = self.media_element_ref.flush(mt) {
-                        Logger::warn(&format!(
-                            "Could not remove data from the previous {mt} buffer: {}",
-                            e
-                        ));
-                    }
-                    selector.restart_from_position(self.media_element_ref.wanted_position() - 0.2);
-                }
-                if pl_store.curr_media_playlist(mt).is_none() {
-                    if let Some(id) = pl_store.curr_media_playlist_id(mt) {
-                        if let Some(url) = pl_store.media_playlist_url(id) {
-                            use PlaylistFileType::*;
-                            Logger::debug("Core: Media changed, requesting its media playlist");
-                            let id = id.clone();
-                            let url = url.clone();
-                            self.requester
-                                .fetch_playlist(url, MediaPlaylist { id, media_type: mt });
-                        }
-                    }
+                self.segment_selectors
+                    .get_mut(mt)
+                    .restart_from_position(self.media_element_ref.wanted_position() - 0.2);
+            }
+
+            let playlist_to_fetch = self.playlist_store.as_ref().and_then(|pl_store| {
+                if pl_store.curr_media_playlist(mt).is_some() {
+                    None
+                } else {
+                    let id = pl_store.curr_media_playlist_id(mt)?.clone();
+                    let url = pl_store.media_playlist_url(&id)?.clone();
+                    Some((id, url))
                 }
             });
-            if !changed_media_types.is_empty() {
-                self.clean_up_playlist_refresh_timers();
+
+            if let Some((id, url)) = playlist_to_fetch {
+                use PlaylistFileType::*;
+                Logger::debug("Core: Media changed, requesting its media playlist");
+                self.requester
+                    .fetch_playlist(url, MediaPlaylist { id, media_type: mt });
             }
-            self.check_segments_to_request();
         }
+
+        if !changed_media_types.is_empty() {
+            self.clean_up_playlist_refresh_timers();
+        }
+        self.check_segments_to_request();
     }
 
     /// Method called once a segment request ended with success
@@ -1188,12 +1208,12 @@ impl Dispatcher {
         duration_ms: f64,
     ) {
         Logger::lazy_info(&|| {
-            let media_type = segment_req.media_type();
+            let lane_label = segment_req.lane_tag().label();
             match segment_req.time_info() {
-                None => format!("Loaded {} init segment", media_type),
+                None => format!("Loaded {} init segment", lane_label),
                 Some(time_info) => format!(
                     "Loaded {} segment: t: {}, d: {}",
-                    media_type,
+                    lane_label,
                     time_info.start(),
                     time_info.duration()
                 ),
@@ -1203,20 +1223,35 @@ impl Dispatcher {
         self.adaptive_selector
             .add_metric(duration_ms, resource_size);
 
-        if self.is_probe_segment_request(&segment_req) {
-            self.do_probe_segment_inspection(&segment_req, result);
-            self.check_playlists_ready();
-            return;
-        }
-
         let media_type = segment_req.media_type();
-        let (_, _, time_info, context) = segment_req.deconstruct();
-        match (time_info, context) {
-            (Some(time_info), SegmentRequestContext::Playback(context)) => {
-                self.on_media_segment_loaded(result, media_type, time_info, context);
+        let Some(action) = self.segment_action_tracker.take(segment_req.action_id()) else {
+            Logger::warn("Loaded segment with unknown pending action.");
+            return;
+        };
+
+        match action {
+            PendingSegmentAction::Media {
+                media_type: action_media_type,
+                time_info,
+                quality_context,
+            } => {
+                if Some(action_media_type) != media_type {
+                    Logger::warn("Loaded media segment with mismatched media type action.");
+                }
+                self.on_media_segment_loaded(result, action_media_type, time_info, quality_context);
             }
-            (None, SegmentRequestContext::Playback(_)) | (_, SegmentRequestContext::Probe) => {
-                self.on_init_segment_loaded(result, media_type);
+            PendingSegmentAction::Init {
+                media_type: action_media_type,
+                init_segment_id,
+            } => {
+                if Some(action_media_type) != media_type {
+                    Logger::warn("Loaded init segment with mismatched media type action.");
+                }
+                self.on_init_segment_loaded(result, action_media_type, init_segment_id);
+            }
+            PendingSegmentAction::Probe { probe_segment } => {
+                self.do_probe_segment_inspection(probe_segment, media_type, result);
+                self.check_playlists_ready();
             }
         }
     }
@@ -1252,7 +1287,7 @@ impl Dispatcher {
             Err(x) => {
                 let media_type = x.media_type();
                 let message = x.to_string();
-                jsSendSegmentParsingError(true, x.into(), media_type, &message);
+                jsSendSegmentParsingError(true, x.into(), Some(media_type), &message);
                 self.stop_current_content();
             }
             Ok(()) => {
@@ -1267,19 +1302,35 @@ impl Dispatcher {
         }
     }
 
-    fn on_init_segment_loaded(&mut self, data: JsMemoryBlob, media_type: MediaType) {
+    fn on_init_segment_loaded(&mut self, data: JsMemoryBlob, media_type: MediaType, init_id: f64) {
         match self.media_element_ref.push_init_segment(media_type, data) {
             Err(x) => {
                 let media_type = x.media_type();
                 let message = x.to_string();
-                jsSendSegmentParsingError(true, x.into(), media_type, &message);
+                jsSendSegmentParsingError(true, x.into(), Some(media_type), &message);
                 self.stop_current_content();
             }
-            Ok(()) => self.segment_selectors.get_mut(media_type).validate_init(),
+            Ok(()) => self
+                .segment_selectors
+                .get_mut(media_type)
+                .validate_init(init_id),
         }
 
         self.check_best_variant();
         self.check_segments_to_request();
+    }
+
+    fn abort_segment_requests_with_type(&mut self, media_type: MediaType) {
+        let aborted_actions = self.requester.abort_segments_with_type(media_type);
+        for action_id in aborted_actions {
+            if self
+                .segment_action_tracker
+                .take(action_id)
+                .is_some_and(|action| action.is_probe())
+            {
+                self.ready_probe_segment = None;
+            }
+        }
     }
 
     /// Removes from `self.playlist_refresh_timers` timers for playlist that are not current

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -680,6 +680,9 @@ impl Dispatcher {
                     TopLevelPlaylistParsingError::Media(err) => {
                         jsSendMediaPlaylistParsingError(true, err.into(), None, &message);
                     }
+                    TopLevelPlaylistParsingError::NotAPlaylist => {
+                        jsSendOtherError(true, OtherErrorCode::NotAPlaylist, &message);
+                    }
                 }
                 self.stop_current_content();
             }

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -513,10 +513,11 @@ impl Dispatcher {
                 Some(MediaType::Video),
                 &err.to_string(),
             ),
-            PlaylistStoreError::MissingSelectedStreamMetadata
-            | PlaylistStoreError::UnsupportedStartupStream => {
-                // XXX TODO: Should Unsupported be `NoSupportedVariant`?
+            PlaylistStoreError::MissingSelectedStreamMetadata => {
                 jsSendOtherError(true, OtherErrorCode::Unknown, &err.to_string())
+            }
+            PlaylistStoreError::UnsupportedStartupStream => {
+                jsSendOtherError(true, OtherErrorCode::NoSupportedVariant, &err.to_string())
             }
         }
     }

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -10,16 +10,16 @@ use crate::{
             format_variants_info_for_js,
         },
         jsAnnounceFetchedContent, jsAnnounceTrackUpdate, jsAnnounceVariantLockStatusChange,
-        jsAnnounceVariantUpdate, jsClearTimer, jsInspectSegment, jsSendMediaPlaylistParsingError,
+        jsAnnounceVariantUpdate, jsInspectSegment, jsSendMediaPlaylistParsingError,
         jsSendMediaPlaylistRequestError, jsSendMultivariantPlaylistParsingError,
         jsSendMultivariantPlaylistRequestError, jsSendOtherError, jsSendPushedSegmentError,
         jsSendRemoveBufferError, jsSendSegmentParsingError, jsSendSegmentRequestError,
         jsSendSourceBufferCreationError, jsSetMediaSourceDuration, jsStartObservingPlayback,
-        jsStopObservingPlayback, jsTimer, jsUpdateContentInfo, AddSourceBufferErrorCode, MediaType,
+        jsStopObservingPlayback, jsUpdateContentInfo, AddSourceBufferErrorCode, MediaType,
         MultivariantPlaylistParsingErrorCode, OtherErrorCode, PlaylistNature, PlaylistType,
-        PushedSegmentErrorCode, RequestId, SourceBufferId, TimerId, TimerReason,
+        PushedSegmentErrorCode, RequestId, SourceBufferId, TimerId,
     },
-    dispatcher::segment_action_tracker::PendingSegmentAction,
+    dispatcher::{segment_request_contexts::PendingSegmentRequest, StartingPosition},
     media_element::{SegmentQualityContext, SourceBufferCreationError},
     parser::{SegmentTimeInfo, TopLevelPlaylist, TopLevelPlaylistParsingError},
     playlist_store::{
@@ -41,7 +41,7 @@ impl Dispatcher {
     pub(super) fn stop_current_content(&mut self) {
         Logger::info("Core: Stopping current content (if one) and resetting player");
         self.requester.reset();
-        self.segment_action_tracker.clear();
+        self.segment_request_contexts.clear();
         jsStopObservingPlayback();
         self.media_element_ref.reset();
         self.segment_selectors.reset_selectors(0.);
@@ -117,23 +117,26 @@ impl Dispatcher {
     /// Method to call once a timer for Playlist refresh, started with the jsTimer JavaScript
     /// function, has finished, with the corrsonding `TimerId` as argument.
     pub(super) fn on_playlist_refresh_timer_ended(&mut self, id: TimerId) {
-        let found = self.playlist_refresh_timers.iter().position(|x| x.0 == id);
-        if let Some(idx) = found {
-            let (_, playlist_type) = self.playlist_refresh_timers.remove(idx);
-            if let Some(playlist_store) = &self.playlist_store {
-                match playlist_type {
-                    PlaylistFileType::TopLevelPlaylist => self
-                        .requester
-                        .fetch_playlist(playlist_store.url().clone(), playlist_type),
-                    PlaylistFileType::MediaPlaylist { ref id, .. } => {
-                        if let Some(u) = playlist_store.media_playlist_url(id) {
-                            self.requester.fetch_playlist(u.clone(), playlist_type)
-                        } else {
-                            Logger::error("Core: Cannot refresh Media Playlist: id not found");
-                        }
-                    }
-                }
-            }
+        let (Some(playlist_id), Some(playlist_store)) = (
+            self.playlist_refresh_timers.resolve_timer(id),
+            &self.playlist_store,
+        ) else {
+            return;
+        };
+
+        if let (Some(url), Some(media_type)) = (
+            playlist_store.media_playlist_url(&playlist_id),
+            playlist_store.curr_media_type_for(&playlist_id),
+        ) {
+            self.requester.fetch_playlist(
+                url.clone(),
+                PlaylistFileType::MediaPlaylist {
+                    id: playlist_id,
+                    media_type,
+                },
+            );
+        } else {
+            Logger::error("Core: Cannot refresh Media Playlist: id not found");
         }
     }
 
@@ -195,15 +198,16 @@ impl Dispatcher {
             .requester
             .on_pending_request_failure(request_id, has_timeouted, status)
         {
+            // Failing segment request
             RetryResult::Failed {
                 request_type: FinishedRequestType::Segment(s),
                 reason,
                 status,
             } => {
                 if self
-                    .segment_action_tracker
-                    .take(s.action_id())
-                    .is_some_and(|action| action.is_probe())
+                    .segment_request_contexts
+                    .take(s.id())
+                    .is_some_and(|ctxt| ctxt.is_probe())
                 {
                     self.ready_probe_segment = None;
                 }
@@ -219,6 +223,7 @@ impl Dispatcher {
                 );
                 self.stop_current_content();
             }
+            // Failing playlist request
             RetryResult::Failed {
                 request_type: FinishedRequestType::Playlist(x),
                 reason,
@@ -297,9 +302,7 @@ impl Dispatcher {
         Logger::info(&format!("Core: MediaSource state changed: {:?}", state));
         self.media_element_ref
             .update_media_source_ready_state(state);
-        if state == MediaSourceReadyState::Open {
-            self.check_ready_to_load_segments();
-        }
+        self.recheck_player_state();
     }
 
     /// Method to call when a `SourceBuffer`'s creation failed.
@@ -431,7 +434,7 @@ impl Dispatcher {
 
     /// Method to call when a new codec support report has been received.
     pub(super) fn on_codecs_support_update_core(&mut self) {
-        self.check_playlists_ready();
+        self.recheck_player_state();
     }
 
     /// For each media type, check if segment need to be requested, and if that's the case, perform
@@ -455,62 +458,43 @@ impl Dispatcher {
 
     /// Start a startup probe request if not already in progress.
     ///
+    /// Probe segment requests are segment requests with the goal of obtaining more
+    /// information not found in the playlist(s): which codecs is it and other attributes.
+    ///
     /// # Returns
     ///
     /// Returns `true` if the probe process has been started, or `false` if we
     /// cannot do that.
     fn start_probe_segment_request(&mut self, probe_segment: ProbeSegmentMetadata) -> bool {
-        if self.ready_probe_segment.is_some() || self.segment_action_tracker.has(|a| a.is_probe()) {
+        if self.ready_probe_segment.is_some() || self.segment_request_contexts.has(|a| a.is_probe())
+        {
             return true; // probe already going on
         }
 
-        let action_id = self
-            .segment_action_tracker
-            .insert(PendingSegmentAction::Probe {
+        let req_id = self
+            .segment_request_contexts
+            .insert(PendingSegmentRequest::Probe {
+                // TODO: cloning here may be unnecessary if we're smart about it? Though
+                // it may be not worth it.
                 probe_segment: probe_segment.clone(),
             });
         match &probe_segment.context {
             ProbeSegmentContext::Init { .. } => self.requester.request_segment_unlocked(
                 RequestLaneTag::Probe,
-                probe_segment.url.clone(),
+                &probe_segment.url,
                 probe_segment.byte_range.as_ref(),
                 None,
-                action_id,
+                req_id,
             ),
             ProbeSegmentContext::Media { time_info } => self.requester.request_segment_unlocked(
                 RequestLaneTag::Probe,
-                probe_segment.url.clone(),
+                &probe_segment.url,
                 probe_segment.byte_range.as_ref(),
                 Some(time_info.clone()),
-                action_id,
+                req_id,
             ),
         }
         true
-    }
-
-    fn startup_wanted_position(&self, playlist_store: &PlaylistStore) -> f64 {
-        // XXX TODO: duplicated?
-        match self.ready_state {
-            PlayerReadyState::Loading {
-                ref starting_position,
-            } => {
-                if let Some(starting_pos) = starting_position {
-                    match starting_pos.start_type {
-                        StartingPositionType::Absolute => starting_pos.position,
-                        StartingPositionType::FromBeginning => {
-                            playlist_store.curr_min_position().unwrap_or(0.) + starting_pos.position
-                        }
-                        StartingPositionType::FromEnd => playlist_store
-                            .curr_max_position()
-                            .map(|max| max - starting_pos.position)
-                            .unwrap_or(playlist_store.expected_start_time()),
-                    }
-                } else {
-                    playlist_store.expected_start_time()
-                }
-            }
-            _ => self.media_element_ref.wanted_position(),
-        }
     }
 
     fn handle_playlist_store_error(&mut self, err: PlaylistStoreError) {
@@ -537,68 +521,22 @@ impl Dispatcher {
         }
     }
 
-    /// Returns `true` if startup should stop progressing for now.
-    fn handle_startup_status(&mut self) -> bool {
-        let wanted_position = {
-            let Some(playlist_store) = self.playlist_store.as_ref() else {
-                return false;
-            };
-            self.startup_wanted_position(playlist_store)
-        };
-
-        let startup_status = {
-            let Some(playlist_store) = self.playlist_store.as_mut() else {
-                return false;
-            };
-            playlist_store.startup_status(wanted_position)
-        };
-
-        match startup_status {
-            Ok(StartupStatus::Ready) => false,
-            Ok(StartupStatus::AwaitingSupportCheck) => true,
-            Ok(StartupStatus::NeedsProbe(probe_segment)) => {
-                if self.start_probe_segment_request(probe_segment) {
-                    true
-                } else {
-                    jsSendSegmentParsingError(
-                        true,
-                        crate::bindings::SegmentParsingErrorCode::UnknownError,
-                        Some(MediaType::Video),
-                        "No probe segment was available to determine startup metadata",
-                    );
-                    self.stop_current_content();
-                    true
-                }
-            }
-            Err(err) => {
-                self.handle_playlist_store_error(err);
-                self.stop_current_content();
-                true
-            }
-        }
-    }
-
-    fn direct_media_media_type(&self) -> Option<MediaType> {
-        let playlist_store = self.playlist_store.as_ref()?;
-        if playlist_store.has_media_type(MediaType::Audio) {
-            Some(MediaType::Audio)
-        } else if playlist_store.has_media_type(MediaType::Video) {
-            Some(MediaType::Video)
-        } else {
-            None
-        }
-    }
-
     /// Once a "probe segment" has been loaded, it needs to be inspected so information
     /// can be extracted from it and the state be updated accordingly.
     ///
-    /// This is what this method does.
+    /// This is what this method does: inspect the segment and update the playlist state
+    /// accordingly.
     fn do_probe_segment_inspection(
         &mut self,
         probe_segment: ProbeSegmentMetadata,
         segment_media_type: Option<MediaType>,
         data: JsMemoryBlob,
     ) {
+        let Some(playlist_store) = self.playlist_store.as_mut() else {
+            Logger::error("Core: asked to do segment inspection without having a playlist store");
+            return;
+        };
+
         let inspection = match jsInspectSegment(data.id()) {
             Ok(inspection) => inspection,
             Err((code, message)) => {
@@ -615,13 +553,21 @@ impl Dispatcher {
             }
         };
 
-        if let Some(playlist_store) = self.playlist_store.as_mut() {
-            playlist_store.set_direct_media_info(crate::parser::DirectMediaInfo {
-                mime_type: inspection.mime_type,
-                media_type: inspection.media_type,
-                codec: inspection.codec,
-            });
-        }
+        // Update playlist information with inspection result
+        playlist_store.set_direct_media_info(crate::parser::DirectMediaInfo {
+            mime_type: inspection.mime_type,
+            media_type: inspection.media_type,
+            codec: inspection.codec,
+        });
+
+        // That might have led to more timing-related information
+        jsUpdateContentInfo(
+            playlist_store.curr_min_position(),
+            playlist_store.curr_max_position(),
+            playlist_store.playlist_type(),
+        );
+
+        // Store segment for future playback
         self.ready_probe_segment = Some(ReadyProbeSegment {
             request: probe_segment,
             data,
@@ -635,9 +581,9 @@ impl Dispatcher {
     /// method allows to both reset that state and to push it to the buffers.
     fn consume_probe_segment(&mut self) {
         let Some(ReadyProbeSegment { request, data }) = self.ready_probe_segment.take() else {
-            return;
+            return; // No stored probe segment
         };
-        let Some(media_type) = self.direct_media_media_type() else {
+        let Some(media_type) = has_playlist_store_media_type(self.playlist_store.as_ref()) else {
             jsSendOtherError(
                 true,
                 OtherErrorCode::Unknown,
@@ -670,100 +616,58 @@ impl Dispatcher {
         }
     }
 
-    /// Method called on various events that could lead to start loading segments.
-    ///
-    /// If all conditions are met, the `Dispatcher` is set to the next
-    /// `AwaitingSegments` `PlayerReadyState`, playback observations begin,
-    /// and the potential initialization segments are requested.
-    fn check_ready_to_load_segments(&mut self) {
-        let starting_pos = match self.ready_state {
-            PlayerReadyState::Loading {
-                ref starting_position,
-            } => starting_position,
-            _ => {
-                return;
-            }
-        };
-
-        match self.media_element_ref.media_source_ready_state() {
-            Some(MediaSourceReadyState::Closed) | None => {
-                return;
-            }
-            _ => {}
-        }
-
-        let playlist_store = if let Some(pl_store) = self.playlist_store.as_ref() {
-            pl_store
-        } else {
-            return;
-        };
-
-        if playlist_store.are_playlists_ready() {
-            if let Some(starting_pos) = starting_pos {
-                let actual_start = match starting_pos.start_type {
-                    StartingPositionType::Absolute => starting_pos.position,
-                    StartingPositionType::FromBeginning => {
-                        playlist_store.curr_min_position().unwrap_or(0.) + starting_pos.position
-                    }
-                    StartingPositionType::FromEnd => playlist_store
-                        .curr_max_position()
-                        .map(|max| max - starting_pos.position)
-                        .unwrap_or(playlist_store.expected_start_time()),
-                };
-                if actual_start > 0. {
-                    self.media_element_ref.seek(actual_start);
-                }
-            } else {
-                let start_time = playlist_store.expected_start_time();
-                if start_time > 0. {
-                    self.media_element_ref.seek(start_time);
-                }
-            }
-
-            self.ready_state = PlayerReadyState::AwaitingSegments;
-            if playlist_store.playlist_type() != PlaylistNature::VoD {
-                let _ = jsSetMediaSourceDuration(u32::MAX as f64);
-            } else if let Some(duration) = playlist_store.curr_duration() {
-                let _ = jsSetMediaSourceDuration(duration);
-            } else {
-                Logger::warn("Core: Unknown content duration");
-            }
-
-            if let Some(Err(e)) = self.init_source_buffer(MediaType::Audio) {
-                let (code, msg) = format_source_buffer_creation_err_for_js(e);
-                jsSendSourceBufferCreationError(true, code, MediaType::Audio, &msg);
-                self.stop_current_content();
-                return;
-            }
-            if let Some(Err(e)) = self.init_source_buffer(MediaType::Video) {
-                let (code, msg) = format_source_buffer_creation_err_for_js(e);
-                jsSendSourceBufferCreationError(true, code, MediaType::Video, &msg);
-                self.stop_current_content();
-                return;
-            }
-            jsStartObservingPlayback();
-            self.consume_probe_segment();
-        }
-    }
-
     /// Method called once a playlist request ended with success
     fn on_playlist_fetch_success(
         &mut self,
         pl_info: PlaylistRequestInfo,
-        result: Vec<u8>,
+        data: Vec<u8>,
         final_url: Url,
     ) {
         let PlaylistRequestInfo { playlist_type, .. } = pl_info;
-        if let PlaylistFileType::MediaPlaylist { id, media_type } = playlist_type {
-            self.on_media_playlist_loaded(id, result, media_type, final_url);
-        } else {
-            self.on_top_level_playlist_loaded(result, final_url);
+        match playlist_type {
+            PlaylistFileType::TopLevelPlaylist => {
+                self.on_top_level_playlist_loaded(data, final_url)
+            }
+
+            PlaylistFileType::MediaPlaylist { id, media_type } => {
+                Logger::info(&format!(
+                    "Media playlist loaded successfully: {}",
+                    final_url.get_ref()
+                ));
+                let refresh_interval = {
+                    let Some(playlist_store) = self.playlist_store.as_mut() else {
+                        jsSendOtherError(
+                            true,
+                            OtherErrorCode::Unknown,
+                            "Media playlist loaded but no top-level playlist",
+                        );
+                        self.stop_current_content();
+                        return;
+                    };
+                    match playlist_store.update_media_playlist(&id, data.as_ref(), final_url) {
+                        Err(e) => {
+                            let err_message = e.to_string();
+                            jsSendMediaPlaylistParsingError(
+                                true,
+                                e.into(),
+                                Some(media_type),
+                                &err_message,
+                            );
+                            self.stop_current_content();
+                            return;
+                        }
+                        Ok(p) => p.refresh_interval(),
+                    }
+                };
+                self.process_parsed_media_playlist(id, refresh_interval);
+            }
         }
     }
 
     /// Method called once the top-level Playlist was loaded with success, with its response data
     /// and url as argument.
     fn on_top_level_playlist_loaded(&mut self, data: Vec<u8>, playlist_url: Url) {
+        Logger::info("Core: top-level playlist loaded");
         match TopLevelPlaylist::parse(data.as_ref(), playlist_url) {
             Err(err) => {
                 let message = err.to_string();
@@ -778,12 +682,20 @@ impl Dispatcher {
                 self.stop_current_content();
             }
             Ok(pl) => {
-                Logger::info("Core: Top-level playlist parsed successfully");
+                Logger::info("Core: top-level playlist parsed successfully");
                 let estimate = self.adaptive_selector.get_estimate();
                 match PlaylistStore::try_new(pl, estimate) {
                     Ok(pl_store) => {
+                        // TODO: ugly
+                        let direct_media_refresh = pl_store
+                            .direct_media_playlist()
+                            .map(|(id, playlist)| (id.clone(), playlist.refresh_interval()));
+
                         self.playlist_store = Some(pl_store);
-                        self.check_playlists_ready();
+                        if let Some((playlist_id, refresh_interval)) = direct_media_refresh {
+                            self.process_parsed_media_playlist(playlist_id, refresh_interval);
+                        }
+                        self.recheck_player_state();
                     }
                     Err(err) => {
                         self.handle_playlist_store_error(err);
@@ -794,150 +706,51 @@ impl Dispatcher {
         }
     }
 
-    /// Method called once a Media Playlist was loaded with success, with its id, response data
-    /// and url as argument.
-    fn on_media_playlist_loaded(
+    /// Method called once a Media Playlist was parsed with success
+    fn process_parsed_media_playlist(
         &mut self,
         playlist_id: MediaPlaylistPermanentId,
-        data: Vec<u8>,
-        media_type: MediaType,
-        playlist_url: Url,
+        refresh_interval: Option<f64>,
     ) {
-        Logger::info(&format!(
-            "Media playlist loaded successfully: {}",
-            playlist_url.get_ref()
-        ));
-        if let Some(ref mut playlist_store) = self.playlist_store.as_mut() {
-            match playlist_store.update_media_playlist(&playlist_id, data.as_ref(), playlist_url) {
-                Err(e) => {
-                    let err_message = e.to_string();
-                    jsSendMediaPlaylistParsingError(true, e.into(), Some(media_type), &err_message);
-                    self.stop_current_content();
-                }
-                Ok(p) => {
-                    if let Some(refresh_interval) = p.refresh_interval() {
-                        let timer_id = jsTimer(refresh_interval, TimerReason::MediaPlaylistRefresh);
-                        self.playlist_refresh_timers.push((
-                            timer_id,
-                            PlaylistFileType::MediaPlaylist {
-                                id: playlist_id,
-                                media_type,
-                            },
-                        ));
-                    }
+        let Some(playlist_store) = self.playlist_store.as_ref() else {
+            return;
+        };
+        self.playlist_refresh_timers
+            .set_timer(playlist_id.clone(), refresh_interval);
 
-                    if let Some(duration) = playlist_store.segment_target_duration() {
-                        let mut min_buffer_time = f64::max(3., duration - 1.);
-                        min_buffer_time = f64::min(8., min_buffer_time);
-                        Logger::debug(&format!(
-                            "Core: Updating min_buffer_time: {min_buffer_time}"
-                        ));
-                        self.media_element_ref
-                            .update_min_buffer_time(min_buffer_time);
-                    }
-                    if self.ready_state.is_loading() {
-                        self.check_ready_to_load_segments();
-                    } else {
-                        self.check_segments_to_request();
-                    }
-
-                    if let Some(playlist_store) = self.playlist_store.as_ref() {
-                        let min_pos = playlist_store.curr_min_position();
-                        let max_pos = playlist_store.curr_max_position();
-                        jsUpdateContentInfo(min_pos, max_pos, playlist_store.playlist_type());
-                    }
-                }
-            }
-        } else {
-            jsSendOtherError(
-                true,
-                crate::bindings::OtherErrorCode::Unknown,
-                "Media playlist loaded but no top-level playlist",
-            );
-            self.stop_current_content();
+        if let Some(duration) = playlist_store.segment_target_duration() {
+            let mut min_buffer_time = f64::max(3., duration - 1.);
+            min_buffer_time = f64::min(8., min_buffer_time);
+            Logger::debug(&format!(
+                "Core: Updating min_buffer_time: {min_buffer_time}"
+            ));
+            self.media_element_ref
+                .update_min_buffer_time(min_buffer_time);
         }
+
+        // That might have led to more timing-related information
+        jsUpdateContentInfo(
+            playlist_store.curr_min_position(),
+            playlist_store.curr_max_position(),
+            playlist_store.playlist_type(),
+        );
+        self.recheck_player_state();
     }
 
-    fn check_playlists_ready(&mut self) {
-        if self.playlist_store.is_none() {
-            return; // No PlaylistStore == no loaded top-level playlist yet
-        }
-
-        if self.handle_startup_status() {
-            return;
-        }
-
-        let playlist_store = self.playlist_store.as_mut().unwrap();
-
-        // Ensure there's at least one variant that is supported here
-        if playlist_store.playlist_kind() == PlaylistType::MultivariantPlaylist
-            && playlist_store.supported_variants().is_empty()
-        {
-            jsSendOtherError(
-                true,
-                crate::bindings::OtherErrorCode::NoSupportedVariant,
-                "Error while parsing MultivariantPlaylist: no compatible variant found.",
-            );
-            self.stop_current_content();
-            return;
-        }
-
-        // -- The top level playlist is considered "ready" --
-
-        // Start fetching initial media playlists if needed
-        use PlaylistFileType::*;
-        [MediaType::Video, MediaType::Audio]
-            .into_iter()
-            .for_each(|mt| {
-                if playlist_store.curr_media_playlist(mt).is_some() {
-                    return; // Already fetched
-                }
-                if let Some(id) = playlist_store.curr_media_playlist_id(mt) {
-                    if let Some(url) = playlist_store.media_playlist_url(id) {
-                        let id = id.clone();
-                        let url = url.clone();
-                        self.requester
-                            .fetch_playlist(url, MediaPlaylist { id, media_type: mt });
-                    }
-                }
-            });
-
-        // Now "Announce" lifecycle events if needed
-
-        // SAFETY: The following lines are unsafe because they may actually define raw pointers
-        // to point to Rust's heap memory and put it in the returned values.
-        //
-        // However, we're calling the JS binding function it is communicated to directly
-        // after and thus before the corresponding underlying data had a chance to be
-        // dropped.
-        //
-        // Because one of the rules of those bindings is to copy all pointed data
-        // synchronously on call, we should not encounter any issue.
-        let variants_info =
-            unsafe { format_variants_info_for_js(playlist_store.supported_variants().as_slice()) };
-        let audio_tracks_info =
-            unsafe { format_audio_tracks_for_js(playlist_store.audio_tracks()) };
-        let selected_audio_track = playlist_store.selected_audio_track_id();
-        let is_selected = selected_audio_track.is_some();
-        let curr_audio_track = if let Some(selected) = selected_audio_track {
-            Some(selected)
-        } else {
-            playlist_store.curr_audio_track_id()
+    /// Look if progress can be made in playing the current content by checking the full state
+    fn recheck_player_state(&mut self) {
+        match self.ready_state {
+            PlayerReadyState::Stopped => {}
+            PlayerReadyState::AwaitingPlaylistInfo { .. } => {
+                self.inner_advance_awaiting_playlist_info_state();
+            }
+            PlayerReadyState::AwaitingMediaSource { .. } => {
+                self.inner_advance_awaiting_media_source_state();
+            }
+            PlayerReadyState::AwaitingSegments | PlayerReadyState::Playing => {
+                self.check_segments_to_request();
+            }
         };
-        jsAnnounceFetchedContent(
-            playlist_store.playlist_kind(),
-            variants_info,
-            audio_tracks_info,
-        );
-        // NOTE: We could also "invent" a variant id / audio track id from this point on?
-        if playlist_store.playlist_kind() == PlaylistType::MultivariantPlaylist {
-            jsAnnounceVariantUpdate(playlist_store.curr_variant().map(|v| v.id()));
-            jsAnnounceTrackUpdate(MediaType::Audio, curr_audio_track, is_selected);
-        }
-
-        if playlist_store.are_playlists_ready() {
-            self.check_ready_to_load_segments();
-        }
     }
 
     fn init_source_buffer(
@@ -1037,9 +850,7 @@ impl Dispatcher {
         [MediaType::Audio, MediaType::Video]
             .into_iter()
             .for_each(|mt| {
-                let pl_store = if let Some(playlist_store) = self.playlist_store.as_ref() {
-                    playlist_store
-                } else {
+                let Some(pl_store) = self.playlist_store.as_ref() else {
                     self.abort_segment_requests_with_type(mt);
                     return;
                 };
@@ -1088,9 +899,7 @@ impl Dispatcher {
     }
 
     fn check_segment_to_request_for_type(&mut self, media_type: MediaType) {
-        let pl_store = if let Some(playlist_store) = self.playlist_store.as_ref() {
-            playlist_store
-        } else {
+        let Some(pl_store) = self.playlist_store.as_ref() else {
             return;
         };
         if !self.requester.has_segment_request_pending(media_type) {
@@ -1101,9 +910,9 @@ impl Dispatcher {
                     .get_mut(media_type)
                     .most_needed_segment(seg_info.0, &seg_info.1, inventory);
                 if let Some(i) = most_needed_segment.init_segment() {
-                    let action_id =
-                        self.segment_action_tracker
-                            .insert(PendingSegmentAction::Init {
+                    let req_id =
+                        self.segment_request_contexts
+                            .insert(PendingSegmentRequest::Init {
                                 media_type,
                                 init_segment_id: i.id(),
                             });
@@ -1111,19 +920,19 @@ impl Dispatcher {
                         media_type,
                         i.url().clone(),
                         i.byte_range(),
-                        action_id,
+                        req_id,
                     );
                 } else if let Some(seg) = most_needed_segment.media_segment() {
-                    let action_id =
-                        self.segment_action_tracker
-                            .insert(PendingSegmentAction::Media {
+                    let req_id =
+                        self.segment_request_contexts
+                            .insert(PendingSegmentRequest::Media {
                                 media_type,
                                 time_info: seg.time_info().clone(),
 
                                 quality_context: seg_info.1,
                             });
                     self.requester
-                        .request_media_segment(media_type, seg, action_id);
+                        .request_media_segment(media_type, seg, req_id);
                 }
             }
         }
@@ -1224,34 +1033,34 @@ impl Dispatcher {
             .add_metric(duration_ms, resource_size);
 
         let media_type = segment_req.media_type();
-        let Some(action) = self.segment_action_tracker.take(segment_req.action_id()) else {
-            Logger::warn("Loaded segment with unknown pending action.");
+        let Some(req_ctxt) = self.segment_request_contexts.take(segment_req.id()) else {
+            Logger::warn("Loaded segment with unknown pending context.");
             return;
         };
 
-        match action {
-            PendingSegmentAction::Media {
-                media_type: action_media_type,
+        match req_ctxt {
+            PendingSegmentRequest::Media {
+                media_type: req_media_type,
                 time_info,
                 quality_context,
             } => {
-                if Some(action_media_type) != media_type {
-                    Logger::warn("Loaded media segment with mismatched media type action.");
+                if Some(req_media_type) != media_type {
+                    Logger::warn("Loaded media segment with mismatched media type context.");
                 }
-                self.on_media_segment_loaded(result, action_media_type, time_info, quality_context);
+                self.on_media_segment_loaded(result, req_media_type, time_info, quality_context);
             }
-            PendingSegmentAction::Init {
-                media_type: action_media_type,
+            PendingSegmentRequest::Init {
+                media_type: req_media_type,
                 init_segment_id,
             } => {
-                if Some(action_media_type) != media_type {
-                    Logger::warn("Loaded init segment with mismatched media type action.");
+                if Some(req_media_type) != media_type {
+                    Logger::warn("Loaded init segment with mismatched media type context.");
                 }
-                self.on_init_segment_loaded(result, action_media_type, init_segment_id);
+                self.on_init_segment_loaded(result, req_media_type, init_segment_id);
             }
-            PendingSegmentAction::Probe { probe_segment } => {
+            PendingSegmentRequest::Probe { probe_segment } => {
                 self.do_probe_segment_inspection(probe_segment, media_type, result);
-                self.check_playlists_ready();
+                self.recheck_player_state();
             }
         }
     }
@@ -1321,12 +1130,12 @@ impl Dispatcher {
     }
 
     fn abort_segment_requests_with_type(&mut self, media_type: MediaType) {
-        let aborted_actions = self.requester.abort_segments_with_type(media_type);
-        for action_id in aborted_actions {
+        let aborted_reqs = self.requester.abort_segments_with_type(media_type);
+        for req_id in aborted_reqs {
             if self
-                .segment_action_tracker
-                .take(action_id)
-                .is_some_and(|action| action.is_probe())
+                .segment_request_contexts
+                .take(req_id)
+                .is_some_and(|ctxt| ctxt.is_probe())
             {
                 self.ready_probe_segment = None;
             }
@@ -1337,20 +1146,170 @@ impl Dispatcher {
     /// anymore and abort their corresponding timers
     fn clean_up_playlist_refresh_timers(&mut self) {
         if let Some(ref pl_store) = self.playlist_store {
-            self.playlist_refresh_timers.retain(|x| {
-                if let PlaylistFileType::MediaPlaylist { id, .. } = &x.1 {
-                    if !pl_store.is_curr_media_playlist(id) {
-                        jsClearTimer(x.0);
-                        return false;
+            self.playlist_refresh_timers
+                .retain(|id| pl_store.is_curr_media_playlist(id))
+        } else {
+            self.playlist_refresh_timers.clear_all_timers();
+        }
+    }
+
+    /// Try to progress `ready_state` when in the `AwaitingPlaylistInfo` state
+    fn inner_advance_awaiting_playlist_info_state(&mut self) {
+        let (starting_position, playlist_store) =
+            match (self.playlist_store.as_mut(), &self.ready_state) {
+                (
+                    Some(playlist_store),
+                    PlayerReadyState::AwaitingPlaylistInfo { starting_position },
+                ) => (*starting_position, playlist_store),
+                _ => {
+                    return;
+                }
+            };
+
+        // Progress through the "startup steps" of the linked `PlaylistStore`, returning `true`
+        let wanted_position = get_initial_position(playlist_store, starting_position);
+        match playlist_store.startup_status(wanted_position) {
+            Ok(StartupStatus::Ready) => false,
+            Ok(StartupStatus::AwaitingSupportCheck) => true,
+            Ok(StartupStatus::NeedsProbe(probe_segment)) => {
+                if self.start_probe_segment_request(probe_segment) {
+                    return;
+                } else {
+                    jsSendSegmentParsingError(
+                        true,
+                        crate::bindings::SegmentParsingErrorCode::UnknownError,
+                        Some(MediaType::Video),
+                        "No probe segment was available to determine startup metadata",
+                    );
+                    self.stop_current_content();
+                    return;
+                }
+            }
+            Err(err) => {
+                self.handle_playlist_store_error(err);
+                self.stop_current_content();
+                return;
+            }
+        };
+
+        // Ensure there's at least one variant that is supported here
+        if playlist_store.playlist_kind() == PlaylistType::MultivariantPlaylist
+            && playlist_store.supported_variants().is_empty()
+        {
+            jsSendOtherError(
+                true,
+                crate::bindings::OtherErrorCode::NoSupportedVariant,
+                "Error while parsing MultivariantPlaylist: no compatible variant found.",
+            );
+            self.stop_current_content();
+            return;
+        }
+
+        // Start fetching initial media playlists if needed
+        use PlaylistFileType::*;
+        [MediaType::Video, MediaType::Audio]
+            .into_iter()
+            .for_each(|mt| {
+                if playlist_store.curr_media_playlist(mt).is_some() {
+                    return; // Already fetched
+                }
+                if let Some(id) = playlist_store.curr_media_playlist_id(mt) {
+                    if let Some(url) = playlist_store.media_playlist_url(id) {
+                        let id = id.clone();
+                        let url = url.clone();
+                        self.requester
+                            .fetch_playlist(url, MediaPlaylist { id, media_type: mt });
                     }
                 }
-                true
             });
+
+        // Now "Announce" lifecycle events if needed
+
+        // SAFETY: The following lines are unsafe because they may actually define raw pointers
+        // to point to Rust's heap memory and put it in the returned values.
+        //
+        // However, we're calling the JS binding function it is communicated to directly
+        // after and thus before the corresponding underlying data had a chance to be
+        // dropped.
+        //
+        // Because one of the rules of those bindings is to copy all pointed data
+        // synchronously on call, we should not encounter any issue.
+        let variants_info =
+            unsafe { format_variants_info_for_js(playlist_store.supported_variants().as_slice()) };
+        let audio_tracks_info =
+            unsafe { format_audio_tracks_for_js(playlist_store.audio_tracks()) };
+        let selected_audio_track = playlist_store.selected_audio_track_id();
+        let is_selected = selected_audio_track.is_some();
+        let curr_audio_track = if let Some(selected) = selected_audio_track {
+            Some(selected)
         } else {
-            while let Some(timer_info) = self.playlist_refresh_timers.pop() {
-                jsClearTimer(timer_info.0);
-            }
+            playlist_store.curr_audio_track_id()
+        };
+        jsAnnounceFetchedContent(
+            playlist_store.playlist_kind(),
+            variants_info,
+            audio_tracks_info,
+        );
+
+        // NOTE: We could also "invent" a variant id / audio track id from this point on?
+        if playlist_store.playlist_kind() == PlaylistType::MultivariantPlaylist {
+            jsAnnounceVariantUpdate(playlist_store.curr_variant().map(|v| v.id()));
+            jsAnnounceTrackUpdate(MediaType::Audio, curr_audio_track, is_selected);
         }
+
+        if playlist_store.are_playlists_ready() {
+            self.ready_state = PlayerReadyState::AwaitingMediaSource { starting_position };
+            self.recheck_player_state();
+        }
+    }
+
+    /// Try to progress `ready_state` when in the `AwaitingMediaSource` state
+    fn inner_advance_awaiting_media_source_state(&mut self) {
+        let starting_pos = match (
+            &self.ready_state,
+            self.media_element_ref.media_source_ready_state(),
+        ) {
+            (_, Some(MediaSourceReadyState::Closed) | None) => {
+                return;
+            }
+            (PlayerReadyState::AwaitingMediaSource { starting_position }, _) => *starting_position,
+            _ => {
+                return;
+            }
+        };
+
+        let Some(playlist_store) = self.playlist_store.as_ref() else {
+            return;
+        };
+
+        let wanted_start = get_initial_position(playlist_store, starting_pos);
+        if wanted_start > 0. {
+            self.media_element_ref.seek(wanted_start);
+        }
+
+        self.ready_state = PlayerReadyState::AwaitingSegments;
+        if playlist_store.playlist_type() != PlaylistNature::VoD {
+            let _ = jsSetMediaSourceDuration(u32::MAX as f64);
+        } else if let Some(duration) = playlist_store.curr_duration() {
+            let _ = jsSetMediaSourceDuration(duration);
+        } else {
+            Logger::warn("Core: Unknown content duration");
+        }
+
+        if let Some(Err(e)) = self.init_source_buffer(MediaType::Audio) {
+            let (code, msg) = format_source_buffer_creation_err_for_js(e);
+            jsSendSourceBufferCreationError(true, code, MediaType::Audio, &msg);
+            self.stop_current_content();
+            return;
+        }
+        if let Some(Err(e)) = self.init_source_buffer(MediaType::Video) {
+            let (code, msg) = format_source_buffer_creation_err_for_js(e);
+            jsSendSourceBufferCreationError(true, code, MediaType::Video, &msg);
+            self.stop_current_content();
+            return;
+        }
+        jsStartObservingPlayback();
+        self.consume_probe_segment();
     }
 }
 
@@ -1371,4 +1330,37 @@ fn was_last_segment(
                     .unwrap_or(false)
         })
         .unwrap_or(false)
+}
+
+fn has_playlist_store_media_type(playlist_store: Option<&PlaylistStore>) -> Option<MediaType> {
+    let playlist_store = playlist_store?;
+    if playlist_store.has_media_type(MediaType::Video) {
+        Some(MediaType::Video)
+    } else if playlist_store.has_media_type(MediaType::Audio) {
+        Some(MediaType::Audio)
+    } else {
+        None
+    }
+}
+
+/// Returns the expected position at which we want to start playback, in seconds, according to
+/// both configuration and playlist metadata.
+fn get_initial_position(
+    playlist_store: &PlaylistStore,
+    starting_position: Option<StartingPosition>,
+) -> f64 {
+    if let Some(starting_pos) = starting_position {
+        match starting_pos.start_type {
+            StartingPositionType::Absolute => starting_pos.position,
+            StartingPositionType::FromBeginning => {
+                playlist_store.curr_min_position().unwrap_or(0.) + starting_pos.position
+            }
+            StartingPositionType::FromEnd => playlist_store
+                .curr_max_position()
+                .map(|max| max - starting_pos.position)
+                .unwrap_or(playlist_store.expected_start_time()),
+        }
+    } else {
+        playlist_store.expected_start_time()
+    }
 }

--- a/src/rs-core/dispatcher/event_listeners/mod.rs
+++ b/src/rs-core/dispatcher/event_listeners/mod.rs
@@ -197,6 +197,7 @@ impl Dispatcher {
 ///
 /// The idea behind this struct is to prevent memory leaks by implementing the
 /// Drop trait on it, so the resource is freed when no ownership of it is left.
+#[derive(Debug)]
 pub struct JsMemoryBlob {
     /// Its unique identifier
     id: ResourceId,

--- a/src/rs-core/dispatcher/mod.rs
+++ b/src/rs-core/dispatcher/mod.rs
@@ -2,6 +2,8 @@ use crate::{
     adaptive::AdaptiveQualitySelector,
     bindings::TimerId,
     media_element::MediaElementReference,
+    media_element::SegmentQualityContext,
+    parser::{ByteRange, SegmentTimeInfo},
     playlist_store::PlaylistStore,
     requester::{PlaylistFileType, Requester},
     segment_selector::NextSegmentSelectors,
@@ -53,6 +55,16 @@ pub struct Dispatcher {
     segment_selectors: NextSegmentSelectors,
 
     playlist_refresh_timers: Vec<(TimerId, PlaylistFileType)>,
+
+    /// When/if loading a MediaPlaylist directly (instead of going through a multivariant
+    /// playlist), we might not have enough information in the playlist itself to start
+    /// setting up buffers and starting the regular playback loop.
+    ///
+    /// Instead, we have to first load a wanted segment, to be able to read that needed
+    /// information from its container first.
+    ///
+    /// This property stores which state of this "probe" process we are in now.
+    direct_media_probe: Option<DirectMediaProbeState>,
 }
 
 /// Identify the playback-related state the `Dispatcher` is in.
@@ -95,4 +107,47 @@ impl StartingPosition {
             position,
         }
     }
+}
+
+/// When/if loading a MediaPlaylist directly (instead of going through a multivariant
+/// playlist), we might not have enough information in the playlist itself on a media's
+/// associated codecs and other similar important properties.
+///
+/// In that case, we have to fetch that data from a segment instead.
+///
+/// `DirectMediaProbeState` stores the state of this process
+#[derive(Debug)]
+enum DirectMediaProbeState {
+    /// We're in the process of loading that segment
+    Pending(ProbeSegmentRequest),
+    /// That initial segment has been fetched
+    Ready {
+        request: ProbeSegmentRequest,
+        data: event_listeners::JsMemoryBlob,
+    },
+}
+
+/// See `DirectMediaProbeState`.
+#[derive(Clone, Debug)]
+struct ProbeSegmentRequest {
+    /// The inferred associated media type to the segment wanted
+    media_type: crate::bindings::MediaType,
+    /// The URL to that segment.
+    url: crate::utils::url::Url,
+    /// The optional byte-range to that segment.
+    byte_range: Option<ByteRange>,
+    context: ProbeSegmentContext,
+}
+
+#[derive(Clone, Debug)]
+enum ProbeSegmentContext {
+    /// This probe segment is a full valid initialization segment
+    InitSegment,
+    /// This probe segment is a full valid Media segment
+    MediaSegment {
+        /// Timing information linked to that media segment
+        time_info: SegmentTimeInfo,
+        /// Other information linked to that media segment
+        context: SegmentQualityContext,
+    },
 }

--- a/src/rs-core/dispatcher/mod.rs
+++ b/src/rs-core/dispatcher/mod.rs
@@ -10,6 +10,9 @@ use crate::{
 mod api;
 mod core;
 mod event_listeners;
+mod segment_action_tracker;
+
+use segment_action_tracker::SegmentActionTracker;
 
 pub(crate) use crate::bindings::{MediaSourceReadyState, PlaybackTickReason, StartingPositionType};
 pub(crate) use event_listeners::{JsMemoryBlob, JsTimeRanges, MediaObservation};
@@ -50,19 +53,20 @@ pub struct Dispatcher {
     /// etc.)
     last_position: f64,
 
+    /// Abstraction allowing to know which is the next segment to request.
     segment_selectors: NextSegmentSelectors,
 
+    /// Current set-up timers to notify about a needed playlist refresh, associated to the playlist
+    /// that needs to be refreshed.
     playlist_refresh_timers: Vec<(TimerId, PlaylistFileType)>,
 
-    /// When/if loading a MediaPlaylist directly (instead of going through a multivariant
-    /// playlist), we might not have enough information in the playlist itself to start
-    /// setting up buffers and starting the regular playback loop.
-    ///
-    /// Instead, we have to first load a wanted segment, to be able to read that needed
-    /// information from its container first.
-    ///
-    /// This property stores which state of this "probe" process we are in now.
-    direct_media_probe: Option<DirectMediaProbeState>,
+    /// Stores data on pending operations linked to init or media segments.
+    /// Allowing to retreive them once finished.
+    segment_action_tracker: SegmentActionTracker,
+
+    /// A startup probe segment that has already been fetched and inspected and now only waits for
+    /// the regular buffering pipeline to be ready before being pushed.
+    ready_probe_segment: Option<ReadyProbeSegment>,
 }
 
 /// Identify the playback-related state the `Dispatcher` is in.
@@ -107,20 +111,8 @@ impl StartingPosition {
     }
 }
 
-/// When/if loading a MediaPlaylist directly (instead of going through a multivariant
-/// playlist), we might not have enough information in the playlist itself on a media's
-/// associated codecs and other similar important properties.
-///
-/// In that case, we have to fetch that data from a segment instead.
-///
-/// `DirectMediaProbeState` stores the state of this process
 #[derive(Debug)]
-enum DirectMediaProbeState {
-    /// We're in the process of loading that segment
-    Pending(ProbeSegmentMetadata),
-    /// That initial segment has been fetched
-    Ready {
-        request: ProbeSegmentMetadata,
-        data: event_listeners::JsMemoryBlob,
-    },
+struct ReadyProbeSegment {
+    request: ProbeSegmentMetadata,
+    data: event_listeners::JsMemoryBlob,
 }

--- a/src/rs-core/dispatcher/mod.rs
+++ b/src/rs-core/dispatcher/mod.rs
@@ -2,9 +2,7 @@ use crate::{
     adaptive::AdaptiveQualitySelector,
     bindings::TimerId,
     media_element::MediaElementReference,
-    media_element::SegmentQualityContext,
-    parser::{ByteRange, SegmentTimeInfo},
-    playlist_store::PlaylistStore,
+    playlist_store::{PlaylistStore, ProbeSegmentMetadata},
     requester::{PlaylistFileType, Requester},
     segment_selector::NextSegmentSelectors,
 };
@@ -30,11 +28,11 @@ pub struct Dispatcher {
     /// mostly based on network metrics.
     adaptive_selector: AdaptiveQualitySelector,
 
-    /// Store the "Multivariant Playlist" (structure which describes the currently
+    /// Store the "Top level Playlist" (structure which describes the currently
     /// loaded content) alongside some state to keep track of the chosen... tracks.
     /// (More technically of variants and media streams).
     ///
-    /// `None` if no "Multivariant Playlist" has been loaded yet.
+    /// `None` if no "Top level Playlist" has been loaded yet.
     playlist_store: Option<PlaylistStore>,
 
     /// Abstraction allowing to perform playlist and segment requests, while
@@ -119,35 +117,10 @@ impl StartingPosition {
 #[derive(Debug)]
 enum DirectMediaProbeState {
     /// We're in the process of loading that segment
-    Pending(ProbeSegmentRequest),
+    Pending(ProbeSegmentMetadata),
     /// That initial segment has been fetched
     Ready {
-        request: ProbeSegmentRequest,
+        request: ProbeSegmentMetadata,
         data: event_listeners::JsMemoryBlob,
-    },
-}
-
-/// See `DirectMediaProbeState`.
-#[derive(Clone, Debug)]
-struct ProbeSegmentRequest {
-    /// The inferred associated media type to the segment wanted
-    media_type: crate::bindings::MediaType,
-    /// The URL to that segment.
-    url: crate::utils::url::Url,
-    /// The optional byte-range to that segment.
-    byte_range: Option<ByteRange>,
-    context: ProbeSegmentContext,
-}
-
-#[derive(Clone, Debug)]
-enum ProbeSegmentContext {
-    /// This probe segment is a full valid initialization segment
-    InitSegment,
-    /// This probe segment is a full valid Media segment
-    MediaSegment {
-        /// Timing information linked to that media segment
-        time_info: SegmentTimeInfo,
-        /// Other information linked to that media segment
-        context: SegmentQualityContext,
     },
 }

--- a/src/rs-core/dispatcher/mod.rs
+++ b/src/rs-core/dispatcher/mod.rs
@@ -1,18 +1,19 @@
 use crate::{
     adaptive::AdaptiveQualitySelector,
-    bindings::TimerId,
+    dispatcher::playlist_refresh_timers::PlaylistRefreshTimers,
     media_element::MediaElementReference,
     playlist_store::{PlaylistStore, ProbeSegmentMetadata},
-    requester::{PlaylistFileType, Requester},
+    requester::Requester,
     segment_selector::NextSegmentSelectors,
 };
 
 mod api;
 mod core;
 mod event_listeners;
-mod segment_action_tracker;
+mod playlist_refresh_timers;
+mod segment_request_contexts;
 
-use segment_action_tracker::SegmentActionTracker;
+use segment_request_contexts::SegmentRequestContexts;
 
 pub(crate) use crate::bindings::{MediaSourceReadyState, PlaybackTickReason, StartingPositionType};
 pub(crate) use event_listeners::{JsMemoryBlob, JsTimeRanges, MediaObservation};
@@ -58,11 +59,11 @@ pub struct Dispatcher {
 
     /// Current set-up timers to notify about a needed playlist refresh, associated to the playlist
     /// that needs to be refreshed.
-    playlist_refresh_timers: Vec<(TimerId, PlaylistFileType)>,
+    playlist_refresh_timers: PlaylistRefreshTimers,
 
-    /// Stores data on pending operations linked to init or media segments.
+    /// Stores data on pending requests linked to init or media segments.
     /// Allowing to retreive them once finished.
-    segment_action_tracker: SegmentActionTracker,
+    segment_request_contexts: SegmentRequestContexts,
 
     /// A startup probe segment that has already been fetched and inspected and now only waits for
     /// the regular buffering pipeline to be ready before being pushed.
@@ -75,28 +76,31 @@ enum PlayerReadyState {
     /// No content is currently loaded.
     Stopped,
 
-    /// We're preparing a content's playlist, MediaSource and SourceBuffers
-    Loading {
+    /// We're preparing a content's playlist base information
+    /// Appears after `Stopped` and before `AwaitingMediaSource`.
+    AwaitingPlaylistInfo {
+        starting_position: Option<StartingPosition>,
+    },
+
+    /// We're creating a `MediaSource` and the corresponding buffers.
+    /// Appears after `AwaitingPlaylistInfo` and before `AwaitingSegments`.
+    AwaitingMediaSource {
         starting_position: Option<StartingPosition>,
     },
 
     /// The SourceBuffers are all ready but currently awaiting segments before
     /// being aple to play.
+    /// Appears after `AwaitingMediaSource` and before `Playing`.
     AwaitingSegments,
 
     /// The content has enough segments to play.
     /// Note that this does not mean the media element is currently playing content:
     /// it can still be paused or at a `0` playback rate.
+    /// Appears after `AwaitingSegments`.
     Playing,
 }
 
-impl PlayerReadyState {
-    pub(crate) fn is_loading(&self) -> bool {
-        matches!(self, PlayerReadyState::Loading { .. })
-    }
-}
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct StartingPosition {
     start_type: StartingPositionType,
     position: f64,

--- a/src/rs-core/dispatcher/playlist_refresh_timers.rs
+++ b/src/rs-core/dispatcher/playlist_refresh_timers.rs
@@ -1,0 +1,72 @@
+use crate::{
+    bindings::{jsClearTimer, jsTimer, TimerId, TimerReason},
+    parser::MediaPlaylistPermanentId,
+};
+
+/// Live/Event Media Playlist may need to be refreshed at regular interval.
+///
+/// This structure simplifies the setup of a timer associated to a content's media playlist(s) by
+/// ensuring:
+/// - that only one timer is set at once for a particular media playlist
+/// - facilitating clean-up of the media playlists that are not of interest anymore
+pub(super) struct PlaylistRefreshTimers(Vec<(TimerId, MediaPlaylistPermanentId)>);
+
+impl PlaylistRefreshTimers {
+    /// Create a new empty `PlaylistRefreshTimers`
+    pub(super) fn new() -> Self {
+        Self(vec![])
+    }
+
+    /// Add or re-set a timer for a specific media playlist, corresponding to the given
+    /// `refresh_interval`.
+    pub(super) fn set_timer(
+        &mut self,
+        pl: MediaPlaylistPermanentId,
+        refresh_interval: Option<f64>,
+    ) {
+        // First if a timer for that one was already set-up, clear it
+        self.0.retain(|(timer_id, playlist_type)| {
+            if playlist_type == &pl {
+                jsClearTimer(*timer_id);
+                false
+            } else {
+                true
+            }
+        });
+
+        if let Some(refresh_interval) = refresh_interval {
+            let timer_id = jsTimer(refresh_interval, TimerReason::MediaPlaylistRefresh);
+            self.0.push((timer_id, pl));
+        }
+    }
+
+    /// To call once a timer has resolved: remove it from stored timers and return information on
+    /// the corresponding media playlist.
+    pub(super) fn resolve_timer(&mut self, timer_id: TimerId) -> Option<MediaPlaylistPermanentId> {
+        let found_idx = self.0.iter().position(|x| x.0 == timer_id)?;
+        let (_, playlist_type) = self.0.remove(found_idx);
+        Some(playlist_type)
+    }
+
+    /// Clear all pending timers triggered by this struct.
+    pub(super) fn clear_all_timers(&mut self) {
+        while let Some(timer_info) = self.0.pop() {
+            jsClearTimer(timer_info.0);
+        }
+    }
+
+    /// Retains only the timers specified by the predicate.
+    pub(super) fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&MediaPlaylistPermanentId) -> bool,
+    {
+        self.0.retain(|x| {
+            if !f(&x.1) {
+                jsClearTimer(x.0);
+                false
+            } else {
+                true
+            }
+        });
+    }
+}

--- a/src/rs-core/dispatcher/segment_action_tracker.rs
+++ b/src/rs-core/dispatcher/segment_action_tracker.rs
@@ -1,0 +1,99 @@
+pub(crate) type SegmentActionId = u32;
+
+use std::collections::HashMap;
+
+use crate::{
+    bindings::MediaType, media_element::SegmentQualityContext, parser::SegmentTimeInfo,
+    playlist_store::ProbeSegmentMetadata,
+};
+
+/// Simple store util which maps pending async segment operations to an u32
+/// `SegmentActionId`.
+///
+/// Modules doing async operation often just refer back to an identifier when done. This
+/// util allows to store the necessary information to take back the context once done.
+///
+/// This type of structure is necessary here because async operations might go through JS,
+/// so we cannot just rely easily on Rust's `async` abstraction to save such state.
+pub(crate) struct SegmentActionTracker {
+    /// `SegmentActionId` that will be returned for the next inserted action.
+    next_action_id: SegmentActionId,
+    /// The stored "actions" themselves.
+    actions: HashMap<SegmentActionId, PendingSegmentAction>,
+}
+
+impl SegmentActionTracker {
+    /// Create a new `SegmentActionTracker`.
+    pub(crate) fn new() -> Self {
+        Self {
+            next_action_id: 0,
+            actions: HashMap::new(),
+        }
+    }
+
+    /// Remove all operations currently waiting on this `SegmentActionTracker`.
+    pub(crate) fn clear(&mut self) {
+        self.actions.clear();
+    }
+
+    /// Add a new pending action in the tracker, returning a `SegmentActionId`.
+    pub(crate) fn insert(&mut self, action: PendingSegmentAction) -> SegmentActionId {
+        let action_id = self.next_action_id;
+
+        // NOTE: We do not assume here the number of actions nor the longevity of the
+        // runtime, so we use `wrapping_add` as a security against overflows.
+        // The risk of conflict is so ridiculously low that it should not matter.
+        self.next_action_id = self.next_action_id.wrapping_add(1);
+        self.actions.insert(action_id, action);
+        action_id
+    }
+
+    /// Get back the context associated to the given `SegmentActionId`.
+    pub(crate) fn take(&mut self, action_id: SegmentActionId) -> Option<PendingSegmentAction> {
+        self.actions.remove(&action_id)
+    }
+
+    /// Check a predicate against all stored actions, returning `true` if any of them matches.
+    pub(crate) fn has<F>(&self, predicate: F) -> bool
+    where
+        F: Fn(&PendingSegmentAction) -> bool,
+    {
+        self.actions.values().any(predicate)
+    }
+}
+
+/// Singular action item inserted into the `SegmentActionTracker`.
+pub(crate) enum PendingSegmentAction {
+    /// This action concerns an initialization segment
+    Init {
+        /// The `MediaType` the initialization segment is linked to.
+        media_type: MediaType,
+        /// Unique identifier identifying that initialization segment for the
+        /// corresponding media and `MediaType`.
+        init_segment_id: f64,
+    },
+    /// This action concerns a media segment
+    Media {
+        /// The `MediaType` the media segment is linked to.
+        media_type: MediaType,
+        /// Time-related metadata linked to that segment.
+        time_info: SegmentTimeInfo,
+        /// Additional context required for ABR
+        quality_context: SegmentQualityContext,
+    },
+    /// This action concerns a "probe" request: we're loading a segment to know about a media's
+    /// characteristics
+    Probe { probe_segment: ProbeSegmentMetadata },
+}
+
+impl PendingSegmentAction {
+    pub(crate) fn is_probe(&self) -> bool {
+        matches!(self, Self::Probe { .. })
+    }
+    pub(crate) fn is_media(&self) -> bool {
+        matches!(self, Self::Media { .. })
+    }
+    pub(crate) fn is_init(&self) -> bool {
+        matches!(self, Self::Init { .. })
+    }
+}

--- a/src/rs-core/dispatcher/segment_request_contexts.rs
+++ b/src/rs-core/dispatcher/segment_request_contexts.rs
@@ -1,4 +1,4 @@
-pub(crate) type SegmentActionId = u32;
+pub(crate) type SegmentRequestId = u32;
 
 use std::collections::HashMap;
 
@@ -8,63 +8,63 @@ use crate::{
 };
 
 /// Simple store util which maps pending async segment operations to an u32
-/// `SegmentActionId`.
+/// `SegmentRequestId`.
 ///
 /// Modules doing async operation often just refer back to an identifier when done. This
 /// util allows to store the necessary information to take back the context once done.
 ///
 /// This type of structure is necessary here because async operations might go through JS,
 /// so we cannot just rely easily on Rust's `async` abstraction to save such state.
-pub(crate) struct SegmentActionTracker {
-    /// `SegmentActionId` that will be returned for the next inserted action.
-    next_action_id: SegmentActionId,
-    /// The stored "actions" themselves.
-    actions: HashMap<SegmentActionId, PendingSegmentAction>,
+pub(crate) struct SegmentRequestContexts {
+    /// `SegmentRequestId` that will be returned for the next inserted item.
+    next_request_id: SegmentRequestId,
+    /// The stored "contexts" themselves.
+    contexts: HashMap<SegmentRequestId, PendingSegmentRequest>,
 }
 
-impl SegmentActionTracker {
-    /// Create a new `SegmentActionTracker`.
+impl SegmentRequestContexts {
+    /// Create a new `SegmentRequestContexts`.
     pub(crate) fn new() -> Self {
         Self {
-            next_action_id: 0,
-            actions: HashMap::new(),
+            next_request_id: 0,
+            contexts: HashMap::new(),
         }
     }
 
-    /// Remove all operations currently waiting on this `SegmentActionTracker`.
+    /// Remove all operations currently stored on this `SegmentRequestContexts`.
     pub(crate) fn clear(&mut self) {
-        self.actions.clear();
+        self.contexts.clear();
     }
 
-    /// Add a new pending action in the tracker, returning a `SegmentActionId`.
-    pub(crate) fn insert(&mut self, action: PendingSegmentAction) -> SegmentActionId {
-        let action_id = self.next_action_id;
+    /// Add context for a new request, returning a `SegmentRequestId`.
+    pub(crate) fn insert(&mut self, context: PendingSegmentRequest) -> SegmentRequestId {
+        let request_id = self.next_request_id;
 
-        // NOTE: We do not assume here the number of actions nor the longevity of the
+        // NOTE: We do not assume here the number of requests nor the longevity of the
         // runtime, so we use `wrapping_add` as a security against overflows.
         // The risk of conflict is so ridiculously low that it should not matter.
-        self.next_action_id = self.next_action_id.wrapping_add(1);
-        self.actions.insert(action_id, action);
-        action_id
+        self.next_request_id = self.next_request_id.wrapping_add(1);
+        self.contexts.insert(request_id, context);
+        request_id
     }
 
-    /// Get back the context associated to the given `SegmentActionId`.
-    pub(crate) fn take(&mut self, action_id: SegmentActionId) -> Option<PendingSegmentAction> {
-        self.actions.remove(&action_id)
+    /// Get back the context associated to the given `SegmentRequestId`.
+    pub(crate) fn take(&mut self, request_id: SegmentRequestId) -> Option<PendingSegmentRequest> {
+        self.contexts.remove(&request_id)
     }
 
-    /// Check a predicate against all stored actions, returning `true` if any of them matches.
+    /// Check a predicate against all stored contexts, returning `true` if any of them matches.
     pub(crate) fn has<F>(&self, predicate: F) -> bool
     where
-        F: Fn(&PendingSegmentAction) -> bool,
+        F: Fn(&PendingSegmentRequest) -> bool,
     {
-        self.actions.values().any(predicate)
+        self.contexts.values().any(predicate)
     }
 }
 
-/// Singular action item inserted into the `SegmentActionTracker`.
-pub(crate) enum PendingSegmentAction {
-    /// This action concerns an initialization segment
+/// Singular item inserted into the `SegmentRequestContexts`.
+pub(crate) enum PendingSegmentRequest {
+    /// This request concerns an initialization segment
     Init {
         /// The `MediaType` the initialization segment is linked to.
         media_type: MediaType,
@@ -72,7 +72,7 @@ pub(crate) enum PendingSegmentAction {
         /// corresponding media and `MediaType`.
         init_segment_id: f64,
     },
-    /// This action concerns a media segment
+    /// This request concerns a media segment
     Media {
         /// The `MediaType` the media segment is linked to.
         media_type: MediaType,
@@ -81,12 +81,12 @@ pub(crate) enum PendingSegmentAction {
         /// Additional context required for ABR
         quality_context: SegmentQualityContext,
     },
-    /// This action concerns a "probe" request: we're loading a segment to know about a media's
+    /// This request concerns a "probe" request: we're loading a segment to know about a media's
     /// characteristics
     Probe { probe_segment: ProbeSegmentMetadata },
 }
 
-impl PendingSegmentAction {
+impl PendingSegmentRequest {
     pub(crate) fn is_probe(&self) -> bool {
         matches!(self, Self::Probe { .. })
     }

--- a/src/rs-core/parser/media_playlist.rs
+++ b/src/rs-core/parser/media_playlist.rs
@@ -85,6 +85,15 @@ impl SegmentList {
     pub(crate) fn media(&self) -> &[MediaSegmentInfo] {
         self.media.as_slice()
     }
+
+    /// Returns information on the segment including the position given, in seconds.
+    ///
+    /// Returns `None` if no such media segment is found.
+    pub(crate) fn segment_from_pos(&self, pos: f64) -> Option<&MediaSegmentInfo> {
+        self.media
+            .iter()
+            .find(|s| s.end() > pos && s.start() <= pos)
+    }
 }
 
 /// Information linked to an initialization segment.
@@ -532,7 +541,9 @@ impl MediaPlaylist {
                 if is_precise {
                     Some(actual_time)
                 } else {
-                    self.segment_from_pos(actual_time).map(|s| s.start())
+                    self.segment_list
+                        .segment_from_pos(actual_time)
+                        .map(|s| s.start())
                 }
             })
     }
@@ -649,17 +660,5 @@ impl MediaPlaylist {
     /// Returns `None` if unknown.
     fn extension(&self) -> Option<&str> {
         self.segment_list.media().first().map(|s| s.url.extension())
-    }
-
-    /// Returns information on the segment including the position given, in seconds.
-    ///
-    /// Returns `None` if no such media segment is found.
-    /// XXX TODO: Why is this one now public? How was segment requesting done before? Shouldn't we
-    /// go through `SegmentList`?
-    pub(crate) fn segment_from_pos(&self, pos: f64) -> Option<&MediaSegmentInfo> {
-        self.segment_list
-            .media()
-            .iter()
-            .find(|s| s.end() > pos && s.start() <= pos)
     }
 }

--- a/src/rs-core/parser/media_playlist.rs
+++ b/src/rs-core/parser/media_playlist.rs
@@ -654,7 +654,9 @@ impl MediaPlaylist {
     /// Returns information on the segment including the position given, in seconds.
     ///
     /// Returns `None` if no such media segment is found.
-    fn segment_from_pos(&self, pos: f64) -> Option<&MediaSegmentInfo> {
+    /// XXX TODO: Why is this one now public? How was segment requesting done before? Shouldn't we
+    /// go through `SegmentList`?
+    pub(crate) fn segment_from_pos(&self, pos: f64) -> Option<&MediaSegmentInfo> {
         self.segment_list
             .media()
             .iter()

--- a/src/rs-core/parser/mod.rs
+++ b/src/rs-core/parser/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use multi_variant_playlist::{
     MediaPlaylistPermanentId, MediaPlaylistUpdateError, MultivariantPlaylistParsingError,
 };
 pub(crate) use top_level_playlist::{
-    DirectMediaPlaylist, ProbeSegmentPayload, TopLevelPlaylist, TopLevelPlaylistParsingError,
+    DirectMediaInfo, TopLevelPlaylist, TopLevelPlaylistParsingError,
 };
 pub(crate) use value_parsers::ByteRange;
 pub(crate) use variant_stream::{VariantStream, VideoResolution};

--- a/src/rs-core/parser/mod.rs
+++ b/src/rs-core/parser/mod.rs
@@ -3,6 +3,7 @@ mod audio_track_list;
 mod media_playlist;
 mod media_tag;
 mod multi_variant_playlist;
+mod top_level_playlist;
 mod value_parsers;
 mod variable_substitution;
 mod variant_stream;
@@ -14,8 +15,8 @@ pub(crate) use media_playlist::{
 };
 pub(crate) use media_tag::{MediaTag, MediaTagType};
 pub(crate) use multi_variant_playlist::{
-    MediaPlaylistPermanentId, MediaPlaylistUpdateError, MultivariantPlaylist,
-    MultivariantPlaylistParsingError,
+    MediaPlaylistPermanentId, MediaPlaylistUpdateError, MultivariantPlaylistParsingError,
 };
+pub(crate) use top_level_playlist::{TopLevelPlaylist, TopLevelPlaylistParsingError};
 pub(crate) use value_parsers::ByteRange;
 pub(crate) use variant_stream::{VariantStream, VideoResolution};

--- a/src/rs-core/parser/mod.rs
+++ b/src/rs-core/parser/mod.rs
@@ -17,6 +17,8 @@ pub(crate) use media_tag::{MediaTag, MediaTagType};
 pub(crate) use multi_variant_playlist::{
     MediaPlaylistPermanentId, MediaPlaylistUpdateError, MultivariantPlaylistParsingError,
 };
-pub(crate) use top_level_playlist::{TopLevelPlaylist, TopLevelPlaylistParsingError};
+pub(crate) use top_level_playlist::{
+    DirectMediaPlaylist, ProbeSegmentPayload, TopLevelPlaylist, TopLevelPlaylistParsingError,
+};
 pub(crate) use value_parsers::ByteRange;
 pub(crate) use variant_stream::{VariantStream, VideoResolution};

--- a/src/rs-core/parser/multi_variant_playlist.rs
+++ b/src/rs-core/parser/multi_variant_playlist.rs
@@ -65,9 +65,7 @@ impl MultivariantPlaylist {
             }
         }
         while let Some(line) = lines.next() {
-            let str_line = if let Ok(s) = line {
-                s
-            } else {
+            let Ok(str_line) = line else {
                 return Err(MultivariantPlaylistParsingError::UnableToReadLine);
             };
             if str_line.is_empty() {

--- a/src/rs-core/parser/multi_variant_playlist.rs
+++ b/src/rs-core/parser/multi_variant_playlist.rs
@@ -393,17 +393,21 @@ impl MultivariantPlaylist {
     ///   - The given `MediaPlaylistPermanentId` is linked to some media which isn't linked to
     ///     a MediaPlaylist. In that condition, it is the MediaPlaylist linked to its Variant
     ///     stream that should be done.
+    ///   - The given resource is not linked to a MultiVariantPlaylist
     ///
-    /// Both are probably an error as a `MediaPlaylistPermanentId` should always identify a
+    /// Those are probably errors as a `MediaPlaylistPermanentId` should always identify a
     /// `MediaPlaylist`.
     pub(crate) fn media_playlist_url(&self, wanted_id: &MediaPlaylistPermanentId) -> Option<&Url> {
         match wanted_id.location() {
             MediaPlaylistUrlLocation::Variant => Some(self.variant(wanted_id.id())?.url()),
             MediaPlaylistUrlLocation::AudioTrack => self.audio_url(wanted_id.id()),
             MediaPlaylistUrlLocation::OtherMedia => self.other_media_url(wanted_id.id()),
+            MediaPlaylistUrlLocation::Direct => None, // Should not happen
         }
     }
 
+    /// Returns reference to the `MediaPlaylist` whose `MediaPlaylistPermanentId` is given in
+    /// argument.
     pub(crate) fn media_playlist(
         &self,
         wanted_id: &MediaPlaylistPermanentId,
@@ -414,6 +418,7 @@ impl MultivariantPlaylist {
             }
             MediaPlaylistUrlLocation::AudioTrack => self.audio_playlist(wanted_id.id()),
             MediaPlaylistUrlLocation::OtherMedia => self.other_media_playlist(wanted_id.id()),
+            MediaPlaylistUrlLocation::Direct => None, // Should not happen
         }
     }
 
@@ -433,6 +438,8 @@ impl MultivariantPlaylist {
             MediaPlaylistUrlLocation::OtherMedia => {
                 self.update_other_media_playlist(id.id(), data, url)
             }
+            // Should not happen
+            MediaPlaylistUrlLocation::Direct => Err(MediaPlaylistUpdateError::NotFound),
         }
     }
 
@@ -658,7 +665,7 @@ pub struct MediaPlaylistPermanentId {
 }
 
 impl MediaPlaylistPermanentId {
-    fn new(location: MediaPlaylistUrlLocation, id: u32) -> Self {
+    pub(crate) fn new(location: MediaPlaylistUrlLocation, id: u32) -> Self {
         Self { location, id }
     }
 
@@ -676,13 +683,16 @@ impl MediaPlaylistPermanentId {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum MediaPlaylistUrlLocation {
+pub(crate) enum MediaPlaylistUrlLocation {
     /// This Media Playlist's URL is defined by a variant in the `MultivariantPlaylist` object.
     Variant,
     /// This Media Playlist's URL is an audio-specific track in the `MultivariantPlaylist` object.
     AudioTrack,
     /// This Media Playlist's URL is defined as another media in the `MultivariantPlaylist` object.
     OtherMedia,
+    /// This Media Playlist was directly loaded as the top-level playlist.
+    /// In that case, no `MultiVariantPlaylist` should be available.
+    Direct,
 }
 
 #[cfg(test)]

--- a/src/rs-core/parser/top_level_playlist.rs
+++ b/src/rs-core/parser/top_level_playlist.rs
@@ -5,11 +5,7 @@ use super::{
         MediaPlaylistUrlLocation, MultivariantPlaylist, MultivariantPlaylistParsingError,
     },
 };
-use crate::{
-    bindings::MediaType,
-    parser::{ByteRange, SegmentTimeInfo},
-    utils::url::Url,
-};
+use crate::utils::url::Url;
 use std::{fmt, io};
 
 pub(crate) enum TopLevelPlaylist {
@@ -24,27 +20,20 @@ pub(crate) struct DirectMediaPlaylist {
     id: MediaPlaylistPermanentId,
     /// Url to that media playlist
     url: Url,
-    /// Inferred media type for the segments contained in that media playlist
-    /// XXX TODO: Option?
-    media_type: MediaType,
     /// The `MediaPlaylist` itself
     playlist: MediaPlaylist,
-    /// Known codec string for the segments of that media playlist.
+    /// Known metadata for the segments of that media playlist.
     ///
     /// Can rely on the loading of a "probe segment" in which case it is first set to
     /// `None` and only set to an actual value when known.
-    codec: Option<String>,
+    media_info: Option<DirectMediaInfo>,
 }
 
-pub(crate) struct ProbeSegment {
-    pub(crate) url: Url,
-    pub(crate) byte_range: Option<ByteRange>,
-    pub(crate) payload: ProbeSegmentPayload,
-}
-
-pub(crate) enum ProbeSegmentPayload {
-    Init,
-    Media { time_info: SegmentTimeInfo },
+#[derive(Clone)]
+pub(crate) struct DirectMediaInfo {
+    pub(crate) mime_type: String,
+    pub(crate) media_type: crate::bindings::MediaType,
+    pub(crate) codec: String,
 }
 
 impl TopLevelPlaylist {
@@ -76,13 +65,11 @@ impl DirectMediaPlaylist {
             None,
             &MediaPlaylistContext::default(),
         )?;
-        let media_type = infer_direct_media_type(&playlist);
         Ok(Self {
             id: MediaPlaylistPermanentId::new(MediaPlaylistUrlLocation::Direct, 0),
             url,
-            media_type,
             playlist,
-            codec: None,
+            media_info: None,
         })
     }
 
@@ -94,43 +81,16 @@ impl DirectMediaPlaylist {
         &self.url
     }
 
-    pub(crate) fn media_type(&self) -> MediaType {
-        self.media_type
-    }
-
     pub(crate) fn playlist(&self) -> &MediaPlaylist {
         &self.playlist
     }
 
-    pub(crate) fn codec(&self) -> Option<&str> {
-        self.codec.as_deref()
+    pub(crate) fn media_info(&self) -> Option<&DirectMediaInfo> {
+        self.media_info.as_ref()
     }
 
-    pub(crate) fn set_codec(&mut self, codec: String) {
-        self.codec = Some(codec);
-    }
-
-    // XXX TODO: Unsure if this is the responsibility of top_level_playlist
-    pub(crate) fn probe_segment_for(&self, wanted_position: f64) -> Option<ProbeSegment> {
-        let media_segment = self
-            .playlist
-            .segment_from_pos(wanted_position)
-            .or_else(|| self.playlist.segment_list().media().first())?;
-        if let Some(init_segment) = self.playlist.segment_list().init_for(media_segment) {
-            Some(ProbeSegment {
-                url: init_segment.url().clone(),
-                byte_range: init_segment.byte_range().cloned(),
-                payload: ProbeSegmentPayload::Init,
-            })
-        } else {
-            Some(ProbeSegment {
-                url: media_segment.url().clone(),
-                byte_range: media_segment.byte_range().cloned(),
-                payload: ProbeSegmentPayload::Media {
-                    time_info: media_segment.time_info().clone(),
-                },
-            })
-        }
+    pub(crate) fn set_media_info(&mut self, media_info: DirectMediaInfo) {
+        self.media_info = Some(media_info);
     }
 
     pub(crate) fn media_playlist_url(&self, wanted_id: &MediaPlaylistPermanentId) -> Option<&Url> {
@@ -167,7 +127,6 @@ impl DirectMediaPlaylist {
             Some(&self.playlist),
             &MediaPlaylistContext::default(),
         )?;
-        self.media_type = infer_direct_media_type(&updated);
         self.url = url;
         self.playlist = updated;
         Ok(&self.playlist)
@@ -200,14 +159,4 @@ fn is_multivariant_playlist(data: &[u8]) -> bool {
         }
     }
     false
-}
-
-// XXX TODO: Some checking to do here
-fn infer_direct_media_type(playlist: &MediaPlaylist) -> MediaType {
-    let has_audio_mime = playlist.mime_type(MediaType::Audio).is_some();
-    let has_video_mime = playlist.mime_type(MediaType::Video).is_some();
-    match (has_audio_mime, has_video_mime) {
-        (true, false) => MediaType::Audio,
-        _ => MediaType::Video,
-    }
 }

--- a/src/rs-core/parser/top_level_playlist.rs
+++ b/src/rs-core/parser/top_level_playlist.rs
@@ -1,0 +1,154 @@
+use super::{
+    media_playlist::{MediaPlaylist, MediaPlaylistParsingError},
+    multi_variant_playlist::{
+        MediaPlaylistContext, MediaPlaylistPermanentId, MediaPlaylistUpdateError,
+        MediaPlaylistUrlLocation, MultivariantPlaylist, MultivariantPlaylistParsingError,
+    },
+};
+use crate::{bindings::MediaType, utils::url::Url};
+use std::{fmt, io};
+
+pub(crate) enum TopLevelPlaylist {
+    Multivariant(MultivariantPlaylist),
+    DirectMedia(DirectMediaPlaylist),
+}
+
+pub(crate) struct DirectMediaPlaylist {
+    id: MediaPlaylistPermanentId,
+    url: Url,
+    media_type: MediaType,
+    playlist: MediaPlaylist,
+}
+
+impl TopLevelPlaylist {
+    pub(crate) fn parse(data: &[u8], url: Url) -> Result<Self, TopLevelPlaylistParsingError> {
+        if is_multivariant_playlist(data) {
+            MultivariantPlaylist::parse(io::Cursor::new(data), url)
+                .map(Self::Multivariant)
+                .map_err(TopLevelPlaylistParsingError::Multivariant)
+        } else {
+            DirectMediaPlaylist::parse(data, url)
+                .map(Self::DirectMedia)
+                .map_err(TopLevelPlaylistParsingError::Media)
+        }
+    }
+
+    pub(crate) fn url(&self) -> &Url {
+        match self {
+            Self::Multivariant(playlist) => playlist.url(),
+            Self::DirectMedia(playlist) => playlist.url(),
+        }
+    }
+}
+
+impl DirectMediaPlaylist {
+    pub(crate) fn parse(data: &[u8], url: Url) -> Result<Self, MediaPlaylistParsingError> {
+        let playlist = MediaPlaylist::create(
+            io::Cursor::new(data),
+            url.clone(),
+            None,
+            &MediaPlaylistContext::default(),
+        )?;
+        let media_type = infer_direct_media_type(&playlist);
+        Ok(Self {
+            id: MediaPlaylistPermanentId::new(MediaPlaylistUrlLocation::Direct, 0),
+            url,
+            media_type,
+            playlist,
+        })
+    }
+
+    pub(crate) fn id(&self) -> &MediaPlaylistPermanentId {
+        &self.id
+    }
+
+    pub(crate) fn url(&self) -> &Url {
+        &self.url
+    }
+
+    pub(crate) fn media_type(&self) -> MediaType {
+        self.media_type
+    }
+
+    pub(crate) fn playlist(&self) -> &MediaPlaylist {
+        &self.playlist
+    }
+
+    pub(crate) fn media_playlist_url(&self, wanted_id: &MediaPlaylistPermanentId) -> Option<&Url> {
+        if wanted_id == &self.id {
+            Some(&self.url)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn media_playlist(
+        &self,
+        wanted_id: &MediaPlaylistPermanentId,
+    ) -> Option<&MediaPlaylist> {
+        if wanted_id == &self.id {
+            Some(&self.playlist)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn update_media_playlist(
+        &mut self,
+        id: &MediaPlaylistPermanentId,
+        media_playlist_data: impl io::BufRead,
+        url: Url,
+    ) -> Result<&MediaPlaylist, MediaPlaylistUpdateError> {
+        if id != &self.id {
+            return Err(MediaPlaylistUpdateError::NotFound);
+        }
+        let updated = MediaPlaylist::create(
+            media_playlist_data,
+            url.clone(),
+            Some(&self.playlist),
+            &MediaPlaylistContext::default(),
+        )?;
+        self.media_type = infer_direct_media_type(&updated);
+        self.url = url;
+        self.playlist = updated;
+        Ok(&self.playlist)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum TopLevelPlaylistParsingError {
+    Multivariant(MultivariantPlaylistParsingError),
+    Media(MediaPlaylistParsingError),
+}
+
+impl fmt::Display for TopLevelPlaylistParsingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Multivariant(err) => err.fmt(f),
+            Self::Media(err) => err.fmt(f),
+        }
+    }
+}
+
+fn is_multivariant_playlist(data: &[u8]) -> bool {
+    for line in data.split(|b| *b == b'\n') {
+        let line = std::str::from_utf8(line).unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with("#EXT-X-STREAM-INF") || line.starts_with("#EXT-X-MEDIA") {
+            return true;
+        }
+    }
+    false
+}
+
+// XXX TODO: Some checking to do here
+fn infer_direct_media_type(playlist: &MediaPlaylist) -> MediaType {
+    let has_audio_mime = playlist.mime_type(MediaType::Audio).is_some();
+    let has_video_mime = playlist.mime_type(MediaType::Video).is_some();
+    match (has_audio_mime, has_video_mime) {
+        (true, false) => MediaType::Audio,
+        _ => MediaType::Video,
+    }
+}

--- a/src/rs-core/parser/top_level_playlist.rs
+++ b/src/rs-core/parser/top_level_playlist.rs
@@ -38,16 +38,20 @@ pub(crate) struct DirectMediaInfo {
 
 impl TopLevelPlaylist {
     pub(crate) fn parse(data: &[u8], url: Url) -> Result<Self, TopLevelPlaylistParsingError> {
-        if is_multivariant_playlist(data) {
-            Logger::info("Parser: this is a multivariant playlist, parsing...");
-            MultivariantPlaylist::parse(io::Cursor::new(data), url)
-                .map(Self::Multivariant)
-                .map_err(TopLevelPlaylistParsingError::Multivariant)
-        } else {
-            Logger::info("Parser: this is a top-level media playlist, parsing...");
-            DirectMediaPlaylist::parse(data, url)
-                .map(Self::DirectMedia)
-                .map_err(TopLevelPlaylistParsingError::Media)
+        match classify_playlist(data) {
+            PlaylistKind::Multivariant => {
+                Logger::info("Parser: this is a multivariant playlist, parsing...");
+                MultivariantPlaylist::parse(io::Cursor::new(data), url)
+                    .map(Self::Multivariant)
+                    .map_err(TopLevelPlaylistParsingError::Multivariant)
+            }
+            PlaylistKind::Media => {
+                Logger::info("Parser: this is a top-level media playlist, parsing...");
+                DirectMediaPlaylist::parse(data, url)
+                    .map(Self::DirectMedia)
+                    .map_err(TopLevelPlaylistParsingError::Media)
+            }
+            PlaylistKind::NotAPlaylist => Err(TopLevelPlaylistParsingError::NotAPlaylist),
         }
     }
 
@@ -139,6 +143,7 @@ impl DirectMediaPlaylist {
 pub(crate) enum TopLevelPlaylistParsingError {
     Multivariant(MultivariantPlaylistParsingError),
     Media(MediaPlaylistParsingError),
+    NotAPlaylist,
 }
 
 impl fmt::Display for TopLevelPlaylistParsingError {
@@ -146,21 +151,79 @@ impl fmt::Display for TopLevelPlaylistParsingError {
         match self {
             Self::Multivariant(err) => err.fmt(f),
             Self::Media(err) => err.fmt(f),
+            Self::NotAPlaylist => {
+                write!(f, "The loaded resource does not seem to be an HLS playlist")
+            }
         }
     }
 }
 
-fn is_multivariant_playlist(data: &[u8]) -> bool {
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PlaylistKind {
+    Multivariant,
+    Media,
+    NotAPlaylist,
+}
+
+pub fn classify_playlist(data: &[u8]) -> PlaylistKind {
+    let mut first_non_empty_line = true;
+
     for line in data.split(|b| *b == b'\n') {
-        let line = std::str::from_utf8(line).unwrap_or("").trim();
+        let line = match std::str::from_utf8(line) {
+            Ok(l) => l.trim(),
+            Err(_) => continue,
+        };
+
         if line.is_empty() {
             continue;
         }
-        // XXX TODO: Maybe we should assume Multivariant and do the reverse check to limit
-        //           impact?
+
+        if first_non_empty_line {
+            first_non_empty_line = false;
+            if line != "#EXTM3U" {
+                return PlaylistKind::NotAPlaylist;
+            }
+            continue;
+        }
+
         if line.starts_with("#EXT-X-STREAM-INF:") || line.starts_with("#EXT-X-MEDIA:") {
-            return true;
+            return PlaylistKind::Multivariant;
+        }
+
+        if line.starts_with("#EXT-X-TARGETDURATION")
+            || line.starts_with("#EXT-X-MEDIA-SEQUENCE")
+            || line.starts_with("#EXTINF:")
+        {
+            return PlaylistKind::Media;
         }
     }
-    false
+
+    // Reached end of file without finding media playlist tags.
+    // If #EXTM3U was present, assume Multivariant.
+    if first_non_empty_line {
+        PlaylistKind::NotAPlaylist
+    } else {
+        PlaylistKind::Multivariant
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_playlist, PlaylistKind};
+
+    #[test]
+    fn classifies_non_playlist_input() {
+        assert_eq!(
+            classify_playlist(b"<html>not hls</html>"),
+            PlaylistKind::NotAPlaylist
+        );
+    }
+
+    #[test]
+    fn classifies_media_playlist_input() {
+        assert_eq!(
+            classify_playlist(b"#EXTM3U\n#EXT-X-TARGETDURATION:4\n#EXTINF:4,\nseg.ts\n"),
+            PlaylistKind::Media
+        );
+    }
 }

--- a/src/rs-core/parser/top_level_playlist.rs
+++ b/src/rs-core/parser/top_level_playlist.rs
@@ -5,7 +5,7 @@ use super::{
         MediaPlaylistUrlLocation, MultivariantPlaylist, MultivariantPlaylistParsingError,
     },
 };
-use crate::utils::url::Url;
+use crate::{utils::url::Url, Logger};
 use std::{fmt, io};
 
 pub(crate) enum TopLevelPlaylist {
@@ -39,10 +39,12 @@ pub(crate) struct DirectMediaInfo {
 impl TopLevelPlaylist {
     pub(crate) fn parse(data: &[u8], url: Url) -> Result<Self, TopLevelPlaylistParsingError> {
         if is_multivariant_playlist(data) {
+            Logger::info("Parser: this is a multivariant playlist, parsing...");
             MultivariantPlaylist::parse(io::Cursor::new(data), url)
                 .map(Self::Multivariant)
                 .map_err(TopLevelPlaylistParsingError::Multivariant)
         } else {
+            Logger::info("Parser: this is a top-level media playlist, parsing...");
             DirectMediaPlaylist::parse(data, url)
                 .map(Self::DirectMedia)
                 .map_err(TopLevelPlaylistParsingError::Media)
@@ -154,7 +156,9 @@ fn is_multivariant_playlist(data: &[u8]) -> bool {
         if line.is_empty() {
             continue;
         }
-        if line.starts_with("#EXT-X-STREAM-INF") || line.starts_with("#EXT-X-MEDIA") {
+        // XXX TODO: Maybe we should assume Multivariant and do the reverse check to limit
+        //           impact?
+        if line.starts_with("#EXT-X-STREAM-INF:") || line.starts_with("#EXT-X-MEDIA:") {
             return true;
         }
     }

--- a/src/rs-core/parser/top_level_playlist.rs
+++ b/src/rs-core/parser/top_level_playlist.rs
@@ -5,7 +5,11 @@ use super::{
         MediaPlaylistUrlLocation, MultivariantPlaylist, MultivariantPlaylistParsingError,
     },
 };
-use crate::{bindings::MediaType, utils::url::Url};
+use crate::{
+    bindings::MediaType,
+    parser::{ByteRange, SegmentTimeInfo},
+    utils::url::Url,
+};
 use std::{fmt, io};
 
 pub(crate) enum TopLevelPlaylist {
@@ -13,11 +17,34 @@ pub(crate) enum TopLevelPlaylist {
     DirectMedia(DirectMediaPlaylist),
 }
 
+/// Top-level Media playlist, i.e. there's no Multivariant playlist to rely on,
+/// only a media playlist.
 pub(crate) struct DirectMediaPlaylist {
+    /// Unique identifier for this Media playlist
     id: MediaPlaylistPermanentId,
+    /// Url to that media playlist
     url: Url,
+    /// Inferred media type for the segments contained in that media playlist
+    /// XXX TODO: Option?
     media_type: MediaType,
+    /// The `MediaPlaylist` itself
     playlist: MediaPlaylist,
+    /// Known codec string for the segments of that media playlist.
+    ///
+    /// Can rely on the loading of a "probe segment" in which case it is first set to
+    /// `None` and only set to an actual value when known.
+    codec: Option<String>,
+}
+
+pub(crate) struct ProbeSegment {
+    pub(crate) url: Url,
+    pub(crate) byte_range: Option<ByteRange>,
+    pub(crate) payload: ProbeSegmentPayload,
+}
+
+pub(crate) enum ProbeSegmentPayload {
+    Init,
+    Media { time_info: SegmentTimeInfo },
 }
 
 impl TopLevelPlaylist {
@@ -55,6 +82,7 @@ impl DirectMediaPlaylist {
             url,
             media_type,
             playlist,
+            codec: None,
         })
     }
 
@@ -72,6 +100,37 @@ impl DirectMediaPlaylist {
 
     pub(crate) fn playlist(&self) -> &MediaPlaylist {
         &self.playlist
+    }
+
+    pub(crate) fn codec(&self) -> Option<&str> {
+        self.codec.as_deref()
+    }
+
+    pub(crate) fn set_codec(&mut self, codec: String) {
+        self.codec = Some(codec);
+    }
+
+    // XXX TODO: Unsure if this is the responsibility of top_level_playlist
+    pub(crate) fn probe_segment_for(&self, wanted_position: f64) -> Option<ProbeSegment> {
+        let media_segment = self
+            .playlist
+            .segment_from_pos(wanted_position)
+            .or_else(|| self.playlist.segment_list().media().first())?;
+        if let Some(init_segment) = self.playlist.segment_list().init_for(media_segment) {
+            Some(ProbeSegment {
+                url: init_segment.url().clone(),
+                byte_range: init_segment.byte_range().cloned(),
+                payload: ProbeSegmentPayload::Init,
+            })
+        } else {
+            Some(ProbeSegment {
+                url: media_segment.url().clone(),
+                byte_range: media_segment.byte_range().cloned(),
+                payload: ProbeSegmentPayload::Media {
+                    time_info: media_segment.time_info().clone(),
+                },
+            })
+        }
     }
 
     pub(crate) fn media_playlist_url(&self, wanted_id: &MediaPlaylistPermanentId) -> Option<&Url> {

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -2,8 +2,8 @@ use crate::{
     bindings::{jsIsTypeSupported, MediaType, PlaylistNature},
     media_element::SegmentQualityContext,
     parser::{
-        AudioTrack, MediaPlaylist, MediaPlaylistUpdateError, SegmentList, TopLevelPlaylist,
-        VariantStream,
+        AudioTrack, DirectMediaPlaylist, MediaPlaylist, MediaPlaylistUpdateError, SegmentList,
+        TopLevelPlaylist, VariantStream,
     },
     utils::url::Url,
     Logger,
@@ -268,6 +268,40 @@ impl PlaylistStore {
             TopLevelPlaylist::DirectMedia(playlist) => {
                 playlist.update_media_playlist(id, media_playlist_data, url)
             }
+        }
+    }
+
+    pub(crate) fn current_codec(&self, media_type: MediaType) -> Option<String> {
+        match &self.playlist {
+            TopLevelPlaylist::Multivariant(_) => self.curr_variant()?.codecs(media_type),
+            TopLevelPlaylist::DirectMedia(playlist) => {
+                if playlist.media_type() == media_type {
+                    playlist.codec().map(ToString::to_string)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    /// XXX TODO: Sad that we need to leak that abstraction
+    pub(crate) fn direct_media(&self) -> Option<&DirectMediaPlaylist> {
+        match &self.playlist {
+            TopLevelPlaylist::DirectMedia(playlist) => Some(playlist),
+            TopLevelPlaylist::Multivariant(_) => None,
+        }
+    }
+
+    /// Only if the current `TopLevelPlaylist` is ~DirectMedia`` (going through a media
+    /// playlist directly instead of a multivariant playlist), associate the given codec
+    /// to it.
+    /// XXX TODO: Is this the role of this abstraction to do that weird branching?
+    pub(crate) fn set_direct_media_codec(&mut self, codec: String) {
+        match &mut self.playlist {
+            TopLevelPlaylist::DirectMedia(playlist) => {
+                playlist.set_codec(codec);
+            }
+            TopLevelPlaylist::Multivariant(_) => {}
         }
     }
 

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -247,8 +247,31 @@ impl PlaylistStore {
         ret
     }
 
+    // TODO: This one is ugly, remove
+    pub(crate) fn direct_media_playlist(
+        &self,
+    ) -> Option<(&MediaPlaylistPermanentId, &MediaPlaylist)> {
+        match &self.playlist {
+            TopLevelPlaylist::DirectMedia(playlist) => Some((playlist.id(), playlist.playlist())),
+            TopLevelPlaylist::Multivariant(_) => None,
+        }
+    }
+
     pub(crate) fn is_curr_media_playlist(&self, id: &MediaPlaylistPermanentId) -> bool {
         Some(id) == self.curr_audio_id.as_ref() || Some(id) == self.curr_video_id.as_ref()
+    }
+
+    /// Returns the `MediaType` currently associated to the given Media Playlist id.
+    ///
+    /// Returns `None` when that playlist is not one of the currently-selected media playlists.
+    pub(crate) fn curr_media_type_for(&self, id: &MediaPlaylistPermanentId) -> Option<MediaType> {
+        if Some(id) == self.curr_video_id.as_ref() {
+            Some(MediaType::Video)
+        } else if Some(id) == self.curr_audio_id.as_ref() {
+            Some(MediaType::Audio)
+        } else {
+            None
+        }
     }
 
     /// Returns `true` if the current playlist linked to the given `MediaType` has been loaded.

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -27,7 +27,7 @@ pub(crate) struct ProbeSegmentMetadata {
 #[derive(Clone, Debug)]
 pub(crate) enum ProbeSegmentContext {
     /// This probe segment is a full valid initialization segment
-    Init,
+    Init { id: f64 },
     /// This probe segment is a full valid Media segment
     Media {
         /// Timing information linked to that media segment
@@ -397,7 +397,9 @@ impl PlaylistStore {
             Some(ProbeSegmentMetadata {
                 url: init_segment.url().clone(),
                 byte_range: init_segment.byte_range().cloned(),
-                context: ProbeSegmentContext::Init,
+                context: ProbeSegmentContext::Init {
+                    id: init_segment.id(),
+                },
             })
         } else {
             Some(ProbeSegmentMetadata {

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -2,15 +2,59 @@ use crate::{
     bindings::{jsIsTypeSupported, MediaType, PlaylistNature},
     media_element::SegmentQualityContext,
     parser::{
-        AudioTrack, DirectMediaPlaylist, MediaPlaylist, MediaPlaylistUpdateError, SegmentList,
-        TopLevelPlaylist, VariantStream,
+        AudioTrack, DirectMediaInfo, MediaPlaylist, MediaPlaylistUpdateError, SegmentList,
+        SegmentTimeInfo, TopLevelPlaylist, VariantStream,
     },
     utils::url::Url,
     Logger,
 };
 use std::{cmp::Ordering, io::BufRead};
 
+use crate::parser::ByteRange;
 pub(crate) use crate::parser::MediaPlaylistPermanentId;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ProbeSegmentMetadata {
+    /// The URL to that segment.
+    pub(crate) url: Url,
+    /// The optional byte-range to that segment.
+    pub(crate) byte_range: Option<ByteRange>,
+    // Supplementary context information about that probe segment
+    pub(crate) context: ProbeSegmentContext,
+}
+
+// Supplementary context information about a segment used for "probing"
+#[derive(Clone, Debug)]
+pub(crate) enum ProbeSegmentContext {
+    /// This probe segment is a full valid initialization segment
+    Init,
+    /// This probe segment is a full valid Media segment
+    Media {
+        /// Timing information linked to that media segment
+        time_info: SegmentTimeInfo,
+    },
+}
+
+/// State associated with the initial setup of the top-level playlist (either the
+/// Multivariant playlist or a direct media playlist).
+///
+/// That setup is complexified by the need to know which and if media announced in those
+/// playlists are supported, which can necessitate a segment request and other async API
+/// calls.
+pub(crate) enum StartupStatus {
+    /// A "probe segment" must be loaded and inspected for supplementary
+    /// playlist information before playback can start.
+    ///
+    /// Once the supplementary information is extracted, is should be communicated to the
+    /// `PlaylistStore` (e.g. through `set_direct_media_info`).
+    NeedsProbe(ProbeSegmentMetadata),
+    /// Codecs are currently in their way to be checked by the platform.
+    ///
+    /// Once known, it should be communicated back to the `PlaylistStore`.
+    AwaitingSupportCheck,
+    /// The top level playlist can now be fully exploited for playback.
+    Ready,
+}
 
 /// Stores information about the current loaded Multivariant Playlist and its sub-playlists:
 ///   - Information on the Multivariant Playlist itself.
@@ -50,12 +94,12 @@ pub(crate) struct PlaylistStore {
     /// Store the last communicated bandwidth
     last_bandwidth: f64,
 
-    /// Before actually playing a content, supported codecs need to be checked
-    /// to avoid mistakenly choosing an unsupported codec.
+    /// Before actually playing a multivariant content, supported codecs need to be checked
+    /// to avoid mistakenly choosing an unsupported variant.
     ///
-    /// This bool is set to `true` only once ALL codecs in the
-    /// `MultivariantPlaylist` have been properly checked.
-    codecs_checked: bool,
+    /// This bool is set to `true` only once ALL variants in the
+    /// `MultivariantPlaylist` have had their support resolved.
+    multivariant_support_resolved: bool,
 }
 
 impl PlaylistStore {
@@ -90,13 +134,7 @@ impl PlaylistStore {
                     playlist.video_media_playlist_id_for(initial_variant),
                 )
             }
-            TopLevelPlaylist::DirectMedia(playlist) => {
-                let (audio_id, video_id) = match playlist.media_type() {
-                    MediaType::Audio => (Some(playlist.id().clone()), None),
-                    MediaType::Video => (None, Some(playlist.id().clone())),
-                };
-                (None, audio_id, video_id)
-            }
+            TopLevelPlaylist::DirectMedia(_) => (None, None, None),
         };
 
         Ok(Self {
@@ -107,7 +145,7 @@ impl PlaylistStore {
             curr_audio_track: None,
             is_variant_locked: false,
             last_bandwidth: 0.,
-            codecs_checked: false,
+            multivariant_support_resolved: false,
         })
     }
 
@@ -128,45 +166,30 @@ impl PlaylistStore {
         }
     }
 
-    /// Check which codecs present in the `MultivariantPlaylist` are supported.
+    /// Resolve which variants in the `MultivariantPlaylist` are supported.
     ///
-    /// This allows the playlist store to know which variant can actually be relied on.
-    /// As such you should be extra careful when using the `PlaylistStore` before that check has
-    /// been completely done.
+    /// This allows the playlist store to know which variant can actually be relied on before
+    /// playback starts.
     ///
-    /// Returns `true` if all codecs in the `MultivariantPlaylist` could have been checked or
-    /// `false` if it still await a response from JavaScript. As that response can be asynchronous
-    /// it is given back to the corresponding Dispatcher's event listener function.
+    /// Returns `true` if support for every relevant variant could be resolved or `false` if it is
+    /// still awaiting a response from JavaScript. As that response can be asynchronous it is given
+    /// back to the corresponding Dispatcher's event listener function.
     ///
-    /// Once that even listener has been called, `check_codecs` can be called again, until it
-    /// returns `true`.
-    pub(crate) fn check_codecs(&mut self) -> Result<bool, PlaylistStoreError> {
-        if self.codecs_checked {
+    /// Once that event listener has been called, `resolve_multivariant_support` can be called
+    /// again, until it returns `true`.
+    fn resolve_multivariant_support(&mut self) -> Result<bool, PlaylistStoreError> {
+        if self.multivariant_support_resolved {
             return Ok(true);
         }
 
         let playlist = match &mut self.playlist {
             TopLevelPlaylist::Multivariant(playlist) => playlist,
-            TopLevelPlaylist::DirectMedia(playlist) => {
-                let media_type = playlist.media_type();
-                let mime_type = playlist.playlist().mime_type(media_type).unwrap_or("");
-                if mime_type.is_empty() {
-                    self.codecs_checked = true;
-                    return Ok(true);
-                }
-                match jsIsTypeSupported(media_type, mime_type) {
-                    Some(_) => {
-                        self.codecs_checked = true;
-                        return Ok(true);
-                    }
-                    None => {
-                        return Ok(false);
-                    }
-                }
+            TopLevelPlaylist::DirectMedia(_) => {
+                return Ok(true);
             }
         };
 
-        let mut are_all_codecs_checked = true;
+        let mut is_multivariant_support_resolved = true;
         playlist.variants_mut().iter_mut().for_each(|v| {
             if v.supported().is_some() {
                 return;
@@ -178,15 +201,15 @@ impl PlaylistStore {
                         if let Some(is_supported) = jsIsTypeSupported(mt, &codec) {
                             v.update_support(is_supported);
                         } else {
-                            are_all_codecs_checked = false;
+                            is_multivariant_support_resolved = false;
                         }
                     }
                 });
         });
-        self.codecs_checked = are_all_codecs_checked;
+        self.multivariant_support_resolved = is_multivariant_support_resolved;
 
-        if are_all_codecs_checked {
-            Logger::info("PS: All codecs have been checked");
+        if is_multivariant_support_resolved {
+            Logger::info("PS: Support has been resolved for all multivariant variants");
             let curr_variant_id = self.curr_variant_id.unwrap();
             let curr_variant_still_here = playlist
                 .supported_variants()
@@ -203,9 +226,9 @@ impl PlaylistStore {
                 }
             }
         } else {
-            Logger::info("PS: Some Playlist codecs need to be asynchronously checked");
+            Logger::info("PS: Some multivariant variants still need asynchronous support checks");
         }
-        Ok(are_all_codecs_checked)
+        Ok(is_multivariant_support_resolved)
     }
 
     /// Returns the list of tuples listing loaded media playlists.
@@ -274,34 +297,116 @@ impl PlaylistStore {
     pub(crate) fn current_codec(&self, media_type: MediaType) -> Option<String> {
         match &self.playlist {
             TopLevelPlaylist::Multivariant(_) => self.curr_variant()?.codecs(media_type),
+            TopLevelPlaylist::DirectMedia(playlist) => playlist
+                .media_info()
+                .filter(|info| info.media_type == media_type)
+                .map(|info| info.codec.clone()),
+        }
+    }
+
+    pub(crate) fn current_mime_type(&self, media_type: MediaType) -> Option<String> {
+        match &self.playlist {
+            TopLevelPlaylist::Multivariant(_) => self
+                .curr_media_playlist(media_type)
+                .map(|playlist| playlist.mime_type(media_type).unwrap_or("").to_string()),
+            TopLevelPlaylist::DirectMedia(playlist) => playlist
+                .media_info()
+                .filter(|info| info.media_type == media_type)
+                .map(|info| info.mime_type.clone()),
+        }
+    }
+
+    /// Returns the next startup action required before playback can begin.
+    ///
+    /// This first ensures that enough stream metadata is known for the currently selected startup
+    /// path. Once that metadata is complete, it resolves whether the selected startup streams are
+    /// actually supported by the current environment.
+    pub(crate) fn startup_status(
+        &mut self,
+        wanted_position: f64,
+    ) -> Result<StartupStatus, PlaylistStoreError> {
+        match &self.playlist {
             TopLevelPlaylist::DirectMedia(playlist) => {
-                if playlist.media_type() == media_type {
-                    playlist.codec().map(ToString::to_string)
-                } else {
-                    None
+                if playlist.media_info().is_none() {
+                    return self
+                        .next_direct_media_probe(wanted_position)
+                        .map(StartupStatus::NeedsProbe)
+                        .ok_or(PlaylistStoreError::NoProbeSegment);
+                }
+            }
+            TopLevelPlaylist::Multivariant(_) => {
+                if [MediaType::Audio, MediaType::Video]
+                    .into_iter()
+                    .any(|media_type| {
+                        self.has_media_type(media_type) && self.current_codec(media_type).is_none()
+                    })
+                {
+                    return Err(PlaylistStoreError::MissingSelectedStreamMetadata);
                 }
             }
         }
-    }
 
-    /// XXX TODO: Sad that we need to leak that abstraction
-    pub(crate) fn direct_media(&self) -> Option<&DirectMediaPlaylist> {
         match &self.playlist {
-            TopLevelPlaylist::DirectMedia(playlist) => Some(playlist),
-            TopLevelPlaylist::Multivariant(_) => None,
+            TopLevelPlaylist::DirectMedia(playlist) => {
+                let media_info = playlist.media_info().unwrap();
+                match jsIsTypeSupported(media_info.media_type, &media_info.codec) {
+                    Some(true) => Ok(StartupStatus::Ready),
+                    Some(false) => Err(PlaylistStoreError::UnsupportedStartupStream),
+                    None => Ok(StartupStatus::AwaitingSupportCheck),
+                }
+            }
+            TopLevelPlaylist::Multivariant(_) => match self.resolve_multivariant_support()? {
+                true => Ok(StartupStatus::Ready),
+                false => Ok(StartupStatus::AwaitingSupportCheck),
+            },
         }
     }
 
-    /// Only if the current `TopLevelPlaylist` is ~DirectMedia`` (going through a media
-    /// playlist directly instead of a multivariant playlist), associate the given codec
-    /// to it.
-    /// XXX TODO: Is this the role of this abstraction to do that weird branching?
-    pub(crate) fn set_direct_media_codec(&mut self, codec: String) {
+    pub(crate) fn set_direct_media_info(&mut self, media_info: DirectMediaInfo) {
         match &mut self.playlist {
             TopLevelPlaylist::DirectMedia(playlist) => {
-                playlist.set_codec(codec);
+                let direct_media_id = playlist.id().clone();
+                match media_info.media_type {
+                    MediaType::Audio => {
+                        self.curr_audio_id = Some(direct_media_id);
+                        self.curr_video_id = None;
+                    }
+                    MediaType::Video => {
+                        self.curr_audio_id = None;
+                        self.curr_video_id = Some(direct_media_id);
+                    }
+                }
+                playlist.set_media_info(media_info);
             }
             TopLevelPlaylist::Multivariant(_) => {}
+        }
+    }
+
+    /// Returns probe segment metadata associated to the `wanted_position` if it exists.
+    fn next_direct_media_probe(&self, wanted_position: f64) -> Option<ProbeSegmentMetadata> {
+        let playlist = match &self.playlist {
+            TopLevelPlaylist::DirectMedia(playlist) => playlist,
+            TopLevelPlaylist::Multivariant(_) => return None,
+        };
+        let media_segment = playlist
+            .playlist()
+            .segment_list()
+            .segment_from_pos(wanted_position)
+            .or_else(|| playlist.playlist().segment_list().media().first())?;
+        if let Some(init_segment) = playlist.playlist().segment_list().init_for(media_segment) {
+            Some(ProbeSegmentMetadata {
+                url: init_segment.url().clone(),
+                byte_range: init_segment.byte_range().cloned(),
+                context: ProbeSegmentContext::Init,
+            })
+        } else {
+            Some(ProbeSegmentMetadata {
+                url: media_segment.url().clone(),
+                byte_range: media_segment.byte_range().cloned(),
+                context: ProbeSegmentContext::Media {
+                    time_info: media_segment.time_info().clone(),
+                },
+            })
         }
     }
 
@@ -854,4 +959,10 @@ pub(crate) enum PlaylistStoreError {
     NoSupportedVariant,
     #[error("No variant was found in the MultivariantPlaylist. Are you sure that this isn't a Media Playlist?")]
     NoInitialVariant,
+    #[error("No probe segment was available to determine startup metadata")]
+    NoProbeSegment,
+    #[error("The selected startup streams lack enough metadata to resolve support")]
+    MissingSelectedStreamMetadata,
+    #[error("The selected startup streams are not supported in the current environment")]
+    UnsupportedStartupStream,
 }

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -988,6 +988,6 @@ pub(crate) enum PlaylistStoreError {
     NoProbeSegment,
     #[error("The selected startup streams lack enough metadata to resolve support")]
     MissingSelectedStreamMetadata,
-    #[error("The selected startup streams are not supported in the current environment")]
+    #[error("No supported startup stream was found for the current content")]
     UnsupportedStartupStream,
 }

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     bindings::{jsIsTypeSupported, MediaType, PlaylistNature},
     media_element::SegmentQualityContext,
     parser::{
-        AudioTrack, MediaPlaylist, MediaPlaylistUpdateError, MultivariantPlaylist, SegmentList,
+        AudioTrack, MediaPlaylist, MediaPlaylistUpdateError, SegmentList, TopLevelPlaylist,
         VariantStream,
     },
     utils::url::Url,
@@ -17,12 +17,13 @@ pub(crate) use crate::parser::MediaPlaylistPermanentId;
 ///   - On the current variant selected.
 ///   - Information on the different audio and video Media Playlists selected.
 pub(crate) struct PlaylistStore {
-    /// A struct representing the "Multivariant Playlist", a.k.a. "Master Playlist" of
-    /// the currently loaded HLS content.
-    playlist: MultivariantPlaylist,
+    /// Representation of the top-level playlist of the currently loaded HLS content.
+    playlist: TopLevelPlaylist,
 
     /// `id` of the currently chosen variant.
-    curr_variant_id: u32,
+    /// `None` if the current content does not rely on variants (e.g. when playing
+    /// Media Playlists directly)
+    curr_variant_id: Option<u32>,
 
     /// Chosen playlist for video.
     ///
@@ -63,26 +64,40 @@ impl PlaylistStore {
     /// Automatically selects the variant with the highest quality (or score if defined) on call.
     /// Please call `update_curr_bandwidth` to select a variant based on an actual criteria.
     pub(crate) fn try_new(
-        playlist: MultivariantPlaylist,
+        playlist: TopLevelPlaylist,
         initial_bandwidth: f64,
     ) -> Result<Self, PlaylistStoreError> {
         Logger::debug(&format!(
             "PS: Creating new PlaylistStore (bw: {initial_bandwidth})"
         ));
-        let variants = playlist.all_variants();
-        let initial_variant =
-            if let Some(variant_id) = best_variant_id(variants.iter(), initial_bandwidth) {
-                playlist.variant(variant_id).unwrap()
-            } else if let Some(variant_id) = fallback_variant_id(variants.iter()) {
-                Logger::info("PS: Found no bandwidth-compatible variant amongst all variants");
-                playlist.variant(variant_id).unwrap()
-            } else {
-                Logger::error("PS: Found no variant in the given MultivariantPlaylist");
-                return Err(PlaylistStoreError::NoInitialVariant);
-            };
-        let curr_variant_id = initial_variant.id();
-        let curr_video_id = playlist.video_media_playlist_id_for(initial_variant);
-        let curr_audio_id = playlist.audio_media_playlist_id_for(initial_variant, None);
+        let (curr_variant_id, curr_audio_id, curr_video_id) = match &playlist {
+            TopLevelPlaylist::Multivariant(playlist) => {
+                let variants = playlist.all_variants();
+                let initial_variant = if let Some(variant_id) =
+                    best_variant_id(variants.iter(), initial_bandwidth)
+                {
+                    playlist.variant(variant_id).unwrap()
+                } else if let Some(variant_id) = fallback_variant_id(variants.iter()) {
+                    Logger::info("PS: Found no bandwidth-compatible variant amongst all variants");
+                    playlist.variant(variant_id).unwrap()
+                } else {
+                    Logger::error("PS: Found no variant in the given MultivariantPlaylist");
+                    return Err(PlaylistStoreError::NoInitialVariant);
+                };
+                (
+                    Some(initial_variant.id()),
+                    playlist.audio_media_playlist_id_for(initial_variant, None),
+                    playlist.video_media_playlist_id_for(initial_variant),
+                )
+            }
+            TopLevelPlaylist::DirectMedia(playlist) => {
+                let (audio_id, video_id) = match playlist.media_type() {
+                    MediaType::Audio => (Some(playlist.id().clone()), None),
+                    MediaType::Video => (None, Some(playlist.id().clone())),
+                };
+                (None, audio_id, video_id)
+            }
+        };
 
         Ok(Self {
             playlist,
@@ -102,6 +117,17 @@ impl PlaylistStore {
         self.playlist.url()
     }
 
+    /// Returns which kind of Top-level Playlist we're relying on currently (either
+    /// a MultiVariant Playlist or a direct Media Playlist one)
+    pub(crate) fn playlist_kind(&self) -> crate::bindings::PlaylistType {
+        match &self.playlist {
+            TopLevelPlaylist::Multivariant(_) => {
+                crate::bindings::PlaylistType::MultivariantPlaylist
+            }
+            TopLevelPlaylist::DirectMedia(_) => crate::bindings::PlaylistType::MediaPlaylist,
+        }
+    }
+
     /// Check which codecs present in the `MultivariantPlaylist` are supported.
     ///
     /// This allows the playlist store to know which variant can actually be relied on.
@@ -119,8 +145,29 @@ impl PlaylistStore {
             return Ok(true);
         }
 
+        let playlist = match &mut self.playlist {
+            TopLevelPlaylist::Multivariant(playlist) => playlist,
+            TopLevelPlaylist::DirectMedia(playlist) => {
+                let media_type = playlist.media_type();
+                let mime_type = playlist.playlist().mime_type(media_type).unwrap_or("");
+                if mime_type.is_empty() {
+                    self.codecs_checked = true;
+                    return Ok(true);
+                }
+                match jsIsTypeSupported(media_type, mime_type) {
+                    Some(_) => {
+                        self.codecs_checked = true;
+                        return Ok(true);
+                    }
+                    None => {
+                        return Ok(false);
+                    }
+                }
+            }
+        };
+
         let mut are_all_codecs_checked = true;
-        self.playlist.variants_mut().iter_mut().for_each(|v| {
+        playlist.variants_mut().iter_mut().for_each(|v| {
             if v.supported().is_some() {
                 return;
             }
@@ -140,14 +187,14 @@ impl PlaylistStore {
 
         if are_all_codecs_checked {
             Logger::info("PS: All codecs have been checked");
-            let curr_variant_still_here = self
-                .playlist
+            let curr_variant_id = self.curr_variant_id.unwrap();
+            let curr_variant_still_here = playlist
                 .supported_variants()
                 .iter()
-                .any(|v| v.id() == self.curr_variant_id);
+                .any(|v| v.id() == curr_variant_id);
 
             if !curr_variant_still_here {
-                let new_variant_id = self.playlist.supported_variants().first().map(|v| v.id());
+                let new_variant_id = playlist.supported_variants().first().map(|v| v.id());
                 if let Some(variant_id) = new_variant_id {
                     self.set_curr_variant_and_media_id(variant_id);
                 } else {
@@ -214,23 +261,37 @@ impl PlaylistStore {
         media_playlist_data: impl BufRead,
         url: Url,
     ) -> Result<&MediaPlaylist, MediaPlaylistUpdateError> {
-        self.playlist
-            .update_media_playlist(id, media_playlist_data, url)
+        match &mut self.playlist {
+            TopLevelPlaylist::Multivariant(playlist) => {
+                playlist.update_media_playlist(id, media_playlist_data, url)
+            }
+            TopLevelPlaylist::DirectMedia(playlist) => {
+                playlist.update_media_playlist(id, media_playlist_data, url)
+            }
+        }
     }
 
     /// Returns vec describing all available variant streams in the current MultivariantPlaylist.
     pub(crate) fn supported_variants(&self) -> Vec<&VariantStream> {
-        self.playlist.supported_variants()
+        match &self.playlist {
+            TopLevelPlaylist::Multivariant(playlist) => playlist.supported_variants(),
+            TopLevelPlaylist::DirectMedia(_) => vec![],
+        }
     }
 
     /// Returns vec describing all available variant streams in the current MultivariantPlaylist.
     pub(crate) fn variants_for_curr_track(&self) -> Vec<&VariantStream> {
-        if let Some(track_id) = self.curr_audio_track {
-            self.playlist.supported_variants_for_audio(track_id)
-        } else if let Some(track_id) = self.curr_audio_track_id() {
-            self.playlist.supported_variants_for_audio(track_id)
-        } else {
-            self.supported_variants()
+        match &self.playlist {
+            TopLevelPlaylist::Multivariant(playlist) => {
+                if let Some(track_id) = self.curr_audio_track {
+                    playlist.supported_variants_for_audio(track_id)
+                } else if let Some(track_id) = self.curr_audio_track_id() {
+                    playlist.supported_variants_for_audio(track_id)
+                } else {
+                    playlist.supported_variants()
+                }
+            }
+            TopLevelPlaylist::DirectMedia(_) => vec![],
         }
     }
 
@@ -305,7 +366,12 @@ impl PlaylistStore {
     /// Returns a reference to the `VariantStream` currently selected. You can influence the
     /// variant currently selected by e.g. calling the `update_curr_bandwidth` method.
     pub(crate) fn curr_variant(&self) -> Option<&VariantStream> {
-        self.playlist.variant(self.curr_variant_id)
+        match (&self.playlist, self.curr_variant_id) {
+            (TopLevelPlaylist::Multivariant(playlist), Some(curr_variant_id)) => {
+                playlist.variant(curr_variant_id)
+            }
+            _ => None,
+        }
     }
 
     /// Optionally update currently-selected variant by communicating the last bandwidth estimate.
@@ -316,7 +382,7 @@ impl PlaylistStore {
     /// MediaPlaylist.
     pub(crate) fn update_curr_bandwidth(&mut self, bandwidth: f64) -> VariantUpdateResult {
         self.last_bandwidth = bandwidth;
-        if self.is_variant_locked() {
+        if self.curr_variant_id.is_none() || self.is_variant_locked() {
             VariantUpdateResult::Unchanged
         } else {
             self.update_variant(None)
@@ -332,6 +398,9 @@ impl PlaylistStore {
     /// to any existing variant. It contains the corresponding update when set to the `Some`
     /// variant.
     pub(crate) fn lock_variant(&mut self, variant_id: u32) -> LockVariantResponse {
+        if self.curr_variant_id.is_none() {
+            return LockVariantResponse::NoVariantWithId;
+        }
         let variants = self.supported_variants();
         let pos = variants.iter().find(|x| x.id() == variant_id);
 
@@ -364,6 +433,10 @@ impl PlaylistStore {
     /// Disable a variant lock, previously created through the `lock_variant` method, to
     /// let adaptive streaming choose the right one instead.
     pub(crate) fn unlock_variant(&mut self) -> VariantUpdateResult {
+        if self.curr_variant_id.is_none() {
+            self.is_variant_locked = false;
+            return VariantUpdateResult::Unchanged;
+        }
         self.is_variant_locked = false;
         self.update_variant(None)
     }
@@ -388,7 +461,10 @@ impl PlaylistStore {
     /// Both are probably an error as a `MediaPlaylistPermanentId` should always identify a
     /// `MediaPlaylist`.
     pub(crate) fn media_playlist_url(&self, wanted_id: &MediaPlaylistPermanentId) -> Option<&Url> {
-        self.playlist.media_playlist_url(wanted_id)
+        match &self.playlist {
+            TopLevelPlaylist::Multivariant(playlist) => playlist.media_playlist_url(wanted_id),
+            TopLevelPlaylist::DirectMedia(playlist) => playlist.media_playlist_url(wanted_id),
+        }
     }
 
     /// Returns the `MediaPlaylistPermanentId` of the MediaPlaylist linked to the media
@@ -414,7 +490,10 @@ impl PlaylistStore {
             MediaType::Video => &self.curr_video_id,
             MediaType::Audio => &self.curr_audio_id,
         } {
-            self.playlist.media_playlist(wanted_id)
+            match &self.playlist {
+                TopLevelPlaylist::Multivariant(playlist) => playlist.media_playlist(wanted_id),
+                TopLevelPlaylist::DirectMedia(playlist) => playlist.media_playlist(wanted_id),
+            }
         } else {
             None
         }
@@ -428,12 +507,11 @@ impl PlaylistStore {
             MediaType::Video => &self.curr_video_id,
             MediaType::Audio => &self.curr_audio_id,
         } {
-            self.playlist.media_playlist(wanted_id).map(|m| {
-                let score: f64 = self
-                    .playlist
-                    .variant(self.curr_variant_id)
+            self.curr_media_playlist(media_type).map(|m| {
+                let score = self
+                    .curr_variant()
                     .map(|v| v.score().unwrap_or(v.bandwidth() as f64))
-                    .unwrap();
+                    .unwrap_or(0.);
 
                 let context = SegmentQualityContext::new(score, wanted_id.as_u32());
                 (m.segment_list(), context)
@@ -505,9 +583,12 @@ impl PlaylistStore {
     /// Returns `None` if no current audio media is known currently or if no `AudioTrack` is
     /// linked to it.
     pub(crate) fn curr_audio_track_id(&self) -> Option<u32> {
-        self.playlist
-            .audio_track_for_media_id(self.curr_audio_id.as_ref()?)
-            .map(|p| p.id())
+        match &self.playlist {
+            TopLevelPlaylist::Multivariant(playlist) => playlist
+                .audio_track_for_media_id(self.curr_audio_id.as_ref()?)
+                .map(|p| p.id()),
+            TopLevelPlaylist::DirectMedia(_) => None,
+        }
     }
 
     /// Returns the `id` of the `AudioTrack` object explicitely selected through the
@@ -520,7 +601,10 @@ impl PlaylistStore {
 
     /// Returns the list of available audio tracks on the current content
     pub(crate) fn audio_tracks(&self) -> &[AudioTrack] {
-        self.playlist.audio_tracks()
+        match &self.playlist {
+            TopLevelPlaylist::Multivariant(playlist) => playlist.audio_tracks(),
+            TopLevelPlaylist::DirectMedia(_) => &[],
+        }
     }
 
     /// Explicitely select an `AudioTrack` based on its `id` property or disable the explicit
@@ -528,12 +612,19 @@ impl PlaylistStore {
     ///
     /// Returns `true` if this call led to a changement for the Audio Media Playlist.
     pub(crate) fn set_audio_track(&mut self, track_id: Option<u32>) -> SetAudioTrackResponse {
+        if self.curr_variant_id.is_none() {
+            self.curr_audio_track = track_id;
+            return SetAudioTrackResponse::NoUpdate;
+        }
         self.curr_audio_track = track_id;
 
         if let Some(variant) = self.curr_variant() {
-            let new_audio_id = self
-                .playlist
-                .audio_media_playlist_id_for(variant, self.curr_audio_track);
+            let new_audio_id = match &self.playlist {
+                TopLevelPlaylist::Multivariant(playlist) => {
+                    playlist.audio_media_playlist_id_for(variant, self.curr_audio_track)
+                }
+                TopLevelPlaylist::DirectMedia(_) => None,
+            };
 
             if new_audio_id.is_none() && self.curr_audio_id.is_some() {
                 // We may be in a case where the choosen track is not available in the
@@ -558,6 +649,10 @@ impl PlaylistStore {
 
     /// Select the best variant available according to your bandwidth and track choice
     fn update_variant(&mut self, variant_id: Option<u32>) -> VariantUpdateResult {
+        let playlist = match &self.playlist {
+            TopLevelPlaylist::Multivariant(playlist) => playlist,
+            TopLevelPlaylist::DirectMedia(_) => return VariantUpdateResult::Unchanged,
+        };
         let new_id = if let Some(id) = variant_id {
             id
         } else {
@@ -574,9 +669,9 @@ impl PlaylistStore {
                 panic!("No variant to choose from. This should be impossible.");
             }
         };
-        if new_id != self.curr_variant_id {
+        if Some(new_id) != self.curr_variant_id {
             let prev_bandwidth = self.curr_variant().map(|v| v.bandwidth());
-            let new_bandwidth = self.playlist.variant(new_id).map(|v| v.bandwidth());
+            let new_bandwidth = playlist.variant(new_id).map(|v| v.bandwidth());
             let prev_audio_id = self.curr_audio_id.clone();
             let prev_video_id = self.curr_video_id.clone();
             self.set_curr_variant_and_media_id(new_id.to_owned());
@@ -603,12 +698,14 @@ impl PlaylistStore {
 
     /// Internally update the current variant chosen as well as its corresponding other media.
     fn set_curr_variant_and_media_id(&mut self, variant_id: u32) {
-        let variant = self.playlist.variant(variant_id).unwrap();
-        self.curr_variant_id = variant_id;
-        self.curr_video_id = self.playlist.video_media_playlist_id_for(variant);
-        self.curr_audio_id = self
-            .playlist
-            .audio_media_playlist_id_for(variant, self.curr_audio_track);
+        let playlist = match &self.playlist {
+            TopLevelPlaylist::Multivariant(playlist) => playlist,
+            TopLevelPlaylist::DirectMedia(_) => return,
+        };
+        let variant = playlist.variant(variant_id).unwrap();
+        self.curr_variant_id = Some(variant_id);
+        self.curr_video_id = playlist.video_media_playlist_id_for(variant);
+        self.curr_audio_id = playlist.audio_media_playlist_id_for(variant, self.curr_audio_track);
     }
 }
 

--- a/src/rs-core/requester/configuration.rs
+++ b/src/rs-core/requester/configuration.rs
@@ -33,7 +33,7 @@ pub(crate) struct RequesterConfiguration {
     /// request should be.
     pub(crate) segment_backoff_max: f64,
 
-    /// Amount of times a failed Multivariant Playlist request might be retried on errors that seem
+    /// Amount of times a failed top-level Playlist request might be retried on errors that seem
     /// temporary: `1` meaning it will be retried once, `2` twice, `0` never retried etc.
     ///
     /// To set to `-1` for infinite retry.
@@ -51,7 +51,7 @@ pub(crate) struct RequesterConfiguration {
     /// fails multiple time consecutively).
     ///
     /// This is roughly the initial delay, in milliseconds, the initial backoff for a retried
-    /// Multivariant Playlist request should be.
+    /// top-level Playlist request should be.
     pub(crate) multi_variant_playlist_backoff_base: f64,
 
     /// When a request is retried, a timeout is awaited to avoid overloading the server.
@@ -59,7 +59,7 @@ pub(crate) struct RequesterConfiguration {
     /// fails multiple time consecutively).
     ///
     /// This is roughly the maximum delay, in milliseconds, the backoff delay for a retried
-    /// Multivariant Playlist request should be.
+    /// top-level Playlist request should be.
     pub(crate) multi_variant_playlist_backoff_max: f64,
 
     /// Amount of times a failed Media Playlist request might be retried on errors that seem

--- a/src/rs-core/requester/mod.rs
+++ b/src/rs-core/requester/mod.rs
@@ -3,7 +3,6 @@ use crate::{
         formatters::format_range_for_js, jsAbortRequest, jsFetch, jsGetRandom, jsTimer, MediaType,
         RequestErrorReason, RequestId, TimerId, TimerReason,
     },
-    media_element::SegmentQualityContext,
     parser::{ByteRange, MediaSegmentInfo, SegmentTimeInfo},
     playlist_store::MediaPlaylistPermanentId,
     utils::url::Url,
@@ -15,6 +14,38 @@ mod configuration;
 pub(crate) use configuration::RequesterConfiguration;
 
 const PRIORITY_STEPS: [f64; 6] = [2., 4., 8., 12., 18., 25.];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RequestLaneTag {
+    Audio,
+    Video,
+    Probe,
+}
+
+impl RequestLaneTag {
+    fn from_media_type(media_type: MediaType) -> Self {
+        match media_type {
+            MediaType::Audio => Self::Audio,
+            MediaType::Video => Self::Video,
+        }
+    }
+
+    fn media_type(self) -> Option<MediaType> {
+        match self {
+            Self::Audio => Some(MediaType::Audio),
+            Self::Video => Some(MediaType::Video),
+            Self::Probe => None,
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Audio => "audio",
+            Self::Video => "video",
+            Self::Probe => "probe",
+        }
+    }
+}
 
 /// The `Requester` is the module performing HTTP(s) requests.
 ///
@@ -116,8 +147,8 @@ pub(crate) struct PlaylistRequestInfo {
 
 /// Metadata associated with a pending media segment request.
 pub(crate) struct WaitingSegmentInfo {
-    /// type of media of the segment requested
-    media_type: MediaType,
+    /// Requester-side lane in which that request is scheduled.
+    lane_tag: RequestLaneTag,
 
     /// Url on which the request is done
     url: Url,
@@ -126,22 +157,19 @@ pub(crate) struct WaitingSegmentInfo {
 
     /// Start and end of the requested segment.
     /// `None` if the segment contains no media data, such as initialization segments
+    ///
+    /// TODO: This is only used for priorization and logging here it seems, maybe a more
+    /// explicit priority-oriented value would be better?
     time_info: Option<SegmentTimeInfo>,
 
-    /// Information about the quality linked to that segment
-    context: SegmentQualityContext,
-}
-
-#[derive(Clone)]
-pub(crate) enum SegmentRequestContext {
-    Playback(SegmentQualityContext),
-    Probe,
+    /// Opaque identifier allowing the dispatcher layer to recover what should happen when the
+    /// request completes.
+    action_id: u32,
 }
 
 impl WaitingSegmentInfo {
-    /// Returns the type of media of the awaiting segment.
-    pub(crate) fn media_type(&self) -> MediaType {
-        self.media_type
+    pub(crate) fn lane_tag(&self) -> RequestLaneTag {
+        self.lane_tag
     }
 
     /// Returns a reference to the URL leading to this awaiting segment.
@@ -165,17 +193,16 @@ impl WaitingSegmentInfo {
         self.time_info.as_ref()
     }
 
-    /// "Context" allowing to detect and compare the quality of this segment with others.
-    pub(crate) fn context(&self) -> &SegmentQualityContext {
-        &self.context
+    pub(crate) fn action_id(&self) -> u32 {
+        self.action_id
     }
 }
 
 /// Trait unifying the Requester's segment which are either in a pending request or which are
 /// awaiting one.
 pub(crate) trait RequesterSegmentInfo {
-    /// Returns the type of media of the corresponding segment.
-    fn media_type(&self) -> MediaType;
+    /// Returns the requester-side lane to which the corresponding request belongs.
+    fn lane_tag(&self) -> RequestLaneTag;
     /// Returns the start time, in playlist time in seconds, at which the segment starts at.
     ///
     /// Should be `None` only for initialization segment.
@@ -193,8 +220,8 @@ pub(crate) trait RequesterSegmentInfo {
 }
 
 impl RequesterSegmentInfo for SegmentRequestInfo {
-    fn media_type(&self) -> MediaType {
-        self.media_type
+    fn lane_tag(&self) -> RequestLaneTag {
+        self.lane_tag
     }
 
     fn start_time(&self) -> Option<f64> {
@@ -211,8 +238,8 @@ impl RequesterSegmentInfo for SegmentRequestInfo {
 }
 
 impl RequesterSegmentInfo for WaitingSegmentInfo {
-    fn media_type(&self) -> MediaType {
-        self.media_type
+    fn lane_tag(&self) -> RequestLaneTag {
+        self.lane_tag
     }
 
     fn start_time(&self) -> Option<f64> {
@@ -233,10 +260,8 @@ pub(crate) struct SegmentRequestInfo {
     /// ID identifying the request on the JavaScript-side.
     request_id: RequestId,
 
-    context: SegmentRequestContext,
-
-    /// type of media of the segment requested
-    media_type: MediaType,
+    /// Requester-side lane in which that request is scheduled.
+    lane_tag: RequestLaneTag,
 
     /// Url on which the request is done
     url: Url,
@@ -246,6 +271,10 @@ pub(crate) struct SegmentRequestInfo {
     /// Start and end of the requested segment.
     /// `None` if the segment contains no media data, such as initialization segments
     time_info: Option<SegmentTimeInfo>,
+
+    /// Opaque identifier allowing the dispatcher layer to recover what should happen when the
+    /// request completes.
+    action_id: u32,
 
     /// Number of time the request has already been attempted.
     attempts_failed: u32,
@@ -259,8 +288,12 @@ pub(crate) struct SegmentRequestInfo {
 }
 
 impl SegmentRequestInfo {
-    pub(crate) fn media_type(&self) -> MediaType {
-        self.media_type
+    pub(crate) fn lane_tag(&self) -> RequestLaneTag {
+        self.lane_tag
+    }
+
+    pub(crate) fn media_type(&self) -> Option<MediaType> {
+        self.lane_tag.media_type()
     }
 
     pub(crate) fn url(&self) -> &Url {
@@ -275,27 +308,16 @@ impl SegmentRequestInfo {
         self.time_info.as_ref()
     }
 
+    pub(crate) fn action_id(&self) -> u32 {
+        self.action_id
+    }
+
     pub(crate) fn attempts_failed(&self) -> u32 {
         self.attempts_failed
     }
 
     pub(crate) fn is_waiting_for_retry(&self) -> bool {
         self.is_waiting_for_retry
-    }
-
-    pub(crate) fn context(&self) -> &SegmentRequestContext {
-        &self.context
-    }
-
-    pub(crate) fn deconstruct(
-        self,
-    ) -> (
-        Url,
-        Option<ByteRange>,
-        Option<SegmentTimeInfo>,
-        SegmentRequestContext,
-    ) {
-        (self.url, self.byte_range, self.time_info, self.context)
     }
 }
 
@@ -401,14 +423,14 @@ impl Requester {
         media_type: MediaType,
         url: Url,
         byte_range: Option<&ByteRange>,
-        context: SegmentQualityContext,
+        action_id: u32,
     ) {
         self.request_segment_now(
             &url,
             byte_range,
-            media_type,
+            RequestLaneTag::from_media_type(media_type),
             None,
-            SegmentRequestContext::Playback(context),
+            action_id,
         );
     }
 
@@ -423,11 +445,13 @@ impl Requester {
         url: &Url,
         byte_range: Option<&ByteRange>,
     ) -> bool {
-        self.pending_segment_requests.iter().any(|s| {
-            s.media_type == media_type && &s.url == url && s.byte_range.as_ref() == byte_range
-        }) || self.segment_waiting_queue.iter().any(|s| {
-            s.media_type == media_type && &s.url == url && s.byte_range.as_ref() == byte_range
-        })
+        let lane_tag = RequestLaneTag::from_media_type(media_type);
+        self.pending_segment_requests
+            .iter()
+            .any(|s| s.lane_tag == lane_tag && &s.url == url && s.byte_range.as_ref() == byte_range)
+            || self.segment_waiting_queue.iter().any(|s| {
+                s.lane_tag == lane_tag && &s.url == url && s.byte_range.as_ref() == byte_range
+            })
     }
 
     /// Fetch a segment in the right format through the given `url`.
@@ -444,7 +468,7 @@ impl Requester {
         &mut self,
         media_type: MediaType,
         seg: &MediaSegmentInfo,
-        context: SegmentQualityContext,
+        action_id: u32,
     ) {
         Logger::info(&format!(
             "Req: Asking to request {} segment: t: {}, d: {}",
@@ -452,23 +476,18 @@ impl Requester {
             seg.start(),
             seg.duration()
         ));
+        let lane_tag = RequestLaneTag::from_media_type(media_type);
         let time_info = Some(seg.time_info().clone());
         if self.can_start_request(seg.start()) {
-            self.request_segment_now(
-                seg.url(),
-                seg.byte_range(),
-                media_type,
-                time_info,
-                SegmentRequestContext::Playback(context),
-            )
+            self.request_segment_now(seg.url(), seg.byte_range(), lane_tag, time_info, action_id)
         } else {
             Logger::debug("Req: pushing segment request to queue");
             self.segment_waiting_queue.push(WaitingSegmentInfo {
-                media_type,
+                lane_tag,
                 url: seg.url().clone(),
                 byte_range: seg.byte_range().cloned(),
                 time_info,
-                context,
+                action_id,
             });
         }
     }
@@ -476,13 +495,13 @@ impl Requester {
     // TODO: Merge it with the others?
     pub(crate) fn request_segment_unlocked(
         &mut self,
-        media_type: MediaType,
+        lane_tag: RequestLaneTag,
         url: Url,
         byte_range: Option<&ByteRange>,
         time_info: Option<SegmentTimeInfo>,
-        context: SegmentRequestContext,
+        action_id: u32,
     ) {
-        self.request_segment_now(&url, byte_range, media_type, time_info, context);
+        self.request_segment_now(&url, byte_range, lane_tag, time_info, action_id);
     }
 
     pub(crate) fn lock_segment_requests(&mut self) -> bool {
@@ -497,13 +516,14 @@ impl Requester {
     }
 
     pub(crate) fn has_segment_request_pending(&self, media_type: MediaType) -> bool {
+        let lane_tag = RequestLaneTag::from_media_type(media_type);
         self.pending_segment_requests
             .iter()
-            .any(|r| r.media_type == media_type)
+            .any(|r| r.lane_tag == lane_tag)
             || self
                 .segment_waiting_queue
                 .iter()
-                .any(|r| r.media_type == media_type)
+                .any(|r| r.lane_tag == lane_tag)
     }
 
     pub(crate) fn on_pending_request_success(
@@ -643,25 +663,29 @@ impl Requester {
         }
     }
 
-    pub(crate) fn abort_segments_with_type(&mut self, media_type: MediaType) {
+    pub(crate) fn abort_segments_with_type(&mut self, media_type: MediaType) -> Vec<u32> {
+        let lane_tag = RequestLaneTag::from_media_type(media_type);
         let mut i = 0;
         let mut aborted_pending = false;
+        let mut aborted_actions = vec![];
         while i < self.pending_segment_requests.len() {
             let next_req = &self.pending_segment_requests[i];
-            if next_req.media_type() == media_type {
+            if next_req.lane_tag() == lane_tag {
                 log_segment_abort(next_req);
                 aborted_pending = true;
                 jsAbortRequest(next_req.request_id);
-                self.pending_segment_requests.remove(i);
+                let removed = self.pending_segment_requests.remove(i);
+                aborted_actions.push(removed.action_id);
             } else {
                 i += 1;
             }
         }
         while i < self.segment_waiting_queue.len() {
             let next_req = &self.segment_waiting_queue[i];
-            if next_req.media_type() == media_type {
+            if next_req.lane_tag() == lane_tag {
                 log_segment_abort(next_req);
-                self.segment_waiting_queue.remove(i);
+                let removed = self.segment_waiting_queue.remove(i);
+                aborted_actions.push(removed.action_id);
             } else {
                 i += 1;
             }
@@ -669,6 +693,7 @@ impl Requester {
         if aborted_pending {
             self.check_segment_queue();
         }
+        aborted_actions
     }
 
     fn end_pending_request(&mut self, request_id: RequestId) -> Option<FinishedRequestType> {
@@ -861,9 +886,9 @@ impl Requester {
                         self.request_segment_now(
                             &seg.url,
                             seg.byte_range.as_ref(),
-                            seg.media_type,
+                            seg.lane_tag,
                             seg.time_info,
-                            SegmentRequestContext::Playback(seg.context),
+                            seg.action_id,
                         );
                     },
                 );
@@ -873,9 +898,9 @@ impl Requester {
                 self.request_segment_now(
                     &seg.url,
                     seg.byte_range.as_ref(),
-                    seg.media_type,
+                    seg.lane_tag,
                     seg.time_info,
-                    SegmentRequestContext::Playback(seg.context),
+                    seg.action_id,
                 );
             }
         }
@@ -923,9 +948,9 @@ impl Requester {
         &mut self,
         url: &Url,
         byte_range: Option<&ByteRange>,
-        media_type: MediaType,
+        lane_tag: RequestLaneTag,
         time_info: Option<SegmentTimeInfo>,
-        context: SegmentRequestContext,
+        action_id: u32,
     ) {
         let (range_start, range_end) = format_range_for_js(byte_range);
         let url_ref = url.get_ref();
@@ -940,13 +965,13 @@ impl Requester {
         ));
         self.pending_segment_requests.push(SegmentRequestInfo {
             request_id,
-            media_type,
+            lane_tag,
             url: url.clone(),
             byte_range: byte_range.cloned(),
             time_info,
+            action_id,
             attempts_failed: 0,
             is_waiting_for_retry: false,
-            context,
         });
     }
 
@@ -967,11 +992,11 @@ impl Requester {
 
 fn log_segment_abort(seg: &impl RequesterSegmentInfo) {
     Logger::lazy_info(&|| {
-        let media_type = seg.media_type();
+        let lane_label = seg.lane_tag().label();
         if let (Some(start), Some(duration)) = (seg.start_time(), seg.duration()) {
-            format!("Req: Aborting {media_type} segment: t: {start}, d: {duration}")
+            format!("Req: Aborting {lane_label} segment: t: {start}, d: {duration}")
         } else {
-            format!("Req: Aborting {media_type} init segment")
+            format!("Req: Aborting {lane_label} init segment")
         }
     });
 }

--- a/src/rs-core/requester/mod.rs
+++ b/src/rs-core/requester/mod.rs
@@ -455,6 +455,18 @@ impl Requester {
         }
     }
 
+    /// XXX TODO: Try merging with `request_media_segment`?
+    pub(crate) fn request_probe_media_segment(
+        &mut self,
+        media_type: MediaType,
+        url: Url,
+        byte_range: Option<&ByteRange>,
+        time_info: SegmentTimeInfo,
+        context: SegmentQualityContext,
+    ) {
+        self.request_segment_now(&url, byte_range, media_type, Some(time_info), context);
+    }
+
     pub(crate) fn lock_segment_requests(&mut self) -> bool {
         let was_locked = self.segment_request_locked;
         self.segment_request_locked = true;

--- a/src/rs-core/requester/mod.rs
+++ b/src/rs-core/requester/mod.rs
@@ -117,7 +117,14 @@ pub(crate) enum PlaylistFileType {
     TopLevelPlaylist,
     /// This is a Media Playlist with this associated `id` and `MediaType`.
     MediaPlaylist {
+        // Identifier uniquely identifying that playlist
         id: MediaPlaylistPermanentId,
+        // The media type associated to the media playlist.
+        // TODO: The media_type should probably be removed long-term here.
+        //       With segments, it makes sense due to the "lane concept" (one
+        //       in-flight request for the given type). For playlists, the only
+        //       reason is due to how it will be then exploited once the request
+        //       is finished, which could be re-computed anyway.
         media_type: MediaType,
     },
 }
@@ -126,7 +133,7 @@ pub(crate) enum PlaylistFileType {
 /// Playlist request.
 pub(crate) struct PlaylistRequestInfo {
     /// ID identifying the request on the JavaScript-side.
-    request_id: RequestId,
+    host_id: RequestId,
 
     /// Url on which the request is done
     pub(crate) url: Url,
@@ -140,7 +147,7 @@ pub(crate) struct PlaylistRequestInfo {
     /// If `true` the request is not really pending, we're currently pending for some
     /// timer to finish before retrying it.
     ///
-    /// In that case, the `request_id` corresponds to the one of the previous request
+    /// In that case, the `host_id` corresponds to the one of the previous request
     /// and should not be relied on.
     pub(crate) is_waiting_for_retry: bool,
 }
@@ -164,7 +171,7 @@ pub(crate) struct WaitingSegmentInfo {
 
     /// Opaque identifier allowing the dispatcher layer to recover what should happen when the
     /// request completes.
-    action_id: u32,
+    caller_id: u32,
 }
 
 impl WaitingSegmentInfo {
@@ -193,8 +200,8 @@ impl WaitingSegmentInfo {
         self.time_info.as_ref()
     }
 
-    pub(crate) fn action_id(&self) -> u32 {
-        self.action_id
+    pub(crate) fn id(&self) -> u32 {
+        self.caller_id
     }
 }
 
@@ -258,7 +265,7 @@ impl RequesterSegmentInfo for WaitingSegmentInfo {
 /// Metadata associated with a pending media segment request.
 pub(crate) struct SegmentRequestInfo {
     /// ID identifying the request on the JavaScript-side.
-    request_id: RequestId,
+    host_id: RequestId,
 
     /// Requester-side lane in which that request is scheduled.
     lane_tag: RequestLaneTag,
@@ -274,7 +281,7 @@ pub(crate) struct SegmentRequestInfo {
 
     /// Opaque identifier allowing the dispatcher layer to recover what should happen when the
     /// request completes.
-    action_id: u32,
+    caller_id: u32,
 
     /// Number of time the request has already been attempted.
     attempts_failed: u32,
@@ -282,7 +289,7 @@ pub(crate) struct SegmentRequestInfo {
     /// If `true` the request is not really pending, we're currently pending for some
     /// timer to finish before retrying it.
     ///
-    /// In that case, the `request_id` corresponds to the one of the previous request
+    /// In that case, the `host_id` corresponds to the one of the previous request
     /// and should not be relied on.
     is_waiting_for_retry: bool,
 }
@@ -308,8 +315,8 @@ impl SegmentRequestInfo {
         self.time_info.as_ref()
     }
 
-    pub(crate) fn action_id(&self) -> u32 {
-        self.action_id
+    pub(crate) fn id(&self) -> u32 {
+        self.caller_id
     }
 
     pub(crate) fn attempts_failed(&self) -> u32 {
@@ -390,7 +397,7 @@ impl Requester {
     }
 
     /// Fetch either the MultivariantPlaylist or a MediaPlaylist reachable
-    /// through the given `url` and add its `request_id` to `pending_playlist_requests`.
+    /// through the given `url` and add its `host_id` to `pending_playlist_requests`.
     ///
     /// Once it succeeds, the `__web_event__request_finished` function will be called.
     pub(crate) fn fetch_playlist(&mut self, url: Url, playlist_type: PlaylistFileType) {
@@ -401,12 +408,10 @@ impl Requester {
             PlaylistFileType::MediaPlaylist { .. } => self.config.media_playlist_request_timeout,
         };
         let url_ref = url.get_ref();
-        let request_id = jsFetch(url_ref, None, None, timeout);
-        Logger::info(&format!(
-            "Req: Fetching playlist u:{url_ref}, id:{request_id}"
-        ));
+        let host_id = jsFetch(url_ref, None, None, timeout);
+        Logger::info(&format!("Req: Fetching playlist u:{url_ref}, id:{host_id}"));
         self.pending_playlist_requests.push(PlaylistRequestInfo {
-            request_id,
+            host_id,
             url,
             playlist_type,
             attempts_failed: 0,
@@ -415,7 +420,7 @@ impl Requester {
     }
 
     /// Fetch the initialization segment whose metadata is given here add its
-    /// `request_id` to `pending_segment_requests`.
+    /// `host_id` to `pending_segment_requests`.
     ///
     /// Once it succeeds, the `__web_event__request_finished` function will be called.
     pub(crate) fn request_init_segment(
@@ -423,14 +428,14 @@ impl Requester {
         media_type: MediaType,
         url: Url,
         byte_range: Option<&ByteRange>,
-        action_id: u32,
+        caller_id: u32,
     ) {
         self.request_segment_now(
             &url,
             byte_range,
             RequestLaneTag::from_media_type(media_type),
             None,
-            action_id,
+            caller_id,
         );
     }
 
@@ -468,7 +473,7 @@ impl Requester {
         &mut self,
         media_type: MediaType,
         seg: &MediaSegmentInfo,
-        action_id: u32,
+        caller_id: u32,
     ) {
         Logger::info(&format!(
             "Req: Asking to request {} segment: t: {}, d: {}",
@@ -479,7 +484,7 @@ impl Requester {
         let lane_tag = RequestLaneTag::from_media_type(media_type);
         let time_info = Some(seg.time_info().clone());
         if self.can_start_request(seg.start()) {
-            self.request_segment_now(seg.url(), seg.byte_range(), lane_tag, time_info, action_id)
+            self.request_segment_now(seg.url(), seg.byte_range(), lane_tag, time_info, caller_id)
         } else {
             Logger::debug("Req: pushing segment request to queue");
             self.segment_waiting_queue.push(WaitingSegmentInfo {
@@ -487,7 +492,7 @@ impl Requester {
                 url: seg.url().clone(),
                 byte_range: seg.byte_range().cloned(),
                 time_info,
-                action_id,
+                caller_id,
             });
         }
     }
@@ -496,12 +501,12 @@ impl Requester {
     pub(crate) fn request_segment_unlocked(
         &mut self,
         lane_tag: RequestLaneTag,
-        url: Url,
+        url: &Url,
         byte_range: Option<&ByteRange>,
         time_info: Option<SegmentTimeInfo>,
-        action_id: u32,
+        caller_id: u32,
     ) {
-        self.request_segment_now(&url, byte_range, lane_tag, time_info, action_id);
+        self.request_segment_now(url, byte_range, lane_tag, time_info, caller_id);
     }
 
     pub(crate) fn lock_segment_requests(&mut self) -> bool {
@@ -528,14 +533,14 @@ impl Requester {
 
     pub(crate) fn on_pending_request_success(
         &mut self,
-        request_id: RequestId,
+        host_id: RequestId,
     ) -> Option<FinishedRequestType> {
-        self.end_pending_request(request_id)
+        self.end_pending_request(host_id)
     }
 
     pub(crate) fn on_pending_request_failure(
         &'_ mut self,
-        request_id: RequestId,
+        host_id: RequestId,
         has_timeouted: bool,
         status: Option<u32>,
     ) -> RetryResult<'_> {
@@ -550,13 +555,13 @@ impl Requester {
             if let Some(pos) = self
                 .pending_segment_requests
                 .iter()
-                .position(|x| x.request_id == request_id)
+                .position(|x| x.host_id == host_id)
             {
                 self.retry_pending_segment_request(pos, reason, status)
             } else if let Some(pos) = self
                 .pending_playlist_requests
                 .iter()
-                .position(|x| x.request_id == request_id)
+                .position(|x| x.host_id == host_id)
             {
                 match self.pending_playlist_requests[pos].playlist_type {
                     PlaylistFileType::TopLevelPlaylist => self.retry_playlist_request(
@@ -573,12 +578,12 @@ impl Requester {
                     ),
                 }
             } else {
-                Logger::info(&format!("Req: Request to retry not found, id:{request_id}"));
+                Logger::info(&format!("Req: Request to retry not found, id:{host_id}"));
                 RetryResult::NotFound
             }
         } else {
-            Logger::info(&format!("Req: Cannot retry request id:{request_id}"));
-            match self.end_pending_request(request_id) {
+            Logger::info(&format!("Req: Cannot retry request id:{host_id}"));
+            match self.end_pending_request(host_id) {
                 None => RetryResult::NotFound,
                 Some(req) => RetryResult::Failed {
                     request_type: req,
@@ -597,22 +602,22 @@ impl Requester {
                 let seg = self
                     .pending_segment_requests
                     .iter_mut()
-                    .find(|s| s.request_id == timer.1);
+                    .find(|s| s.host_id == timer.1);
                 if let Some(seg) = seg {
                     seg.is_waiting_for_retry = false;
                     let (range_start, range_end) = format_range_for_js(seg.byte_range.as_ref());
-                    let request_id = jsFetch(
+                    let host_id = jsFetch(
                         seg.url.get_ref(),
                         range_start,
                         range_end,
                         self.config.segment_request_timeout,
                     );
-                    seg.request_id = request_id;
+                    seg.host_id = host_id;
                 } else {
                     let pla = self
                         .pending_playlist_requests
                         .iter_mut()
-                        .find(|p| p.request_id == timer.1);
+                        .find(|p| p.host_id == timer.1);
                     if let Some(pla) = pla {
                         pla.is_waiting_for_retry = false;
                         let timeout = match pla.playlist_type {
@@ -623,8 +628,8 @@ impl Requester {
                                 self.config.media_playlist_request_timeout
                             }
                         };
-                        let request_id = jsFetch(pla.url.get_ref(), None, None, timeout);
-                        pla.request_id = request_id;
+                        let host_id = jsFetch(pla.url.get_ref(), None, None, timeout);
+                        pla.host_id = host_id;
                     }
                 }
             } else {
@@ -647,7 +652,7 @@ impl Requester {
 
     pub(crate) fn abort_all(&mut self) {
         for elt in self.pending_playlist_requests.drain(..) {
-            jsAbortRequest(elt.request_id);
+            jsAbortRequest(elt.host_id);
         }
         self.abort_all_segments();
         self.check_segment_queue();
@@ -656,7 +661,7 @@ impl Requester {
     pub(crate) fn abort_all_segments(&mut self) {
         while let Some(last_req) = self.pending_segment_requests.pop() {
             log_segment_abort(&last_req);
-            jsAbortRequest(last_req.request_id);
+            jsAbortRequest(last_req.host_id);
         }
         while let Some(last_req) = self.segment_waiting_queue.pop() {
             log_segment_abort(&last_req);
@@ -667,15 +672,15 @@ impl Requester {
         let lane_tag = RequestLaneTag::from_media_type(media_type);
         let mut i = 0;
         let mut aborted_pending = false;
-        let mut aborted_actions = vec![];
+        let mut aborted_requests = vec![];
         while i < self.pending_segment_requests.len() {
             let next_req = &self.pending_segment_requests[i];
             if next_req.lane_tag() == lane_tag {
                 log_segment_abort(next_req);
                 aborted_pending = true;
-                jsAbortRequest(next_req.request_id);
+                jsAbortRequest(next_req.host_id);
                 let removed = self.pending_segment_requests.remove(i);
-                aborted_actions.push(removed.action_id);
+                aborted_requests.push(removed.caller_id);
             } else {
                 i += 1;
             }
@@ -685,7 +690,7 @@ impl Requester {
             if next_req.lane_tag() == lane_tag {
                 log_segment_abort(next_req);
                 let removed = self.segment_waiting_queue.remove(i);
-                aborted_actions.push(removed.action_id);
+                aborted_requests.push(removed.caller_id);
             } else {
                 i += 1;
             }
@@ -693,26 +698,23 @@ impl Requester {
         if aborted_pending {
             self.check_segment_queue();
         }
-        aborted_actions
+        aborted_requests
     }
 
-    fn end_pending_request(&mut self, request_id: RequestId) -> Option<FinishedRequestType> {
-        if let Some(res) = self.end_pending_segment_request(request_id) {
+    fn end_pending_request(&mut self, host_id: RequestId) -> Option<FinishedRequestType> {
+        if let Some(res) = self.end_pending_segment_request(host_id) {
             Some(FinishedRequestType::Segment(res))
         } else {
             Some(FinishedRequestType::Playlist(
-                self.end_pending_playlist_request(request_id)?,
+                self.end_pending_playlist_request(host_id)?,
             ))
         }
     }
 
-    fn end_pending_playlist_request(
-        &mut self,
-        request_id: RequestId,
-    ) -> Option<PlaylistRequestInfo> {
+    fn end_pending_playlist_request(&mut self, host_id: RequestId) -> Option<PlaylistRequestInfo> {
         let mut i = 0;
         while i < self.pending_playlist_requests.len() {
-            if self.pending_playlist_requests[i].request_id == request_id {
+            if self.pending_playlist_requests[i].host_id == host_id {
                 let req = self.pending_playlist_requests.remove(i);
                 return Some(req);
             } else {
@@ -722,10 +724,10 @@ impl Requester {
         None
     }
 
-    fn end_pending_segment_request(&mut self, request_id: RequestId) -> Option<SegmentRequestInfo> {
+    fn end_pending_segment_request(&mut self, host_id: RequestId) -> Option<SegmentRequestInfo> {
         let mut i = 0;
         while i < self.pending_segment_requests.len() {
-            if self.pending_segment_requests[i].request_id == request_id {
+            if self.pending_segment_requests[i].host_id == host_id {
                 let removed = self.pending_segment_requests.remove(i);
                 self.check_segment_queue();
                 return Some(removed);
@@ -747,7 +749,7 @@ impl Requester {
         if max_retry >= 0 && req.attempts_failed >= (max_retry as u32) {
             Logger::info(&format!(
                 "Req: Too much attempts for segment request id:{} a:{}",
-                req.request_id, req.attempts_failed
+                req.host_id, req.attempts_failed
             ));
             let seg = self.pending_segment_requests.remove(pos);
             RetryResult::Failed {
@@ -766,10 +768,10 @@ impl Requester {
             );
             Logger::info(&format!(
                 "Req: Retrying segment request after timer id:{} d:{} a:{}",
-                req.request_id, retry_delay, req.attempts_failed
+                req.host_id, retry_delay, req.attempts_failed
             ));
             let timer_id = jsTimer(retry_delay, TimerReason::RetryRequest);
-            self.retry_timers.push((timer_id, req.request_id));
+            self.retry_timers.push((timer_id, req.host_id));
             let req = self.pending_segment_requests.get(pos).unwrap();
             RetryResult::RetriedSegment {
                 reason,
@@ -790,7 +792,7 @@ impl Requester {
         if max_retry >= 0 && req.attempts_failed >= (max_retry as u32) {
             Logger::info(&format!(
                 "Req: Too much attempts for playlist request id:{} a:{}",
-                req.request_id, req.attempts_failed
+                req.host_id, req.attempts_failed
             ));
             let pl = self.pending_playlist_requests.remove(pos);
             RetryResult::Failed {
@@ -815,10 +817,10 @@ impl Requester {
             let retry_delay = get_waiting_delay(req.attempts_failed, base, max);
             Logger::info(&format!(
                 "Req: Retrying playlist request after timer id:{} d:{} a:{}",
-                req.request_id, retry_delay, req.attempts_failed
+                req.host_id, retry_delay, req.attempts_failed
             ));
             let timer_id = jsTimer(retry_delay, TimerReason::RetryRequest);
-            self.retry_timers.push((timer_id, req.request_id));
+            self.retry_timers.push((timer_id, req.host_id));
 
             let req = self.pending_playlist_requests.get(pos).unwrap();
             RetryResult::RetriedPlaylist {
@@ -831,14 +833,14 @@ impl Requester {
 
     fn retry_pending_playlist_request(
         &mut self,
-        request_id: RequestId,
+        host_id: RequestId,
         reason: RequestErrorReason,
         status: Option<u32>,
     ) -> RetryResult<'_> {
         let pos = self
             .pending_playlist_requests
             .iter_mut()
-            .position(|x| x.request_id == request_id);
+            .position(|x| x.host_id == host_id);
         if let Some(pos) = pos {
             if self.pending_playlist_requests[pos].attempts_failed >= 3 {
                 let seg = self.pending_playlist_requests.remove(pos);
@@ -852,7 +854,7 @@ impl Requester {
                 req.attempts_failed += 1;
                 req.is_waiting_for_retry = true;
                 let timer_id = jsTimer(1000., TimerReason::RetryRequest);
-                self.retry_timers.push((timer_id, req.request_id));
+                self.retry_timers.push((timer_id, req.host_id));
                 RetryResult::RetriedPlaylist {
                     reason,
                     status,
@@ -888,7 +890,7 @@ impl Requester {
                             seg.byte_range.as_ref(),
                             seg.lane_tag,
                             seg.time_info,
-                            seg.action_id,
+                            seg.caller_id,
                         );
                     },
                 );
@@ -900,7 +902,7 @@ impl Requester {
                     seg.byte_range.as_ref(),
                     seg.lane_tag,
                     seg.time_info,
-                    seg.action_id,
+                    seg.caller_id,
                 );
             }
         }
@@ -950,26 +952,26 @@ impl Requester {
         byte_range: Option<&ByteRange>,
         lane_tag: RequestLaneTag,
         time_info: Option<SegmentTimeInfo>,
-        action_id: u32,
+        caller_id: u32,
     ) {
         let (range_start, range_end) = format_range_for_js(byte_range);
         let url_ref = url.get_ref();
-        let request_id = jsFetch(
+        let host_id = jsFetch(
             url_ref,
             range_start,
             range_end,
             self.config.segment_request_timeout,
         );
         Logger::debug(&format!(
-            "Req: Performing segment request. u:{url_ref} id:{request_id}"
+            "Req: Performing segment request. u:{url_ref} id:{host_id}"
         ));
         self.pending_segment_requests.push(SegmentRequestInfo {
-            request_id,
+            host_id,
             lane_tag,
             url: url.clone(),
             byte_range: byte_range.cloned(),
             time_info,
-            action_id,
+            caller_id,
             attempts_failed: 0,
             is_waiting_for_retry: false,
         });

--- a/src/rs-core/requester/mod.rs
+++ b/src/rs-core/requester/mod.rs
@@ -82,8 +82,8 @@ pub(crate) struct Requester {
 /// Identify a type of Playlist requested.
 #[derive(PartialEq)]
 pub(crate) enum PlaylistFileType {
-    /// This is a Multivariant Playlist
-    MultivariantPlaylist,
+    /// This is the top-level Playlist loaded through the public `load` API.
+    TopLevelPlaylist,
     /// This is a Media Playlist with this associated `id` and `MediaType`.
     MediaPlaylist {
         id: MediaPlaylistPermanentId,
@@ -91,7 +91,7 @@ pub(crate) enum PlaylistFileType {
     },
 }
 
-/// Metadata associated with a pending Playlist (either a Multivariant Playlist or a Media
+/// Metadata associated with a pending Playlist (either a top-level Playlist or a Media
 /// Playlist request.
 pub(crate) struct PlaylistRequestInfo {
     /// ID identifying the request on the JavaScript-side.
@@ -367,7 +367,7 @@ impl Requester {
     /// Once it succeeds, the `__web_event__request_finished` function will be called.
     pub(crate) fn fetch_playlist(&mut self, url: Url, playlist_type: PlaylistFileType) {
         let timeout = match playlist_type {
-            PlaylistFileType::MultivariantPlaylist => {
+            PlaylistFileType::TopLevelPlaylist => {
                 self.config.multi_variant_playlist_request_timeout
             }
             PlaylistFileType::MediaPlaylist { .. } => self.config.media_playlist_request_timeout,
@@ -509,7 +509,7 @@ impl Requester {
                 .position(|x| x.request_id == request_id)
             {
                 match self.pending_playlist_requests[pos].playlist_type {
-                    PlaylistFileType::MultivariantPlaylist => self.retry_playlist_request(
+                    PlaylistFileType::TopLevelPlaylist => self.retry_playlist_request(
                         pos,
                         reason,
                         status,
@@ -566,7 +566,7 @@ impl Requester {
                     if let Some(pla) = pla {
                         pla.is_waiting_for_retry = false;
                         let timeout = match pla.playlist_type {
-                            PlaylistFileType::MultivariantPlaylist => {
+                            PlaylistFileType::TopLevelPlaylist => {
                                 self.config.multi_variant_playlist_request_timeout
                             }
                             PlaylistFileType::MediaPlaylist { .. } => {
@@ -748,7 +748,7 @@ impl Requester {
             req.attempts_failed += 1;
             req.is_waiting_for_retry = true;
             let (base, max) = match req.playlist_type {
-                PlaylistFileType::MultivariantPlaylist => (
+                PlaylistFileType::TopLevelPlaylist => (
                     self.config.multi_variant_playlist_backoff_base,
                     self.config.multi_variant_playlist_backoff_max,
                 ),

--- a/src/rs-core/requester/mod.rs
+++ b/src/rs-core/requester/mod.rs
@@ -132,6 +132,12 @@ pub(crate) struct WaitingSegmentInfo {
     context: SegmentQualityContext,
 }
 
+#[derive(Clone)]
+pub(crate) enum SegmentRequestContext {
+    Playback(SegmentQualityContext),
+    Probe,
+}
+
 impl WaitingSegmentInfo {
     /// Returns the type of media of the awaiting segment.
     pub(crate) fn media_type(&self) -> MediaType {
@@ -227,7 +233,7 @@ pub(crate) struct SegmentRequestInfo {
     /// ID identifying the request on the JavaScript-side.
     request_id: RequestId,
 
-    context: SegmentQualityContext,
+    context: SegmentRequestContext,
 
     /// type of media of the segment requested
     media_type: MediaType,
@@ -277,7 +283,7 @@ impl SegmentRequestInfo {
         self.is_waiting_for_retry
     }
 
-    pub(crate) fn context(&self) -> &SegmentQualityContext {
+    pub(crate) fn context(&self) -> &SegmentRequestContext {
         &self.context
     }
 
@@ -287,7 +293,7 @@ impl SegmentRequestInfo {
         Url,
         Option<ByteRange>,
         Option<SegmentTimeInfo>,
-        SegmentQualityContext,
+        SegmentRequestContext,
     ) {
         (self.url, self.byte_range, self.time_info, self.context)
     }
@@ -397,7 +403,13 @@ impl Requester {
         byte_range: Option<&ByteRange>,
         context: SegmentQualityContext,
     ) {
-        self.request_segment_now(&url, byte_range, media_type, None, context);
+        self.request_segment_now(
+            &url,
+            byte_range,
+            media_type,
+            None,
+            SegmentRequestContext::Playback(context),
+        );
     }
 
     /// Returns `true` if a segment with the given identifying characteristics is currently either
@@ -442,7 +454,13 @@ impl Requester {
         ));
         let time_info = Some(seg.time_info().clone());
         if self.can_start_request(seg.start()) {
-            self.request_segment_now(seg.url(), seg.byte_range(), media_type, time_info, context)
+            self.request_segment_now(
+                seg.url(),
+                seg.byte_range(),
+                media_type,
+                time_info,
+                SegmentRequestContext::Playback(context),
+            )
         } else {
             Logger::debug("Req: pushing segment request to queue");
             self.segment_waiting_queue.push(WaitingSegmentInfo {
@@ -455,16 +473,16 @@ impl Requester {
         }
     }
 
-    /// XXX TODO: Try merging with `request_media_segment`?
-    pub(crate) fn request_probe_media_segment(
+    // TODO: Merge it with the others?
+    pub(crate) fn request_segment_unlocked(
         &mut self,
         media_type: MediaType,
         url: Url,
         byte_range: Option<&ByteRange>,
-        time_info: SegmentTimeInfo,
-        context: SegmentQualityContext,
+        time_info: Option<SegmentTimeInfo>,
+        context: SegmentRequestContext,
     ) {
-        self.request_segment_now(&url, byte_range, media_type, Some(time_info), context);
+        self.request_segment_now(&url, byte_range, media_type, time_info, context);
     }
 
     pub(crate) fn lock_segment_requests(&mut self) -> bool {
@@ -845,7 +863,7 @@ impl Requester {
                             seg.byte_range.as_ref(),
                             seg.media_type,
                             seg.time_info,
-                            seg.context,
+                            SegmentRequestContext::Playback(seg.context),
                         );
                     },
                 );
@@ -857,7 +875,7 @@ impl Requester {
                     seg.byte_range.as_ref(),
                     seg.media_type,
                     seg.time_info,
-                    seg.context,
+                    SegmentRequestContext::Playback(seg.context),
                 );
             }
         }
@@ -907,7 +925,7 @@ impl Requester {
         byte_range: Option<&ByteRange>,
         media_type: MediaType,
         time_info: Option<SegmentTimeInfo>,
-        context: SegmentQualityContext,
+        context: SegmentRequestContext,
     ) {
         let (range_start, range_end) = format_range_for_js(byte_range);
         let url_ref = url.get_ref();

--- a/src/rs-core/segment_selector/mod.rs
+++ b/src/rs-core/segment_selector/mod.rs
@@ -211,14 +211,18 @@ impl NextSegmentSelector {
         self.skipped_segments.clear();
     }
 
-    /// Calling this method allows to indicate that the initialization segment was requested and as
-    /// such, don't need to be returned anymore by this `NextSegmentSelector`.
-    pub(crate) fn validate_init(&mut self) {
-        if let InitializationSegmentSelectorStatus::Unvalidated(start) = self.init_status {
-            self.init_status = InitializationSegmentSelectorStatus::Validated(start);
-        } else {
-            Logger::warn("Validation of an initialization segment, but none were returned.");
+    /// Calling this method allows to indicate that the initialization segment identified by `id`
+    /// was requested and as such, doesn't need to be returned anymore by this
+    /// `NextSegmentSelector`.
+    pub(crate) fn validate_init(&mut self, id: f64) {
+        if let InitializationSegmentSelectorStatus::Unvalidated(expected_id) = self.init_status {
+            if expected_id != id {
+                Logger::warn(&format!(
+                    "Validation of an initialization segment with unexpected id. Expected {expected_id}, got {id}."
+                ));
+            }
         }
+        self.init_status = InitializationSegmentSelectorStatus::Validated(id);
     }
 
     /// Calling this method allows to indicate that the media segment ending at `pos` was requested
@@ -242,12 +246,19 @@ impl NextSegmentSelector {
         inventory: &[BufferedChunk],
     ) -> NeededSegmentInfo<'a> {
         let new_media_id = context.media_id();
-        let has_quality_changed = Some(new_media_id) != self.last_media_id;
+        let previous_media_id = self.last_media_id;
+        let has_quality_changed =
+            previous_media_id.is_some() && previous_media_id != Some(new_media_id);
+        let should_recompute_starting_position = previous_media_id != Some(new_media_id);
         self.last_media_id = Some(new_media_id);
 
-        if has_quality_changed {
-            Logger::debug("Selector: Quality changed, recomputing starting position");
-            self.init_status = InitializationSegmentSelectorStatus::Unchecked;
+        if should_recompute_starting_position {
+            if has_quality_changed {
+                Logger::debug("Selector: Quality changed, recomputing starting position");
+                self.init_status = InitializationSegmentSelectorStatus::Unchecked;
+            } else {
+                Logger::debug("Selector: Initial media selection, computing starting position");
+            }
             self.segment_cursor.move_cursor(self.base_pos);
             self.skipped_segments.clear();
             let start_pos = self.recompute_starting_position(context, inventory);

--- a/src/rs-core/segment_selector/mod.rs
+++ b/src/rs-core/segment_selector/mod.rs
@@ -217,7 +217,7 @@ impl NextSegmentSelector {
         if let InitializationSegmentSelectorStatus::Unvalidated(start) = self.init_status {
             self.init_status = InitializationSegmentSelectorStatus::Validated(start);
         } else {
-            Logger::warn("Validation an initialization segment, but none were returned.");
+            Logger::warn("Validation of an initialization segment, but none were returned.");
         }
     }
 

--- a/src/ts-common/generatedWasmEnums.ts
+++ b/src/ts-common/generatedWasmEnums.ts
@@ -11,7 +11,8 @@ export const OtherErrorCode = Object.freeze({
   NoSupportedVariant: 0,
   UnfoundLockedVariant: 1,
   MediaSourceAttachmentError: 2,
-  Unknown: 3,
+  NotAPlaylist: 3,
+  Unknown: 4,
 } as const);
 export type OtherErrorCode =
   (typeof OtherErrorCode)[keyof typeof OtherErrorCode];

--- a/src/ts-common/types.d.ts
+++ b/src/ts-common/types.d.ts
@@ -9,6 +9,7 @@ import type {
   PushedSegmentErrorCode,
   StartingPositionType,
   PlaylistNature,
+  PlaylistType,
   AddSourceBufferErrorCode,
 } from "../wasm/index.js";
 import { MediaSourceReadyState, PlaybackTickReason } from "../wasm/index.js";
@@ -67,7 +68,7 @@ export declare const enum MainMessageType {
 export type WorkerMessage =
   | InitializedWorkerMessage
   | InitializationErrorWorkerMessage
-  | MultivariantPlaylistParsedWorkerMessage
+  | TopLevelPlaylistParsedWorkerMessage
   | ContentInfoUpdateWorkerMessage
   | MediaOffsetUpdateWorkerMessage
   | VariantUpdateWorkerMessage
@@ -104,7 +105,7 @@ export declare const enum WorkerMessageType {
   Error = "err",
   Warning = "warn",
   ContentInfoUpdate = "content-upd",
-  MultivariantPlaylistParsed = "m-playlist",
+  TopLevelPlaylistParsed = "m-playlist",
   TrackUpdate = "track-upd",
   ContentStopped = "ctnt-stop",
   Seek = "seek",
@@ -369,8 +370,8 @@ export interface ContentInfoUpdateWorkerMessage {
     playlistType: PlaylistNature;
   };
 }
-export interface MultivariantPlaylistParsedWorkerMessage {
-  type: WorkerMessageType.MultivariantPlaylistParsed;
+export interface TopLevelPlaylistParsedWorkerMessage {
+  type: WorkerMessageType.TopLevelPlaylistParsed;
   value: {
     /**
      * The identifier for the content on which an error was received.
@@ -378,6 +379,8 @@ export interface MultivariantPlaylistParsedWorkerMessage {
      * `LoadContentMainMessage`.
      */
     contentId: string;
+    playlistType: PlaylistType;
+    mediaType?: MediaType | undefined;
     variants: VariantInfo[];
     audioTracks: AudioTrackInfo[];
   };

--- a/src/ts-common/types.d.ts
+++ b/src/ts-common/types.d.ts
@@ -284,7 +284,7 @@ export interface SegmentRequestErrorWorkerInfo {
     isInit: boolean;
     start?: number | undefined;
     duration?: number | undefined;
-    mediaType: MediaType;
+    mediaType: MediaType | undefined;
     byteRange?: [number, number] | undefined;
     reason: RequestErrorReason;
     status?: number | undefined;

--- a/src/ts-common/types.ts
+++ b/src/ts-common/types.ts
@@ -314,7 +314,7 @@ export interface SegmentRequestErrorWorkerInfo {
     isInit: boolean;
     start?: number | undefined;
     duration?: number | undefined;
-    mediaType: MediaType;
+    mediaType: MediaType | undefined;
     byteRange?: [number, number] | undefined;
     reason: RequestErrorReason;
     status?: number | undefined;

--- a/src/ts-common/types.ts
+++ b/src/ts-common/types.ts
@@ -9,6 +9,7 @@ import type {
   PushedSegmentErrorCode,
   StartingPositionType,
   PlaylistNature,
+  PlaylistType,
   AddSourceBufferErrorCode,
 } from "../wasm/index.js";
 import { MediaSourceReadyState, PlaybackTickReason } from "../wasm/index.js";
@@ -76,7 +77,7 @@ export type WorkerMessage =
   | InitializationErrorWorkerMessage
 
   // Related to content information
-  | MultivariantPlaylistParsedWorkerMessage
+  | TopLevelPlaylistParsedWorkerMessage
   | ContentInfoUpdateWorkerMessage
   | MediaOffsetUpdateWorkerMessage
   | VariantUpdateWorkerMessage
@@ -120,7 +121,7 @@ export const enum WorkerMessageType {
   Error = "err",
   Warning = "warn",
   ContentInfoUpdate = "content-upd",
-  MultivariantPlaylistParsed = "m-playlist",
+  TopLevelPlaylistParsed = "m-playlist",
   TrackUpdate = "track-upd",
   ContentStopped = "ctnt-stop",
   Seek = "seek",
@@ -407,8 +408,8 @@ export interface ContentInfoUpdateWorkerMessage {
   };
 }
 
-export interface MultivariantPlaylistParsedWorkerMessage {
-  type: WorkerMessageType.MultivariantPlaylistParsed;
+export interface TopLevelPlaylistParsedWorkerMessage {
+  type: WorkerMessageType.TopLevelPlaylistParsed;
   value: {
     /**
      * The identifier for the content on which an error was received.
@@ -416,6 +417,7 @@ export interface MultivariantPlaylistParsedWorkerMessage {
      * `LoadContentMainMessage`.
      */
     contentId: string;
+    playlistType: PlaylistType;
     variants: VariantInfo[];
     audioTracks: AudioTrackInfo[];
   };

--- a/src/ts-main/api.ts
+++ b/src/ts-main/api.ts
@@ -1111,12 +1111,14 @@ export default class WaspHlsPlayer extends EventEmitter<WaspHlsPlayerEvents> {
           break;
         case WorkerMessageType.TopLevelPlaylistParsed:
           if (onTopLevelPlaylistParsedMessage(data, this.__contentMetadata__)) {
+            // XXX TODO: Only when codecs known?
             this.trigger("variantListUpdate", this.getVariantList());
             this.trigger("audioTrackListUpdate", this.getAudioTrackList());
             if (
               this.__contentMetadata__?.topLevelPlaylistType ===
               PlaylistType.MediaPlaylist
             ) {
+              // XXX TODO: Only when codecs known?
               this.trigger("variantUpdate", this.getCurrentVariant());
             }
           }
@@ -1124,12 +1126,14 @@ export default class WaspHlsPlayer extends EventEmitter<WaspHlsPlayerEvents> {
         case WorkerMessageType.TrackUpdate:
           if (onTrackUpdateMessage(data, this.__contentMetadata__)) {
             if (data.value.mediaType === MediaType.Audio) {
+              // XXX TODO: Only when codecs known?
               this.trigger("audioTrackUpdate", this.getCurrentAudioTrack());
             }
           }
           break;
         case WorkerMessageType.VariantUpdate:
           if (onVariantUpdateMessage(data, this.__contentMetadata__)) {
+            // XXX TODO: Only when codecs known?
             this.trigger("variantUpdate", this.getCurrentVariant());
           }
           break;

--- a/src/ts-main/api.ts
+++ b/src/ts-main/api.ts
@@ -1111,29 +1111,19 @@ export default class WaspHlsPlayer extends EventEmitter<WaspHlsPlayerEvents> {
           break;
         case WorkerMessageType.TopLevelPlaylistParsed:
           if (onTopLevelPlaylistParsedMessage(data, this.__contentMetadata__)) {
-            // XXX TODO: Only when codecs known?
             this.trigger("variantListUpdate", this.getVariantList());
             this.trigger("audioTrackListUpdate", this.getAudioTrackList());
-            if (
-              this.__contentMetadata__?.topLevelPlaylistType ===
-              PlaylistType.MediaPlaylist
-            ) {
-              // XXX TODO: Only when codecs known?
-              this.trigger("variantUpdate", this.getCurrentVariant());
-            }
           }
           break;
         case WorkerMessageType.TrackUpdate:
           if (onTrackUpdateMessage(data, this.__contentMetadata__)) {
             if (data.value.mediaType === MediaType.Audio) {
-              // XXX TODO: Only when codecs known?
               this.trigger("audioTrackUpdate", this.getCurrentAudioTrack());
             }
           }
           break;
         case WorkerMessageType.VariantUpdate:
           if (onVariantUpdateMessage(data, this.__contentMetadata__)) {
-            // XXX TODO: Only when codecs known?
             this.trigger("variantUpdate", this.getCurrentVariant());
           }
           break;

--- a/src/ts-main/api.ts
+++ b/src/ts-main/api.ts
@@ -18,6 +18,7 @@ import {
 import {
   MediaType,
   PlaylistNature,
+  PlaylistType,
   StartingPositionType,
 } from "../wasm/index.js";
 import DEFAULT_CONFIG from "./default_config.ts";
@@ -52,7 +53,7 @@ import {
   onUpdateMediaSourceDurationMessage,
   onUpdatePlaybackRateMessage,
   onWarningMessage,
-  onMultivariantPlaylistParsedMessage,
+  onTopLevelPlaylistParsedMessage,
   onVariantUpdateMessage,
   onTrackUpdateMessage,
   onFlushMessage,
@@ -362,8 +363,11 @@ export default class WaspHlsPlayer extends EventEmitter<WaspHlsPlayerEvents> {
   }
 
   /**
-   * Loads a new HLS content whose MultivariantPlaylist's URL is given in
+   * Loads a new HLS content whose top-level playlist's URL is given in
    * argument.
+   *
+   * That top-level playlist can be either a Multivariant Playlist or a Media
+   * Playlist.
    *
    * This method can only be called if the `WaspHlsPlayer` is initialized.
    * If that's the case, you should receive synchronously a `"loading"` event,
@@ -406,6 +410,7 @@ export default class WaspHlsPlayer extends EventEmitter<WaspHlsPlayerEvents> {
       minimumPosition: undefined,
       maximumPosition: undefined,
       playlistType: undefined,
+      topLevelPlaylistType: undefined,
       loadingAborter,
       error: null,
     };
@@ -868,6 +873,22 @@ export default class WaspHlsPlayer extends EventEmitter<WaspHlsPlayerEvents> {
     if (this.__contentMetadata__ === null) {
       throw new Error("No content loaded");
     }
+    if (
+      this.__contentMetadata__.topLevelPlaylistType ===
+      PlaylistType.MediaPlaylist
+    ) {
+      const variant =
+        this.__contentMetadata__.variants.find((v) => v.id === variantId) ??
+        null;
+      if (variant === null) {
+        throw new Error(`Unknown variant id: ${variantId}`);
+      }
+      if (this.__contentMetadata__.lockedVariant !== variant) {
+        this.__contentMetadata__.lockedVariant = variant;
+        this.trigger("variantLockUpdate", this.getLockedVariant());
+      }
+      return;
+    }
     postMessageToWorker(this.__worker__, {
       type: MainMessageType.LockVariant,
       value: {
@@ -889,6 +910,16 @@ export default class WaspHlsPlayer extends EventEmitter<WaspHlsPlayerEvents> {
     }
     if (this.__contentMetadata__ === null) {
       throw new Error("No content loaded");
+    }
+    if (
+      this.__contentMetadata__.topLevelPlaylistType ===
+      PlaylistType.MediaPlaylist
+    ) {
+      if (this.__contentMetadata__.lockedVariant !== null) {
+        this.__contentMetadata__.lockedVariant = null;
+        this.trigger("variantLockUpdate", this.getLockedVariant());
+      }
+      return;
     }
     postMessageToWorker(this.__worker__, {
       type: MainMessageType.LockVariant,
@@ -1078,12 +1109,16 @@ export default class WaspHlsPlayer extends EventEmitter<WaspHlsPlayerEvents> {
         case WorkerMessageType.MediaOffsetUpdate:
           onMediaOffsetUpdateMessage(data, this.__contentMetadata__);
           break;
-        case WorkerMessageType.MultivariantPlaylistParsed:
-          if (
-            onMultivariantPlaylistParsedMessage(data, this.__contentMetadata__)
-          ) {
+        case WorkerMessageType.TopLevelPlaylistParsed:
+          if (onTopLevelPlaylistParsedMessage(data, this.__contentMetadata__)) {
             this.trigger("variantListUpdate", this.getVariantList());
             this.trigger("audioTrackListUpdate", this.getAudioTrackList());
+            if (
+              this.__contentMetadata__?.topLevelPlaylistType ===
+              PlaylistType.MediaPlaylist
+            ) {
+              this.trigger("variantUpdate", this.getCurrentVariant());
+            }
           }
           break;
         case WorkerMessageType.TrackUpdate:

--- a/src/ts-main/errors/WaspOtherError.ts
+++ b/src/ts-main/errors/WaspOtherError.ts
@@ -15,6 +15,7 @@ export default class WaspOtherError extends Error {
   /** Specifies the exact error encountered. */
   public readonly code:
     | "MediaSourceAttachmentError"
+    | "NotAPlaylist"
     | "NoSupportedVariant"
     | "UnfoundLockedVariant"
     | "Unknown";
@@ -48,6 +49,9 @@ export default class WaspOtherError extends Error {
         break;
       case OtherErrorCode.NoSupportedVariant:
         this.code = WaspErrorCode.NoSupportedVariant;
+        break;
+      case OtherErrorCode.NotAPlaylist:
+        this.code = WaspErrorCode.NotAPlaylist;
         break;
       default:
         this.code = WaspErrorCode.Unknown;

--- a/src/ts-main/errors/WaspSegmentRequestError.ts
+++ b/src/ts-main/errors/WaspSegmentRequestError.ts
@@ -109,13 +109,16 @@ export interface WaspSegmentRequestErrorArgument {
   isInit: boolean;
   start?: number | undefined;
   duration?: number | undefined;
-  mediaType: MediaType;
+  mediaType: MediaType | undefined;
   byteRange?: [number, number] | undefined;
   reason: RequestErrorReason;
   status?: number | undefined;
 }
 
-function mediaTypeAsArticle(mediaType: MediaType): string {
+function mediaTypeAsArticle(mediaType: MediaType | undefined): string {
+  if (mediaType === undefined) {
+    return "A probe";
+  }
   switch (mediaType) {
     case MediaType.Audio:
       return "An audio";

--- a/src/ts-main/errors/common.ts
+++ b/src/ts-main/errors/common.ts
@@ -84,7 +84,7 @@ export const WaspErrorCode = {
    */
   MediaSourceAttachmentError: "MediaSourceAttachmentError",
   /**
-   * No supported variant was found in the Multivariant Playlist.
+   * No supported startup stream was found for the current content.
    */
   NoSupportedVariant: "NoSupportedVariant",
   /**

--- a/src/ts-main/errors/common.ts
+++ b/src/ts-main/errors/common.ts
@@ -91,6 +91,10 @@ export const WaspErrorCode = {
    * The variant locked through the `lockVariant` API was not found.
    */
   UnfoundLockedVariant: "UnfoundLockedVariant",
+  /**
+   * The loaded resource does not seem to be an HLS playlist.
+   */
+  NotAPlaylist: "NotAPlaylist",
   /** An unknown error arised. */
   Unknown: "Unknown",
 

--- a/src/ts-main/types.ts
+++ b/src/ts-main/types.ts
@@ -1,6 +1,6 @@
 import type QueuedSourceBuffer from "../ts-common/QueuedSourceBuffer.ts";
 import type { AudioTrackInfo, VariantInfo } from "../ts-common/types.ts";
-import type { PlaylistNature } from "../wasm/index.js";
+import type { PlaylistNature, PlaylistType } from "../wasm/index.js";
 import type { WaspError } from "./errors/index.ts";
 import type PlaybackObserver from "./observePlayback.ts";
 
@@ -156,6 +156,11 @@ export interface ContentMetadata {
    * The type of the Multivariant Playlist being played: is it live? Vod?
    */
   playlistType: PlaylistNature | undefined;
+
+  /**
+   * Type of the top-level playlist that was loaded for the content.
+   */
+  topLevelPlaylistType: PlaylistType | undefined;
 
   /**
    * Error encountered in the content which led to the playback being completely

--- a/src/ts-main/worker-message-handlers.ts
+++ b/src/ts-main/worker-message-handlers.ts
@@ -25,7 +25,7 @@ import type {
   ContentInfoUpdateWorkerMessage,
   ContentStoppedWorkerMessage,
   WarningWorkerMessage,
-  MultivariantPlaylistParsedWorkerMessage,
+  TopLevelPlaylistParsedWorkerMessage,
   VariantUpdateWorkerMessage,
   TrackUpdateWorkerMessage,
   FlushWorkerMessage,
@@ -38,6 +38,7 @@ import {
   AddSourceBufferErrorCode,
   MediaType,
   OtherErrorCode,
+  PlaylistType,
 } from "../wasm/index.js";
 import {
   WaspMediaPlaylistParsingError,
@@ -55,6 +56,8 @@ import PlaybackObserver from "./observePlayback.ts";
 import postMessageToWorker from "./postMessageToWorker.ts";
 import type { ContentMetadata } from "./types.ts";
 import { clearElementSrc, getErrorInformation } from "./utils.ts";
+
+const DIRECT_MEDIA_VARIANT_ID = 0;
 
 /**
  * Interval, in milliseconds, at which playback observations are sent to the
@@ -906,23 +909,42 @@ export function onContentInfoUpdateMessage(
 }
 
 /**
- * Handles `MultivariantPlaylistParsedWorkerMessage` messages.
+ * Handles `TopLevelPlaylistParsedWorkerMessage` messages.
  * @param {Object} msg - The worker's message received.
  * @param {Object|null} contentMetadata - Metadata of the content currently
  * playing. `null` if no content is currently playing.
  * This object may be mutated.
  * @returns {boolean} - `true` if the message concerned the current content.
  */
-export function onMultivariantPlaylistParsedMessage(
-  msg: MultivariantPlaylistParsedWorkerMessage,
+export function onTopLevelPlaylistParsedMessage(
+  msg: TopLevelPlaylistParsedWorkerMessage,
   contentMetadata: ContentMetadata | null,
 ): boolean {
   if (contentMetadata?.contentId !== msg.value.contentId) {
     logger.info("API: Ignoring warning due to wrong `contentId`");
     return false;
   }
-  contentMetadata.variants = msg.value.variants;
+  contentMetadata.topLevelPlaylistType = msg.value.playlistType;
+  contentMetadata.variants =
+    msg.value.playlistType === PlaylistType.MultivariantPlaylist
+      ? msg.value.variants
+      : [
+          {
+            id: DIRECT_MEDIA_VARIANT_ID,
+            // TODO: from container if/when available?
+            width: undefined,
+            height: undefined,
+            frameRate: undefined,
+            bandwidth: undefined,
+            videoRange: undefined,
+          },
+        ];
   contentMetadata.audioTracks = msg.value.audioTracks;
+  if (msg.value.playlistType !== PlaylistType.MultivariantPlaylist) {
+    contentMetadata.currVariant = contentMetadata.variants[0];
+    contentMetadata.lockedVariant = null;
+    contentMetadata.currentAudioTrack = undefined;
+  }
   return true;
 }
 
@@ -971,9 +993,16 @@ export function onVariantUpdateMessage(
     logger.info("API: Ignoring warning due to wrong `contentId`");
     return false;
   }
-  const variant = contentMetadata.variants.find(
+  let variant = contentMetadata.variants.find(
     (v) => v.id === msg.value.variantId,
   );
+  if (
+    variant === undefined &&
+    contentMetadata.topLevelPlaylistType === PlaylistType.MediaPlaylist &&
+    msg.value.variantId === DIRECT_MEDIA_VARIANT_ID
+  ) {
+    variant = contentMetadata.variants[0];
+  }
   if (variant === undefined) {
     logger.warn("API: VariantUpdate for an unfound variant");
   }
@@ -1008,9 +1037,16 @@ export function onVariantLockStatusChangeMessage(
     return false;
   }
 
-  const variant = contentMetadata.variants.find(
+  let variant = contentMetadata.variants.find(
     (v) => v.id === msg.value.lockedVariant,
   );
+  if (
+    variant === undefined &&
+    contentMetadata.topLevelPlaylistType === PlaylistType.MediaPlaylist &&
+    msg.value.lockedVariant === DIRECT_MEDIA_VARIANT_ID
+  ) {
+    variant = contentMetadata.variants[0];
+  }
   if (variant === undefined) {
     logger.warn("API: VariantLockStatusChange for an unfound variant");
     if (contentMetadata.lockedVariant !== null) {

--- a/src/ts-main/worker-message-handlers.ts
+++ b/src/ts-main/worker-message-handlers.ts
@@ -38,7 +38,6 @@ import {
   AddSourceBufferErrorCode,
   MediaType,
   OtherErrorCode,
-  PlaylistType,
 } from "../wasm/index.js";
 import {
   WaspMediaPlaylistParsingError,
@@ -56,8 +55,6 @@ import PlaybackObserver from "./observePlayback.ts";
 import postMessageToWorker from "./postMessageToWorker.ts";
 import type { ContentMetadata } from "./types.ts";
 import { clearElementSrc, getErrorInformation } from "./utils.ts";
-
-const DIRECT_MEDIA_VARIANT_ID = 0;
 
 /**
  * Interval, in milliseconds, at which playback observations are sent to the
@@ -925,25 +922,10 @@ export function onTopLevelPlaylistParsedMessage(
     return false;
   }
   contentMetadata.topLevelPlaylistType = msg.value.playlistType;
-  contentMetadata.variants =
-    msg.value.playlistType === PlaylistType.MultivariantPlaylist
-      ? msg.value.variants
-      : [
-          {
-            id: DIRECT_MEDIA_VARIANT_ID,
-            // TODO: from container if/when available?
-            width: undefined,
-            height: undefined,
-            frameRate: undefined,
-            bandwidth: undefined,
-            videoRange: undefined,
-          },
-        ];
+  contentMetadata.variants = msg.value.variants;
   contentMetadata.audioTracks = msg.value.audioTracks;
-  if (msg.value.playlistType !== PlaylistType.MultivariantPlaylist) {
-    contentMetadata.currVariant = contentMetadata.variants[0];
+  if (contentMetadata.lockedVariant !== null) {
     contentMetadata.lockedVariant = null;
-    contentMetadata.currentAudioTrack = undefined;
   }
   return true;
 }
@@ -993,16 +975,9 @@ export function onVariantUpdateMessage(
     logger.info("API: Ignoring warning due to wrong `contentId`");
     return false;
   }
-  let variant = contentMetadata.variants.find(
+  const variant = contentMetadata.variants.find(
     (v) => v.id === msg.value.variantId,
   );
-  if (
-    variant === undefined &&
-    contentMetadata.topLevelPlaylistType === PlaylistType.MediaPlaylist &&
-    msg.value.variantId === DIRECT_MEDIA_VARIANT_ID
-  ) {
-    variant = contentMetadata.variants[0];
-  }
   if (variant === undefined) {
     logger.warn("API: VariantUpdate for an unfound variant");
   }
@@ -1037,16 +1012,9 @@ export function onVariantLockStatusChangeMessage(
     return false;
   }
 
-  let variant = contentMetadata.variants.find(
+  const variant = contentMetadata.variants.find(
     (v) => v.id === msg.value.lockedVariant,
   );
-  if (
-    variant === undefined &&
-    contentMetadata.topLevelPlaylistType === PlaylistType.MediaPlaylist &&
-    msg.value.lockedVariant === DIRECT_MEDIA_VARIANT_ID
-  ) {
-    variant = contentMetadata.variants[0];
-  }
   if (variant === undefined) {
     logger.warn("API: VariantLockStatusChange for an unfound variant");
     if (contentMetadata.lockedVariant !== null) {

--- a/src/ts-worker/bindings.ts
+++ b/src/ts-worker/bindings.ts
@@ -33,6 +33,7 @@ import {
 } from "../wasm/index.js";
 import type {
   HostBindings,
+  InspectSegmentValue,
   MediaPlaylistParsingErrorCode,
   MultivariantPlaylistParsingErrorCode,
   OtherErrorCode,
@@ -52,6 +53,7 @@ import {
 import type { RequestId, ResourceId, TimerId } from "./globals.ts";
 import {
   getDurationFromTrun,
+  getIsoBmffCodecs,
   getMDHDTimescale,
   getTrackFragmentDecodeTime,
 } from "./isobmff-utils.js";
@@ -1024,6 +1026,79 @@ export function appendBuffer(
 }
 
 /**
+ * Recuperate more information on a segment, identified by its `ResourceId`.
+ *
+ * This can generally be relied on to e.g. obtain the `codec` directly from
+ * segment metadata.
+ *
+ * @param resourceId - `ResourceId` of the segment you want more metadata from
+ * @param mimeType - The identified `mime-type` of this segment.
+ * @returns - Object describing the result of the operation.
+ */
+export function inspectSegment(
+  resourceId: ResourceId,
+  mimeType: string,
+): {
+  value: InspectSegmentValue | undefined;
+  errorCode: SegmentParsingErrorCode | undefined;
+  description: string | undefined;
+} {
+  const segment = jsMemoryResources.get(resourceId);
+  if (segment === undefined) {
+    return {
+      value: undefined,
+      errorCode: SegmentParsingErrorCode.NoResource,
+      description:
+        "Segment inspection error: No resource with the given `resourceId`",
+    };
+  }
+
+  let inspectedSegment = segment;
+  if (shouldTransmux(mimeType)) {
+    try {
+      const transmuxedData = createTransmuxer().transmuxSegment(segment);
+      if (transmuxedData === null) {
+        return {
+          value: undefined,
+          errorCode: SegmentParsingErrorCode.TransmuxerError,
+          description:
+            "Segment inspection error: the transmuxer couldn't process the segment",
+        };
+      }
+      inspectedSegment = transmuxedData;
+    } catch (err) {
+      const msg = formatErrMessage(
+        err,
+        "Unknown error while transmuxing segment for inspection",
+      );
+      return {
+        value: undefined,
+        errorCode: SegmentParsingErrorCode.TransmuxerError,
+        description: msg,
+      };
+    }
+  }
+
+  // XXX TODO: what if the segment is still AAC / mpeg-ts here?
+  const codecs = getIsoBmffCodecs(inspectedSegment);
+  if (codecs.length === 0) {
+    return {
+      value: undefined,
+      errorCode: SegmentParsingErrorCode.UnknownError,
+      description:
+        "Segment inspection error: no codec metadata was found in the probe segment",
+    };
+  }
+  return {
+    value: {
+      codec: codecs.join(","),
+    },
+    errorCode: undefined,
+    description: undefined,
+  };
+}
+
+/**
  * @param {number} sourceBufferId
  * @param {number} start
  * @param {number} end
@@ -1562,6 +1637,7 @@ export function getWaspHostCapabilities(): HostBindings {
     setMediaSourceDuration,
     addSourceBuffer,
     isTypeSupported,
+    inspectSegment,
     appendBuffer,
     removeBuffer,
     endOfStream,

--- a/src/ts-worker/bindings.ts
+++ b/src/ts-worker/bindings.ts
@@ -1028,17 +1028,13 @@ export function appendBuffer(
 /**
  * Recuperate more information on a segment, identified by its `ResourceId`.
  *
- * This can generally be relied on to e.g. obtain the `codec` directly from
- * segment metadata.
+ * This can generally be relied on to e.g. obtain the `codec` and mime-type
+ * directly from segment metadata.
  *
  * @param resourceId - `ResourceId` of the segment you want more metadata from
- * @param mimeType - The identified `mime-type` of this segment.
  * @returns - Object describing the result of the operation.
  */
-export function inspectSegment(
-  resourceId: ResourceId,
-  mimeType: string,
-): {
+export function inspectSegment(resourceId: ResourceId): {
   value: InspectSegmentValue | undefined;
   errorCode: SegmentParsingErrorCode | undefined;
   description: string | undefined;
@@ -1053,34 +1049,8 @@ export function inspectSegment(
     };
   }
 
-  let inspectedSegment = segment;
-  if (shouldTransmux(mimeType)) {
-    try {
-      const transmuxedData = createTransmuxer().transmuxSegment(segment);
-      if (transmuxedData === null) {
-        return {
-          value: undefined,
-          errorCode: SegmentParsingErrorCode.TransmuxerError,
-          description:
-            "Segment inspection error: the transmuxer couldn't process the segment",
-        };
-      }
-      inspectedSegment = transmuxedData;
-    } catch (err) {
-      const msg = formatErrMessage(
-        err,
-        "Unknown error while transmuxing segment for inspection",
-      );
-      return {
-        value: undefined,
-        errorCode: SegmentParsingErrorCode.TransmuxerError,
-        description: msg,
-      };
-    }
-  }
-
-  // XXX TODO: what if the segment is still AAC / mpeg-ts here?
-  const codecs = getIsoBmffCodecs(inspectedSegment);
+  // XXX TODO: what if the segment is AAC / mpeg-ts here?
+  const codecs = getIsoBmffCodecs(segment);
   if (codecs.length === 0) {
     return {
       value: undefined,
@@ -1089,13 +1059,26 @@ export function inspectSegment(
         "Segment inspection error: no codec metadata was found in the probe segment",
     };
   }
+  const mediaType = inferMediaTypeFromCodecs(codecs);
   return {
     value: {
+      mediaType,
+      mimeType: mediaType === MediaType.Audio ? "audio/mp4" : "video/mp4",
       codec: codecs.join(","),
     },
     errorCode: undefined,
     description: undefined,
   };
+}
+
+function inferMediaTypeFromCodecs(codecs: string[]): MediaType {
+  return codecs.some((codec) => !isAudioCodec(codec))
+    ? MediaType.Video
+    : MediaType.Audio;
+}
+
+function isAudioCodec(codec: string): boolean {
+  return /^(mp4a|ac-3|ec-3|opus|flac|alac)\b/i.test(codec);
 }
 
 /**

--- a/src/ts-worker/bindings.ts
+++ b/src/ts-worker/bindings.ts
@@ -37,6 +37,7 @@ import type {
   MultivariantPlaylistParsingErrorCode,
   OtherErrorCode,
   PlaylistNature,
+  PlaylistType,
   RequestErrorReason,
   SourceBufferCreationErrorCode,
   TimerReason,
@@ -282,7 +283,7 @@ export function sendMultivariantPlaylistParsingError(
 export function sendMediaPlaylistParsingError(
   fatal: boolean,
   code: MediaPlaylistParsingErrorCode,
-  mediaType: MediaType,
+  mediaType: MediaType | undefined,
   message: string,
 ): void {
   const contentId = playerInstance.getContentInfo()?.contentId;
@@ -1246,6 +1247,7 @@ export function updateContentInfo(
 }
 
 export function announceFetchedContent(
+  playlistType: PlaylistType,
   variantInfo: Uint32Array,
   audioTracksInfo: Uint32Array,
 ): void {
@@ -1384,9 +1386,10 @@ export function announceFetchedContent(
     }
   }
   postMessageToMain({
-    type: WorkerMessageType.MultivariantPlaylistParsed,
+    type: WorkerMessageType.TopLevelPlaylistParsed,
     value: {
       contentId: contentInfo.contentId,
+      playlistType,
       variants: variantInfoObj,
       audioTracks: audioTracksObj,
     },

--- a/src/ts-worker/bindings.ts
+++ b/src/ts-worker/bindings.ts
@@ -1049,9 +1049,8 @@ export function inspectSegment(resourceId: ResourceId): {
     };
   }
 
-  // XXX TODO: what if the segment is AAC / mpeg-ts here?
-  const codecs = getIsoBmffCodecs(segment);
-  if (codecs.length === 0) {
+  const inspection = inspectProbeSegment(segment);
+  if (inspection === undefined) {
     return {
       value: undefined,
       errorCode: SegmentParsingErrorCode.UnknownError,
@@ -1059,16 +1058,50 @@ export function inspectSegment(resourceId: ResourceId): {
         "Segment inspection error: no codec metadata was found in the probe segment",
     };
   }
-  const mediaType = inferMediaTypeFromCodecs(codecs);
   return {
-    value: {
-      mediaType,
-      mimeType: mediaType === MediaType.Audio ? "audio/mp4" : "video/mp4",
-      codec: codecs.join(","),
-    },
+    value: inspection,
     errorCode: undefined,
     description: undefined,
   };
+}
+
+function inspectProbeSegment(
+  segment: Uint8Array,
+): InspectSegmentValue | undefined {
+  const codecs = getIsoBmffCodecs(segment);
+  if (codecs.length > 0) {
+    const mediaType = inferMediaTypeFromCodecs(codecs);
+    return {
+      mediaType,
+      mimeType: mediaType === MediaType.Audio ? "audio/mp4" : "video/mp4",
+      codec: codecs.join(","),
+    };
+  }
+
+  const transmuxedSegment = createTransmuxer().transmuxSegment(segment);
+  if (transmuxedSegment === null) {
+    return undefined;
+  }
+  const transmuxedCodecs = getIsoBmffCodecs(transmuxedSegment);
+  if (transmuxedCodecs.length === 0) {
+    return undefined;
+  }
+  const mediaType = inferMediaTypeFromCodecs(transmuxedCodecs);
+  if (isLikelyAacProbeSegment(segment)) {
+    return {
+      mediaType,
+      mimeType: "audio/aac",
+      codec: transmuxedCodecs.join(","),
+    };
+  }
+  if (isLikelyMpeg2TsProbeSegment(segment)) {
+    return {
+      mediaType,
+      mimeType: mediaType === MediaType.Audio ? "audio/mp2t" : "video/mp2t",
+      codec: transmuxedCodecs.join(","),
+    };
+  }
+  return undefined;
 }
 
 function inferMediaTypeFromCodecs(codecs: string[]): MediaType {
@@ -1078,7 +1111,49 @@ function inferMediaTypeFromCodecs(codecs: string[]): MediaType {
 }
 
 function isAudioCodec(codec: string): boolean {
-  return /^(mp4a|ac-3|ec-3|opus|flac|alac)\b/i.test(codec);
+  return /^(mp4a|ac-3|ec-3|ac-4|opus|flac|alac)\b/i.test(codec);
+}
+
+function isLikelyAacProbeSegment(data: Uint8Array): boolean {
+  const offset = getId3Offset(data, 0);
+  return (
+    data.length >= offset + 2 &&
+    (data[offset] & 0xff) === 0xff &&
+    (data[offset + 1] & 0xf0) === 0xf0 &&
+    (data[offset + 1] & 0x16) === 0x10
+  );
+}
+
+function getId3Offset(data: Uint8Array, initialOffset: number): number {
+  if (
+    data.length - initialOffset < 10 ||
+    data[initialOffset] !== 0x49 ||
+    data[initialOffset + 1] !== 0x44 ||
+    data[initialOffset + 2] !== 0x33
+  ) {
+    return initialOffset;
+  }
+
+  const flags = data[initialOffset + 5];
+  const footerPresent = (flags & 16) >> 4;
+  const size =
+    (data[initialOffset + 6] << 21) |
+    (data[initialOffset + 7] << 14) |
+    (data[initialOffset + 8] << 7) |
+    data[initialOffset + 9];
+  const tagSize = Math.max(0, size) + (footerPresent === 1 ? 20 : 10);
+  return getId3Offset(data, initialOffset + tagSize);
+}
+
+function isLikelyMpeg2TsProbeSegment(data: Uint8Array): boolean {
+  if (data.length < 188 || data[0] !== 0x47) {
+    return false;
+  }
+  return (
+    data.length === 188 ||
+    data[188] === 0x47 ||
+    (data.length >= 377 && data[376] === 0x47)
+  );
 }
 
 /**

--- a/src/ts-worker/bindings.ts
+++ b/src/ts-worker/bindings.ts
@@ -81,7 +81,7 @@ export function sendSegmentRequestError(
   url: string,
   isInit: boolean,
   timeInfo: [number, number] | undefined,
-  mediaType: MediaType,
+  mediaType: MediaType | undefined,
   reason: RequestErrorReason,
   status: number | undefined,
 ): void {
@@ -343,7 +343,7 @@ export function sendSourceBufferCreationError(
 export function sendSegmentParsingError(
   fatal: boolean,
   code: SegmentParsingErrorCode,
-  mediaType: MediaType,
+  mediaType: MediaType | undefined,
   message: string,
 ): void {
   const contentId = playerInstance.getContentInfo()?.contentId;

--- a/src/ts-worker/isobmff-utils.ts
+++ b/src/ts-worker/isobmff-utils.ts
@@ -192,7 +192,7 @@ function getTrackCodec(trak: Uint8Array): string | undefined {
 
 function getCodecFromStsd(
   stsd: Uint8Array,
-  _handlerType: number,
+  handlerType: number,
 ): string | undefined {
   if (stsd.length < 16) {
     return undefined;
@@ -211,18 +211,79 @@ function getCodecFromStsd(
       return undefined;
     }
     const sampleEntry = stsd.subarray(contentStart, boxEnd);
-    switch (boxName) {
-      case 0x61766331: /* avc1 */
-      case 0x61766333 /* avc3 */:
-        return getAvcCodec(sampleEntry, boxName);
-      case 0x6d703461 /* mp4a */:
-        return getMp4aCodec(sampleEntry);
-      default:
-        break;
+    const codec = getCodecFromSampleEntry(sampleEntry, boxName, handlerType);
+    if (codec !== undefined) {
+      return codec;
     }
     cursor = boxEnd;
   }
   return undefined;
+}
+
+function getCodecFromSampleEntry(
+  sampleEntry: Uint8Array,
+  boxName: number,
+  handlerType: number,
+): string | undefined {
+  switch (boxName) {
+    case 0x61766331: /* avc1 */
+    case 0x61766333 /* avc3 */:
+      return getAvcCodec(sampleEntry, boxName);
+    case 0x6d703461 /* mp4a */:
+      return getMp4aCodec(sampleEntry);
+    case 0x656e6376: /* encv */
+    case 0x656e6361 /* enca */:
+      return getEncryptedCodec(sampleEntry, handlerType);
+    case 0x68766331: /* hvc1 */
+    case 0x68657631 /* hev1 */:
+      return getHevcCodec(sampleEntry, boxName);
+    case 0x76703038: /* vp08 */
+    case 0x76703039 /* vp09 */:
+      return getVpCodec(sampleEntry, boxName);
+    case 0x61763031 /* av01 */:
+      return getAv1Codec(sampleEntry);
+    case 0x64766831: /* dvh1 */
+    case 0x64766865: /* dvhe */
+    case 0x64766131: /* dva1 */
+    case 0x64766176: /* dvav */
+    case 0x61763032 /* av02 */:
+    case 0x61632d33: /* ac-3 */
+    case 0x65632d33: /* ec-3 */
+    case 0x61632d34: /* ac-4 */
+    case 0x4f707573: /* Opus */
+    case 0x664c6143: /* fLaC */
+    case 0x616c6163 /* alac */:
+      return fourCC(boxName);
+    default:
+      return undefined;
+  }
+}
+
+function getEncryptedCodec(
+  sampleEntry: Uint8Array,
+  handlerType: number,
+): string | undefined {
+  const boxes = sampleEntry.subarray(getSampleEntryHeaderSize(handlerType));
+  const frma = getBoxContent(boxes, 0x66726d61 /* frma */);
+  if (frma === null || frma.length < 4) {
+    return undefined;
+  }
+  const originalFormat = be4toi(frma, 0);
+  if (originalFormat === 0x656e6376 || originalFormat === 0x656e6361) {
+    return undefined;
+  }
+  return getCodecFromSampleEntry(sampleEntry, originalFormat, handlerType);
+}
+
+function getSampleEntryHeaderSize(handlerType: number): number {
+  switch (handlerType) {
+    case 0x76696465 /* vide */:
+      return 78;
+    case 0x736f756e /* soun */:
+      return 28;
+    default:
+      return 8;
+  }
 }
 
 function getAvcCodec(
@@ -248,38 +309,194 @@ function getMp4aCodec(sampleEntry: Uint8Array): string | undefined {
     return undefined;
   }
 
-  let objectTypeIndication: number | undefined;
-  let cursor = 4; // version + flags
-  while (cursor + 2 <= esds.length) {
-    const tag = esds[cursor];
+  return getCodecFromEsdsDescriptors(esds.subarray(4));
+}
+
+function getHevcCodec(
+  sampleEntry: Uint8Array,
+  boxName: number,
+): string | undefined {
+  if (sampleEntry.length < 78) {
+    return undefined;
+  }
+  const hvcC = getBoxContent(sampleEntry.subarray(78), 0x68766343 /* hvcC */);
+  if (hvcC === null || hvcC.length < 13) {
+    return undefined;
+  }
+
+  const profileByte = hvcC[1];
+  const profileSpace = (profileByte >> 6) & 0x03;
+  const tierFlag = (profileByte >> 5) & 0x01;
+  const profileIdc = profileByte & 0x1f;
+  const compatibilityFlags = reverseBits32(be4toi(hvcC, 2));
+  const levelIdc = hvcC[12];
+  const constraintBytes = trimTrailingZeroBytes(hvcC.subarray(6, 12));
+
+  let profileSpacePrefix = "";
+  if (profileSpace === 1) {
+    profileSpacePrefix = "A";
+  } else if (profileSpace === 2) {
+    profileSpacePrefix = "B";
+  } else if (profileSpace === 3) {
+    profileSpacePrefix = "C";
+  }
+  const constraintString =
+    constraintBytes.length === 0
+      ? "0"
+      : Array.from(constraintBytes, (value) =>
+          value.toString(16).toUpperCase(),
+        ).join(".");
+  return `${fourCC(boxName)}.${profileSpacePrefix}${profileIdc}.${compatibilityFlags
+    .toString(16)
+    .toUpperCase()}.${tierFlag === 1 ? "H" : "L"}${levelIdc}.${constraintString}`;
+}
+
+function getVpCodec(
+  sampleEntry: Uint8Array,
+  boxName: number,
+): string | undefined {
+  if (sampleEntry.length < 78) {
+    return undefined;
+  }
+  const vpcC = getBoxContent(sampleEntry.subarray(78), 0x76706343 /* vpcC */);
+  if (vpcC === null || vpcC.length < 12) {
+    return undefined;
+  }
+
+  const profile = vpcC[4];
+  const level = vpcC[5];
+  const packed = vpcC[6];
+  const bitDepth = packed >> 4;
+  const chromaSubsampling = (packed >> 1) & 0x07;
+  const videoFullRangeFlag = packed & 0x01;
+  const colourPrimaries = vpcC[7];
+  const transferCharacteristics = vpcC[8];
+  const matrixCoefficients = vpcC[9];
+
+  return `${fourCC(boxName)}.${toDecimalString(profile)}.${toDecimalString(level)}.${toDecimalString(bitDepth)}.${toDecimalString(chromaSubsampling)}.${toDecimalString(colourPrimaries)}.${toDecimalString(transferCharacteristics)}.${toDecimalString(matrixCoefficients)}.${toDecimalString(videoFullRangeFlag)}`;
+}
+
+function getAv1Codec(sampleEntry: Uint8Array): string | undefined {
+  if (sampleEntry.length < 78) {
+    return undefined;
+  }
+  const boxes = sampleEntry.subarray(78);
+  const av1C = getBoxContent(boxes, 0x61763143 /* av1C */);
+  if (av1C === null || av1C.length < 4) {
+    return undefined;
+  }
+
+  const profileAndLevel = av1C[1];
+  const profile = (profileAndLevel >> 5) & 0x07;
+  const level = profileAndLevel & 0x1f;
+  const features = av1C[2];
+  const tier = (features & 0x80) !== 0 ? "H" : "M";
+  const highBitdepth = (features & 0x40) !== 0;
+  const twelveBit = (features & 0x20) !== 0;
+  let bitDepth = 8;
+  if (highBitdepth) {
+    bitDepth = twelveBit ? 12 : 10;
+  }
+
+  return `av01.${profile}.${toDecimalString(level)}${tier}.${toDecimalString(bitDepth)}`;
+}
+
+function getCodecFromEsdsDescriptors(
+  data: Uint8Array,
+  objectTypeIndication?: number,
+): string | undefined {
+  let cursor = 0;
+  while (cursor + 2 <= data.length) {
+    const tag = data[cursor];
     cursor += 1;
-    const parsedLength = readDescriptorLength(esds, cursor);
+    const parsedLength = readDescriptorLength(data, cursor);
     if (parsedLength === null) {
       return undefined;
     }
     const [descriptorLength, descriptorHeaderLength] = parsedLength;
     cursor += descriptorHeaderLength;
-    if (cursor + descriptorLength > esds.length) {
+    if (cursor + descriptorLength > data.length) {
       return undefined;
     }
 
+    const descriptor = data.subarray(cursor, cursor + descriptorLength);
+    let nextObjectTypeIndication = objectTypeIndication;
     if (tag === 0x04 /* DecoderConfigDescriptor */) {
-      objectTypeIndication = esds[cursor];
-    } else if (tag === 0x05 /* DecoderSpecificInfo */) {
-      if (objectTypeIndication === undefined || descriptorLength === 0) {
+      if (descriptor.length < 13) {
         return undefined;
       }
-      const audioObjectType = getAudioObjectType(
-        esds.subarray(cursor, cursor + descriptorLength),
-      );
+      nextObjectTypeIndication = descriptor[0];
+    } else if (tag === 0x05 /* DecoderSpecificInfo */) {
+      if (objectTypeIndication === undefined || descriptor.length === 0) {
+        return undefined;
+      }
+      const audioObjectType = getAudioObjectType(descriptor);
       if (audioObjectType === undefined) {
         return undefined;
       }
       return `mp4a.${objectTypeIndication.toString(16)}.${audioObjectType}`;
     }
+
+    const nestedDescriptor = getNestedEsdsDescriptors(
+      tag,
+      descriptor,
+      nextObjectTypeIndication,
+    );
+    const nestedCodec =
+      nestedDescriptor === undefined
+        ? undefined
+        : getCodecFromEsdsDescriptors(
+            nestedDescriptor,
+            nextObjectTypeIndication,
+          );
+    if (nestedCodec !== undefined) {
+      return nestedCodec;
+    }
     cursor += descriptorLength;
   }
   return undefined;
+}
+
+function getNestedEsdsDescriptors(
+  tag: number,
+  descriptor: Uint8Array,
+  objectTypeIndication?: number,
+): Uint8Array | undefined {
+  switch (tag) {
+    case 0x03: {
+      if (descriptor.length < 3) {
+        return undefined;
+      }
+      let cursor = 2; // ES_ID
+      const flags = descriptor[cursor];
+      cursor += 1;
+      if ((flags & 0x80) !== 0) {
+        cursor += 2;
+      }
+      if ((flags & 0x40) !== 0) {
+        if (cursor >= descriptor.length) {
+          return undefined;
+        }
+        const urlLength = descriptor[cursor];
+        cursor += 1 + urlLength;
+      }
+      if ((flags & 0x20) !== 0) {
+        cursor += 2;
+      }
+      return cursor <= descriptor.length
+        ? descriptor.subarray(cursor)
+        : undefined;
+    }
+    case 0x04:
+      return descriptor.subarray(13);
+    case 0x05:
+      return undefined;
+    default:
+      if (objectTypeIndication === 0x40) {
+        return descriptor;
+      }
+      return undefined;
+  }
 }
 
 function getAudioObjectType(data: Uint8Array): number | undefined {
@@ -354,6 +571,28 @@ function getNextBox(
 
 function toHex(value: number): string {
   return value.toString(16).padStart(2, "0");
+}
+
+function toDecimalString(value: number): string {
+  return value.toString(10).padStart(2, "0");
+}
+
+function trimTrailingZeroBytes(buf: Uint8Array): Uint8Array {
+  let end = buf.length;
+  while (end > 0 && buf[end - 1] === 0) {
+    end--;
+  }
+  return buf.subarray(0, end);
+}
+
+function reverseBits32(value: number): number {
+  let reversed = 0;
+  let current = value >>> 0;
+  for (let i = 0; i < 32; i++) {
+    reversed = (reversed << 1) | (current & 0x01);
+    current >>>= 1;
+  }
+  return reversed >>> 0;
 }
 
 function fourCC(value: number): string {

--- a/src/ts-worker/isobmff-utils.ts
+++ b/src/ts-worker/isobmff-utils.ts
@@ -139,6 +139,233 @@ function getMDHDTimescale(buffer: Uint8Array): number | undefined {
 }
 
 /**
+ * Extract RFC 6381 codec strings from the initialization metadata contained in
+ * the given ISOBMFF data.
+ *
+ * Returns an empty array if no supported codec metadata could be parsed.
+ * @param {Uint8Array} buffer
+ * @returns {string[]}
+ */
+function getIsoBmffCodecs(buffer: Uint8Array): string[] {
+  const moov = getBoxContent(buffer, 0x6d6f6f76 /* moov */);
+  if (moov === null) {
+    return [];
+  }
+
+  const traks = getBoxesContent(moov, 0x7472616b /* trak */);
+  return traks.reduce((acc: string[], trak: Uint8Array) => {
+    const codec = getTrackCodec(trak);
+    if (codec !== undefined && !acc.includes(codec)) {
+      acc.push(codec);
+    }
+    return acc;
+  }, []);
+}
+
+function getTrackCodec(trak: Uint8Array): string | undefined {
+  const mdia = getBoxContent(trak, 0x6d646961 /* mdia */);
+  if (mdia === null) {
+    return undefined;
+  }
+
+  const hdlr = getBoxContent(mdia, 0x68646c72 /* hdlr */);
+  if (hdlr === null || hdlr.length < 12) {
+    return undefined;
+  }
+
+  const minf = getBoxContent(mdia, 0x6d696e66 /* minf */);
+  if (minf === null) {
+    return undefined;
+  }
+  const stbl = getBoxContent(minf, 0x7374626c /* stbl */);
+  if (stbl === null) {
+    return undefined;
+  }
+  const stsd = getBoxContent(stbl, 0x73747364 /* stsd */);
+  if (stsd === null) {
+    return undefined;
+  }
+
+  const handlerType = be4toi(hdlr, 8);
+  return getCodecFromStsd(stsd, handlerType);
+}
+
+function getCodecFromStsd(
+  stsd: Uint8Array,
+  _handlerType: number,
+): string | undefined {
+  if (stsd.length < 16) {
+    return undefined;
+  }
+
+  const entryCount = be4toi(stsd, 4);
+  let cursor = 8;
+  for (let i = 0; i < entryCount && cursor + 8 <= stsd.length; i++) {
+    const [boxStart, contentStart, boxEnd, boxName] = getNextBox(stsd, cursor);
+    if (
+      boxStart === undefined ||
+      contentStart === undefined ||
+      boxEnd === undefined ||
+      boxName === undefined
+    ) {
+      return undefined;
+    }
+    const sampleEntry = stsd.subarray(contentStart, boxEnd);
+    switch (boxName) {
+      case 0x61766331: /* avc1 */
+      case 0x61766333 /* avc3 */:
+        return getAvcCodec(sampleEntry, boxName);
+      case 0x6d703461 /* mp4a */:
+        return getMp4aCodec(sampleEntry);
+      default:
+        break;
+    }
+    cursor = boxEnd;
+  }
+  return undefined;
+}
+
+function getAvcCodec(
+  sampleEntry: Uint8Array,
+  boxName: number,
+): string | undefined {
+  if (sampleEntry.length < 78) {
+    return undefined;
+  }
+  const avcC = getBoxContent(sampleEntry.subarray(78), 0x61766343 /* avcC */);
+  if (avcC === null || avcC.length < 4) {
+    return undefined;
+  }
+  return `${fourCC(boxName)}.${toHex(avcC[1])}${toHex(avcC[2])}${toHex(avcC[3])}`;
+}
+
+function getMp4aCodec(sampleEntry: Uint8Array): string | undefined {
+  if (sampleEntry.length < 28) {
+    return undefined;
+  }
+  const esds = getBoxContent(sampleEntry.subarray(28), 0x65736473 /* esds */);
+  if (esds === null || esds.length < 2) {
+    return undefined;
+  }
+
+  let objectTypeIndication: number | undefined;
+  let cursor = 4; // version + flags
+  while (cursor + 2 <= esds.length) {
+    const tag = esds[cursor];
+    cursor += 1;
+    const parsedLength = readDescriptorLength(esds, cursor);
+    if (parsedLength === null) {
+      return undefined;
+    }
+    const [descriptorLength, descriptorHeaderLength] = parsedLength;
+    cursor += descriptorHeaderLength;
+    if (cursor + descriptorLength > esds.length) {
+      return undefined;
+    }
+
+    if (tag === 0x04 /* DecoderConfigDescriptor */) {
+      objectTypeIndication = esds[cursor];
+    } else if (tag === 0x05 /* DecoderSpecificInfo */) {
+      if (objectTypeIndication === undefined || descriptorLength === 0) {
+        return undefined;
+      }
+      const audioObjectType = getAudioObjectType(
+        esds.subarray(cursor, cursor + descriptorLength),
+      );
+      if (audioObjectType === undefined) {
+        return undefined;
+      }
+      return `mp4a.${objectTypeIndication.toString(16)}.${audioObjectType}`;
+    }
+    cursor += descriptorLength;
+  }
+  return undefined;
+}
+
+function getAudioObjectType(data: Uint8Array): number | undefined {
+  if (data.length === 0) {
+    return undefined;
+  }
+  let audioObjectType = data[0] >> 3;
+  if (audioObjectType === 31) {
+    if (data.length < 2) {
+      return undefined;
+    }
+    audioObjectType = 32 + ((data[0] & 0x07) << 3) + (data[1] >> 5);
+  }
+  return audioObjectType;
+}
+
+function readDescriptorLength(
+  data: Uint8Array,
+  offset: number,
+): [number, number] | null {
+  let length = 0;
+  let cursor = offset;
+  let bytesRead = 0;
+  while (cursor < data.length && bytesRead < 4) {
+    const value = data[cursor];
+    cursor += 1;
+    bytesRead += 1;
+    length = (length << 7) | (value & 0x7f);
+    if ((value & 0x80) === 0) {
+      return [length, bytesRead];
+    }
+  }
+  return null;
+}
+
+function getNextBox(
+  buf: Uint8Array,
+  offset: number,
+):
+  | [
+      number /* start byte */,
+      number /* content start */,
+      number /* end byte */,
+      number /* box name */,
+    ]
+  | [] {
+  if (offset + 8 > buf.length) {
+    return [];
+  }
+
+  let cursor = offset;
+  let boxSize = be4toi(buf, cursor);
+  cursor += 4;
+  const boxName = be4toi(buf, cursor);
+  cursor += 4;
+
+  if (boxSize === 0) {
+    boxSize = buf.length - offset;
+  } else if (boxSize === 1) {
+    if (cursor + 8 > buf.length) {
+      return [];
+    }
+    boxSize = be8toi(buf, cursor);
+    cursor += 8;
+  }
+
+  if (boxSize < 8 || offset + boxSize > buf.length) {
+    return [];
+  }
+  return [offset, cursor, offset + boxSize, boxName];
+}
+
+function toHex(value: number): string {
+  return value.toString(16).padStart(2, "0");
+}
+
+function fourCC(value: number): string {
+  return String.fromCharCode(
+    (value >>> 24) & 0xff,
+    (value >>> 16) & 0xff,
+    (value >>> 8) & 0xff,
+    value & 0xff,
+  );
+}
+
+/**
  * Returns the "default sample duration" which is the default value for duration
  * of samples found in a "traf" ISOBMFF box.
  *
@@ -389,4 +616,9 @@ function be8toi(bytes: Uint8Array, offset: number): number {
   );
 }
 
-export { getDurationFromTrun, getTrackFragmentDecodeTime, getMDHDTimescale };
+export {
+  getDurationFromTrun,
+  getTrackFragmentDecodeTime,
+  getMDHDTimescale,
+  getIsoBmffCodecs,
+};

--- a/src/wasm/abi/wasm-enums.json
+++ b/src/wasm/abi/wasm-enums.json
@@ -13,7 +13,8 @@
         "NoSupportedVariant": 0,
         "UnfoundLockedVariant": 1,
         "MediaSourceAttachmentError": 2,
-        "Unknown": 3
+        "NotAPlaylist": 3,
+        "Unknown": 4
       }
     },
     "SourceBufferCreationErrorCode": {

--- a/src/wasm/abi/wasm-functions.json
+++ b/src/wasm/abi/wasm-functions.json
@@ -16,6 +16,7 @@
     "__js_func__free_resource",
     "__js_func__get_random",
     "__js_func__get_resource_len",
+    "__js_func__inspect_segment",
     "__js_func__is_type_supported",
     "__js_func__log",
     "__js_func__remove_buffer",

--- a/src/wasm/js/enums.ts
+++ b/src/wasm/js/enums.ts
@@ -11,6 +11,7 @@ export {
   OtherErrorCode,
   PlaybackTickReason,
   PlaylistNature,
+  PlaylistType,
   PushedSegmentErrorCode,
   RemoveBufferErrorCode,
   RemoveMediaSourceErrorCode,

--- a/src/wasm/js/helpers.ts
+++ b/src/wasm/js/helpers.ts
@@ -5,6 +5,7 @@ import {
 } from "./memory.js";
 import type { HostResult } from "./types.js";
 
+// TODO: Maybe more safety into that one
 const OPTIONAL_ID_NONE = 0xffffffff;
 
 export function unwrapResult<Value, ErrorCode extends number>(

--- a/src/wasm/js/imports.ts
+++ b/src/wasm/js/imports.ts
@@ -148,19 +148,23 @@ export function createWasmImports(bindings: HostBindings): WebAssembly.Imports {
       },
       __js_func__inspect_segment(
         resourceId: number,
-        mimeTypePtr: number,
-        mimeTypeLen: number,
+        mediaTypeOut: number,
+        parsedMimeTypePtrOut: number,
+        parsedMimeTypeLenOut: number,
         codecPtrOut: number,
         codecLenOut: number,
         errCodeOut: number,
         errDescPtrOut: number,
         errDescLenOut: number,
       ): number {
-        const result = bindings.inspectSegment(
-          resourceId,
-          readString(mimeTypePtr, mimeTypeLen),
-        );
+        const result = bindings.inspectSegment(resourceId);
         if (result.errorCode === undefined && result.value !== undefined) {
+          getUint32Memory()[mediaTypeOut >>> 2] = result.value.mediaType;
+          writeOptionalString(
+            result.value.mimeType,
+            parsedMimeTypePtrOut,
+            parsedMimeTypeLenOut,
+          );
           writeOptionalString(result.value.codec, codecPtrOut, codecLenOut);
           return 1;
         }

--- a/src/wasm/js/imports.ts
+++ b/src/wasm/js/imports.ts
@@ -408,7 +408,7 @@ export function createWasmImports(bindings: HostBindings): WebAssembly.Imports {
         bindings.sendSegmentParsingError(
           fatal !== 0,
           code as SegmentParsingErrorCode,
-          mediaType as MediaType,
+          rawOptionalId(mediaType) as MediaType | undefined,
           readString(messagePtr, messageLen),
         );
       },

--- a/src/wasm/js/imports.ts
+++ b/src/wasm/js/imports.ts
@@ -8,10 +8,10 @@ import type {
   PlaylistType,
   PushedSegmentErrorCode,
   RequestErrorReason,
-  SegmentParsingErrorCode,
   SourceBufferCreationErrorCode,
   TimerReason,
 } from "./enums.js";
+import { SegmentParsingErrorCode } from "./enums.js";
 import {
   getWasmExports,
   getUint8Memory,
@@ -145,6 +145,29 @@ export function createWasmImports(bindings: HostBindings): WebAssembly.Imports {
           readString(typPtr, typLen),
         );
         return value === undefined ? -1 : value ? 1 : 0;
+      },
+      __js_func__inspect_segment(
+        resourceId: number,
+        mimeTypePtr: number,
+        mimeTypeLen: number,
+        codecPtrOut: number,
+        codecLenOut: number,
+        errCodeOut: number,
+        errDescPtrOut: number,
+        errDescLenOut: number,
+      ): number {
+        const result = bindings.inspectSegment(
+          resourceId,
+          readString(mimeTypePtr, mimeTypeLen),
+        );
+        if (result.errorCode === undefined && result.value !== undefined) {
+          writeOptionalString(result.value.codec, codecPtrOut, codecLenOut);
+          return 1;
+        }
+        getUint32Memory()[errCodeOut >>> 2] =
+          result.errorCode ?? SegmentParsingErrorCode.UnknownError;
+        writeOptionalString(result.description, errDescPtrOut, errDescLenOut);
+        return 0;
       },
       __js_func__append_buffer(
         sourceBufferId: number,

--- a/src/wasm/js/imports.ts
+++ b/src/wasm/js/imports.ts
@@ -5,6 +5,7 @@ import type {
   MultivariantPlaylistParsingErrorCode,
   OtherErrorCode,
   PlaylistNature,
+  PlaylistType,
   PushedSegmentErrorCode,
   RequestErrorReason,
   SegmentParsingErrorCode,
@@ -236,6 +237,7 @@ export function createWasmImports(bindings: HostBindings): WebAssembly.Imports {
         );
       },
       __js_func__announce_fetched_content(
+        playlistType: number,
         variantInfoPtr: number,
         variantInfoLen: number,
         audioTracksInfoPtr: number,
@@ -243,6 +245,7 @@ export function createWasmImports(bindings: HostBindings): WebAssembly.Imports {
       ): void {
         const buffer = getWasmExports().memory.buffer;
         bindings.announceFetchedContent(
+          playlistType as PlaylistType,
           new Uint32Array(buffer, variantInfoPtr, variantInfoLen),
           new Uint32Array(buffer, audioTracksInfoPtr, audioTracksInfoLen),
         );
@@ -364,7 +367,7 @@ export function createWasmImports(bindings: HostBindings): WebAssembly.Imports {
         bindings.sendMediaPlaylistParsingError(
           fatal !== 0,
           code as MediaPlaylistParsingErrorCode,
-          mediaType as MediaType,
+          rawOptionalId(mediaType) as MediaType | undefined,
           readString(messagePtr, messageLen),
         );
       },

--- a/src/wasm/js/types.ts
+++ b/src/wasm/js/types.ts
@@ -29,6 +29,8 @@ export interface AppendBufferValue {
 
 export interface InspectSegmentValue {
   codec: string;
+  mimeType: string;
+  mediaType: MediaType;
 }
 
 export interface HostResult<Value, ErrorCode extends number> {
@@ -61,7 +63,6 @@ export interface HostBindings {
   isTypeSupported(mediaType: MediaType, typ: string): boolean | undefined;
   inspectSegment(
     resourceId: number,
-    mimeType: string,
   ): HostResult<InspectSegmentValue, SegmentParsingErrorCode>;
   appendBuffer(
     sourceBufferId: number,

--- a/src/wasm/js/types.ts
+++ b/src/wasm/js/types.ts
@@ -11,6 +11,7 @@ import type {
   OtherErrorCode,
   PlaybackTickReason,
   PlaylistNature,
+  PlaylistType,
   PushedSegmentErrorCode,
   RemoveBufferErrorCode,
   RemoveMediaSourceErrorCode,
@@ -78,6 +79,7 @@ export interface HostBindings {
     playlistNature: PlaylistNature,
   ): void;
   announceFetchedContent(
+    playlistType: PlaylistType,
     variantInfo: Uint32Array,
     audioTracksInfo: Uint32Array,
   ): void;
@@ -127,7 +129,7 @@ export interface HostBindings {
   sendMediaPlaylistParsingError(
     fatal: boolean,
     code: MediaPlaylistParsingErrorCode,
-    mediaType: MediaType,
+    mediaType: MediaType | undefined,
     message: string,
   ): void;
   sendSegmentParsingError(

--- a/src/wasm/js/types.ts
+++ b/src/wasm/js/types.ts
@@ -144,7 +144,7 @@ export interface HostBindings {
   sendSegmentParsingError(
     fatal: boolean,
     code: SegmentParsingErrorCode,
-    mediaType: MediaType,
+    mediaType: MediaType | undefined,
     message: string,
   ): void;
   sendPushedSegmentError(

--- a/src/wasm/js/types.ts
+++ b/src/wasm/js/types.ts
@@ -27,6 +27,10 @@ export interface AppendBufferValue {
   duration: number | undefined;
 }
 
+export interface InspectSegmentValue {
+  codec: string;
+}
+
 export interface HostResult<Value, ErrorCode extends number> {
   value: Value | undefined;
   errorCode: ErrorCode | undefined;
@@ -55,6 +59,10 @@ export interface HostBindings {
     typ: string,
   ): HostResult<number, AddSourceBufferErrorCode>;
   isTypeSupported(mediaType: MediaType, typ: string): boolean | undefined;
+  inspectSegment(
+    resourceId: number,
+    mimeType: string,
+  ): HostResult<InspectSegmentValue, SegmentParsingErrorCode>;
   appendBuffer(
     sourceBufferId: number,
     resourceId: number,


### PR DESCRIPTION
An old issue #12, asked whether this player handled media playlist directly, as opposed to MultiVariant Playlist.

It doesn't, as I initially did not see the point. In the professional streaming world, I've been much more accustomed to the latter, but turns out that tools targeted to users directly might just provide a media playlist URL, because they don't need the complexity of adaptive bitrate (because they've only one video rendition) or multiple/separate audio/subtitles tracks.

I wondered what would change in the codebase to support this case. Turns out a lot more than I thought and I'm still not done:

- [x] Instead of having one normalized `MultiVariantPlaylist` struct with e.g. optional and default values when only given a media playlist URL, I thought that doing a `TopLevelPlaylist` Rust `enum` which transport either the `MultiVariantPlaylist` or `MediaPlaylist` explicitly was more appropriate here.

   This means that other blocks in the player are aware of this difference.
   
   It does mean that this abstraction could seem "leaky" at first, instead of just contained in parsing-oriented logic, but as both types lead to very different handling anyway (see further point), I thought it was the right choice to make this explicit.

- [x] API-wise, nothing changes. There are still `variantUpdate`, `audioTrackUpdate` etc. events and the corresponding methods, just the "variant" is unique and linked to the information the player got from that unique Media Playlist.

  Unlike the player's internals, the API profits much more IMO from not having to care about that concept. There's no special separate handling that would need to be done in the Media Playlist case, just many methods/events/errors are kind of useless in that case, but that's not an issue.

- [x] With a `MultiVariantPlaylist`, the player has to select which variant and audio "track" it wants to select before starting to load its media playlist and segments.

   As this may depend on what the device currently supports in terms of codecs, there is a necessary codec checking step initially before selecting the right initial track (thus playlist and segments loading has a dependency on codec checks).
 
   With a `MediaPlaylist` directly, the codecs are not explicitly announced in advance.
   With the current API, we would still want to detect if that Playlist has supported codecs or not, so instead the idea there is to first load a segment from that playlist, then check which codec and container it is, and then at last do the codec check before continuing playback (or just throwing - a `NoSupportedVariant` historically, maybe to rename/re-document?)

   This does mean a complex distinct path for media playlist though, that is not yet finished