### PR TITLE
[WIP] Probe segment for Multivariant Playlist

### DIFF
--- a/demo/src/components/ContentBar.tsx
+++ b/demo/src/components/ContentBar.tsx
@@ -91,16 +91,16 @@ export default React.memo(function ContentBar({
 
 const DEFAULT_CONTENT_LIST = [
   {
-    name: "Angel One (fmp4, multi-audio, multi-variants)",
+    name: "Angel One (fmp4, multi-audio, ABR)",
     url: "https://storage.googleapis.com/shaka-demo-assets/angel-one-hls/hls.m3u8",
   },
   {
-    name: "Big Buck Bunny (mpeg-ts, multi-variants, 10s segments)",
+    name: "Big Buck Bunny (mpeg-ts, ABR, 10s segments)",
     url: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8",
   },
   {
-    name: "HLS Bitmovin (fmp4, multi-variants, 4s segments)",
-    url: "https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s-fmp4/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8",
+    name: "China documentary Arte (mpeg-ts, ABR, no playlist codec)",
+    url: "https://test-streams.mux.dev/test_001/stream.m3u8",
   },
 ];
 

--- a/src/rs-core/dispatcher/api/mod.rs
+++ b/src/rs-core/dispatcher/api/mod.rs
@@ -32,7 +32,7 @@ impl Dispatcher {
             segment_selectors: NextSegmentSelectors::new(0., 30.),
             segment_request_contexts: SegmentRequestContexts::new(),
             playlist_refresh_timers: PlaylistRefreshTimers::new(),
-            ready_probe_segment: None,
+            ready_probe_segments: Default::default(),
         }
     }
 

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -199,7 +199,9 @@ impl Dispatcher {
                 status,
             } => {
                 let req_ctxt = self.segment_request_contexts.take(s.id());
-                if let Some(media_type) = req_ctxt.as_ref().and_then(|ctxt| ctxt.requested_media_type())
+                if let Some(media_type) = req_ctxt
+                    .as_ref()
+                    .and_then(|ctxt| ctxt.requested_media_type())
                 {
                     self.ready_probe_segments.clear_media_type(media_type);
                 }
@@ -457,6 +459,16 @@ impl Dispatcher {
     /// be requested (when a request finished, when a media playlist has been updated, when the
     /// playhead advances etc.).
     pub(super) fn check_segments_to_request(&mut self) {
+        if self
+            .playlist_store
+            .as_ref()
+            .is_some_and(|pl_store| !pl_store.are_playlists_ready())
+        {
+            return;
+        }
+        if !startup::ensure_current_streams_ready(self, self.media_element_ref.wanted_position()) {
+            return;
+        }
         let was_already_locked = self.requester.lock_segment_requests();
         [MediaType::Video, MediaType::Audio]
             .into_iter()

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -40,7 +40,7 @@ impl Dispatcher {
         self.media_element_ref.reset();
         self.segment_selectors.reset_selectors(0.);
         self.playlist_store = None;
-        self.ready_probe_segment = None;
+        self.ready_probe_segments.clear();
         self.last_position = 0.;
         self.clean_up_playlist_refresh_timers();
         self.ready_state = PlayerReadyState::Stopped;
@@ -199,11 +199,9 @@ impl Dispatcher {
                 status,
             } => {
                 let req_ctxt = self.segment_request_contexts.take(s.id());
-                if req_ctxt
-                    .as_ref()
-                    .is_some_and(PendingSegmentRequest::is_probe)
+                if let Some(media_type) = req_ctxt.as_ref().and_then(|ctxt| ctxt.requested_media_type())
                 {
-                    self.ready_probe_segment = None;
+                    self.ready_probe_segments.clear_media_type(media_type);
                 }
 
                 if status.is_some_and(|s| s == 404 || s == 410)
@@ -478,7 +476,7 @@ impl Dispatcher {
     fn do_probe_segment_inspection(
         &mut self,
         probe_segment: ProbeSegmentMetadata,
-        segment_media_type: Option<MediaType>,
+        requested_media_type: Option<MediaType>,
         data: JsMemoryBlob,
     ) {
         let Some(playlist_store) = self.playlist_store.as_mut() else {
@@ -492,7 +490,7 @@ impl Dispatcher {
                 jsSendSegmentParsingError(
                     true,
                     code,
-                    segment_media_type,
+                    requested_media_type,
                     message
                         .as_deref()
                         .unwrap_or("Unknown probe segment parsing error"),
@@ -503,11 +501,31 @@ impl Dispatcher {
         };
 
         // Update playlist information with inspection result
-        playlist_store.set_direct_media_info(crate::parser::DirectMediaInfo {
+        let media_info = crate::parser::DirectMediaInfo {
             mime_type: inspection.mime_type,
             media_type: inspection.media_type,
             codec: inspection.codec,
-        });
+        };
+        let resolved_media_type = match playlist_store.playlist_kind() {
+            crate::bindings::PlaylistType::MediaPlaylist => {
+                let media_type = media_info.media_type;
+                playlist_store.set_direct_media_info(media_info);
+                media_type
+            }
+            crate::bindings::PlaylistType::MultivariantPlaylist => {
+                let Some(media_type) = requested_media_type else {
+                    jsSendOtherError(
+                        true,
+                        OtherErrorCode::Unknown,
+                        "Missing media type for multivariant probe result",
+                    );
+                    self.stop_current_content();
+                    return;
+                };
+                playlist_store.set_multivariant_media_info(media_type, media_info);
+                media_type
+            }
+        };
 
         // That might have led to more timing-related information
         jsUpdateContentInfo(
@@ -517,8 +535,9 @@ impl Dispatcher {
         );
 
         // Store segment for future playback
-        self.ready_probe_segment = Some(ReadyProbeSegment {
+        self.ready_probe_segments.insert(ReadyProbeSegment {
             request: probe_segment,
+            media_type: resolved_media_type,
             data,
         });
     }
@@ -852,6 +871,7 @@ impl Dispatcher {
 
         for mt in changed_media_types.iter().copied() {
             Logger::info(&format!("Core: {} MediaPlaylist changed", mt));
+            self.ready_probe_segments.clear_media_type(mt);
 
             if abort_prev {
                 self.abort_segment_requests_with_type(mt);
@@ -954,8 +974,11 @@ impl Dispatcher {
                 }
                 self.on_init_segment_loaded(result, req_media_type, init_segment_id);
             }
-            PendingSegmentRequest::Probe { probe_segment } => {
-                self.do_probe_segment_inspection(probe_segment, media_type, result);
+            PendingSegmentRequest::Probe {
+                probe_segment,
+                requested_media_type,
+            } => {
+                self.do_probe_segment_inspection(probe_segment, requested_media_type, result);
                 self.recheck_player_state();
             }
         }
@@ -1024,12 +1047,12 @@ impl Dispatcher {
     fn abort_segment_requests_with_type(&mut self, media_type: MediaType) {
         let aborted_reqs = self.requester.abort_segments_with_type(media_type);
         for req_id in aborted_reqs {
-            if self
+            if let Some(media_type) = self
                 .segment_request_contexts
                 .take(req_id)
-                .is_some_and(|ctxt| ctxt.is_probe())
+                .and_then(|ctxt| ctxt.requested_media_type())
             {
-                self.ready_probe_segment = None;
+                self.ready_probe_segments.clear_media_type(media_type);
             }
         }
     }

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -459,16 +459,10 @@ impl Dispatcher {
     /// be requested (when a request finished, when a media playlist has been updated, when the
     /// playhead advances etc.).
     pub(super) fn check_segments_to_request(&mut self) {
-        if self
-            .playlist_store
-            .as_ref()
-            .is_some_and(|pl_store| !pl_store.are_playlists_ready())
-        {
+        if !self.ready_to_load_segments() {
             return;
         }
-        if !startup::ensure_current_streams_ready(self, self.media_element_ref.wanted_position()) {
-            return;
-        }
+
         let was_already_locked = self.requester.lock_segment_requests();
         [MediaType::Video, MediaType::Audio]
             .into_iter()
@@ -512,32 +506,25 @@ impl Dispatcher {
             }
         };
 
-        // Update playlist information with inspection result
-        let media_info = crate::parser::DirectMediaInfo {
+        // NOTE: we prefer giving the requested media type than what the segment turned out to be
+        // because if what was assumed to be a Video playlist turns out to be finally an audio-only
+        // one, the `PlaylistStore` will be completely lost when we tell him to update the `Audio`
+        // playlist where all it can see is a `Video` playlist.
+        // We could consider that this case needs to be fixed but it's for a condition that is so
+        // rare that I don't think we really gain in doing a complex playlist-type-change path.
+        let considered_media_type = if let Some(media_type) = requested_media_type {
+            media_type
+        } else {
+            inspection.media_type
+        };
+
+        // Now update playlist information with inspection result
+        let media_info = crate::parser::ExternalMediaInfo {
             mime_type: inspection.mime_type,
             media_type: inspection.media_type,
             codec: inspection.codec,
         };
-        let resolved_media_type = match playlist_store.playlist_kind() {
-            crate::bindings::PlaylistType::MediaPlaylist => {
-                let media_type = media_info.media_type;
-                playlist_store.set_direct_media_info(media_info);
-                media_type
-            }
-            crate::bindings::PlaylistType::MultivariantPlaylist => {
-                let Some(media_type) = requested_media_type else {
-                    jsSendOtherError(
-                        true,
-                        OtherErrorCode::Unknown,
-                        "Missing media type for multivariant probe result",
-                    );
-                    self.stop_current_content();
-                    return;
-                };
-                playlist_store.set_multivariant_media_info(media_type, media_info);
-                media_type
-            }
-        };
+        playlist_store.set_external_media_info(media_info, considered_media_type);
 
         // That might have led to more timing-related information
         jsUpdateContentInfo(
@@ -549,7 +536,7 @@ impl Dispatcher {
         // Store segment for future playback
         self.ready_probe_segments.insert(ReadyProbeSegment {
             request: probe_segment,
-            media_type: resolved_media_type,
+            media_type: considered_media_type,
             data,
         });
     }
@@ -627,7 +614,6 @@ impl Dispatcher {
                 let estimate = self.adaptive_selector.get_estimate();
                 match PlaylistStore::try_new(pl, estimate) {
                     Ok(pl_store) => {
-                        // TODO: ugly
                         let direct_media_refresh = pl_store
                             .direct_media_playlist()
                             .map(|(id, playlist)| (*id, playlist.refresh_interval()));

--- a/src/rs-core/dispatcher/core/mod.rs
+++ b/src/rs-core/dispatcher/core/mod.rs
@@ -630,7 +630,7 @@ impl Dispatcher {
                         // TODO: ugly
                         let direct_media_refresh = pl_store
                             .direct_media_playlist()
-                            .map(|(id, playlist)| (id.clone(), playlist.refresh_interval()));
+                            .map(|(id, playlist)| (*id, playlist.refresh_interval()));
 
                         self.playlist_store = Some(pl_store);
                         if let Some((playlist_id, refresh_interval)) = direct_media_refresh {
@@ -654,7 +654,7 @@ impl Dispatcher {
         refresh_interval: Option<f64>,
     ) {
         self.playlist_refresh_timers
-            .set_timer(playlist_id.clone(), refresh_interval);
+            .set_timer(playlist_id, refresh_interval);
 
         let Some(playlist_store) = self.playlist_store.as_ref() else {
             return;
@@ -904,7 +904,7 @@ impl Dispatcher {
                 if pl_store.curr_media_playlist(mt).is_some() {
                     None
                 } else {
-                    let id = pl_store.curr_media_playlist_id(mt)?.clone();
+                    let id = *pl_store.curr_media_playlist_id(mt)?;
                     let url = pl_store.media_playlist_url(&id)?.clone();
                     Some((id, url))
                 }

--- a/src/rs-core/dispatcher/core/startup.rs
+++ b/src/rs-core/dispatcher/core/startup.rs
@@ -36,12 +36,21 @@ impl Dispatcher {
             }
         };
     }
+
+    pub(super) fn ready_to_load_segments(&mut self) -> bool {
+        if self
+            .playlist_store
+            .as_ref()
+            .is_some_and(|pl_store| !pl_store.are_playlists_ready())
+        {
+            false // Playlist(s) not yet fetched
+        } else {
+            ensure_ready_playlist_store(self, self.media_element_ref.wanted_position())
+        }
+    }
 }
 
-pub(super) fn ensure_current_streams_ready(
-    dispatcher: &mut Dispatcher,
-    wanted_position: f64,
-) -> bool {
+fn ensure_ready_playlist_store(dispatcher: &mut Dispatcher, wanted_position: f64) -> bool {
     let Some(playlist_store) = dispatcher.playlist_store.as_mut() else {
         return false;
     };
@@ -58,17 +67,23 @@ pub(super) fn ensure_current_streams_ready(
         StartupStatus::Ready => true,
         StartupStatus::AwaitingSupportCheck => false,
         StartupStatus::VariantSwitchNeeded { variant_id } => {
-            let Some(playlist_store) = dispatcher.playlist_store.as_mut() else {
-                return false;
-            };
-            let changed_media_types = playlist_store.switch_startup_variant(variant_id);
             jsAnnounceVariantUpdate(Some(variant_id));
+
+            let changed_media_types = playlist_store.switch_startup_variant(variant_id);
             dispatcher.handle_media_playlist_update(&changed_media_types, false, false);
             false
         }
-        StartupStatus::NeedsProbes(probe_requests) => {
-            let error_media_type = probe_error_media_type(&probe_requests);
-            if start_probe_segment_requests(dispatcher, probe_requests) {
+        StartupStatus::NeedsProbes(probe_metadata) => {
+            let error_media_type = if probe_metadata.len() == 1 {
+                probe_metadata[0].1
+            } else {
+                None
+            };
+
+            if probe_metadata
+                .into_iter()
+                .all(|probe_request| start_probe_segment_request(dispatcher, probe_request))
+            {
                 false
             } else {
                 jsSendSegmentParsingError(
@@ -81,16 +96,6 @@ pub(super) fn ensure_current_streams_ready(
                 false
             }
         }
-    }
-}
-
-fn probe_error_media_type(
-    probe_requests: &[(ProbeSegmentMetadata, Option<MediaType>)],
-) -> Option<MediaType> {
-    if probe_requests.len() == 1 {
-        probe_requests[0].1
-    } else {
-        None
     }
 }
 
@@ -182,7 +187,7 @@ fn advance_awaiting_playlist_info_state(dispatcher: &mut Dispatcher) {
         return;
     }
 
-    if !ensure_current_streams_ready(dispatcher, wanted_position) {
+    if !ensure_ready_playlist_store(dispatcher, wanted_position) {
         return;
     }
 
@@ -253,24 +258,6 @@ fn advance_awaiting_media_source_state(dispatcher: &mut Dispatcher) {
     }
     jsStartObservingPlayback();
     consume_probe_segments(dispatcher);
-}
-
-/// Start a startup probe request if not already in progress.
-///
-/// Probe segment requests are segment requests with the goal of obtaining more
-/// information not found in the playlist(s): which codecs is it and other attributes.
-///
-/// # Returns
-///
-/// Returns `true` if the probe process has been started, or `false` if we
-/// cannot do that.
-fn start_probe_segment_requests(
-    dispatcher: &mut Dispatcher,
-    probe_requests: Vec<(ProbeSegmentMetadata, Option<MediaType>)>,
-) -> bool {
-    probe_requests
-        .into_iter()
-        .all(|probe_request| start_probe_segment_request(dispatcher, probe_request))
 }
 
 fn start_probe_segment_request(

--- a/src/rs-core/dispatcher/core/startup.rs
+++ b/src/rs-core/dispatcher/core/startup.rs
@@ -114,11 +114,13 @@ fn advance_awaiting_playlist_info_state(dispatcher: &mut Dispatcher) {
             }
             if let Some(id) = playlist_store.curr_media_playlist_id(mt) {
                 if let Some(url) = playlist_store.media_playlist_url(id) {
-                    let id = id.clone();
                     let url = url.clone();
                     dispatcher.requester.fetch_playlist(
                         url,
-                        PlaylistFileType::MediaPlaylist { id, media_type: mt },
+                        PlaylistFileType::MediaPlaylist {
+                            id: *id,
+                            media_type: mt,
+                        },
                     );
                 }
             }

--- a/src/rs-core/dispatcher/core/startup.rs
+++ b/src/rs-core/dispatcher/core/startup.rs
@@ -45,14 +45,6 @@ pub(super) fn ensure_current_streams_ready(
     let Some(playlist_store) = dispatcher.playlist_store.as_mut() else {
         return false;
     };
-    let prev_variant_id = playlist_store.curr_variant().map(|v| v.id());
-    let prev_audio_id = playlist_store
-        .curr_media_playlist_id(MediaType::Audio)
-        .cloned();
-    let prev_video_id = playlist_store
-        .curr_media_playlist_id(MediaType::Video)
-        .cloned();
-
     let status = match playlist_store.startup_status(wanted_position) {
         Ok(status) => status,
         Err(err) => {
@@ -62,50 +54,43 @@ pub(super) fn ensure_current_streams_ready(
         }
     };
 
-    let Some(playlist_store) = dispatcher.playlist_store.as_ref() else {
-        return false;
-    };
-    let curr_variant_id = playlist_store.curr_variant().map(|v| v.id());
-    let curr_audio_id = playlist_store
-        .curr_media_playlist_id(MediaType::Audio)
-        .cloned();
-    let curr_video_id = playlist_store
-        .curr_media_playlist_id(MediaType::Video)
-        .cloned();
-    if curr_variant_id != prev_variant_id
-        || curr_audio_id != prev_audio_id
-        || curr_video_id != prev_video_id
-    {
-        let mut changed_media_types = vec![];
-        if curr_audio_id != prev_audio_id {
-            changed_media_types.push(MediaType::Audio);
-        }
-        if curr_video_id != prev_video_id {
-            changed_media_types.push(MediaType::Video);
-        }
-
-        jsAnnounceVariantUpdate(curr_variant_id);
-        dispatcher.handle_media_playlist_update(&changed_media_types, false, false);
-        return false;
-    }
-
     match status {
         StartupStatus::Ready => true,
         StartupStatus::AwaitingSupportCheck => false,
+        StartupStatus::VariantSwitchNeeded { variant_id } => {
+            let Some(playlist_store) = dispatcher.playlist_store.as_mut() else {
+                return false;
+            };
+            let changed_media_types = playlist_store.switch_startup_variant(variant_id);
+            jsAnnounceVariantUpdate(Some(variant_id));
+            dispatcher.handle_media_playlist_update(&changed_media_types, false, false);
+            false
+        }
         StartupStatus::NeedsProbes(probe_requests) => {
+            let error_media_type = probe_error_media_type(&probe_requests);
             if start_probe_segment_requests(dispatcher, probe_requests) {
                 false
             } else {
                 jsSendSegmentParsingError(
                     true,
                     crate::bindings::SegmentParsingErrorCode::UnknownError,
-                    Some(MediaType::Video),
+                    error_media_type,
                     "No probe segment was available to determine startup metadata",
                 );
                 dispatcher.stop_current_content();
                 false
             }
         }
+    }
+}
+
+fn probe_error_media_type(
+    probe_requests: &[(ProbeSegmentMetadata, Option<MediaType>)],
+) -> Option<MediaType> {
+    if probe_requests.len() == 1 {
+        probe_requests[0].1
+    } else {
+        None
     }
 }
 

--- a/src/rs-core/dispatcher/core/startup.rs
+++ b/src/rs-core/dispatcher/core/startup.rs
@@ -1,6 +1,7 @@
 use super::super::segment_request_contexts::PendingSegmentRequest;
 use super::{utils, Dispatcher, PlayerReadyState, ReadyProbeSegment};
 use crate::media_element::SegmentPushMetadata;
+use crate::playlist_store::ProbeSegmentMetadata;
 use crate::{
     bindings::{
         formatters::{
@@ -14,7 +15,7 @@ use crate::{
         PlaylistType,
     },
     media_element::SourceBufferCreationError,
-    playlist_store::{ProbeSegmentContext, ProbeSegmentMetadata, StartupStatus},
+    playlist_store::{ProbeSegmentContext, StartupStatus},
     requester::{PlaylistFileType, RequestLaneTag},
     Logger,
 };
@@ -50,44 +51,7 @@ fn advance_awaiting_playlist_info_state(dispatcher: &mut Dispatcher) {
             }
         };
 
-    // Progress through the "startup steps" of the linked `PlaylistStore`, returning `true`
     let wanted_position = utils::get_initial_position(playlist_store, starting_position);
-    match playlist_store.startup_status(wanted_position) {
-        Ok(StartupStatus::Ready) => {}
-        Ok(StartupStatus::AwaitingSupportCheck) => return,
-        Ok(StartupStatus::NeedsProbe(probe_segment)) => {
-            if start_probe_segment_request(dispatcher, probe_segment) {
-                return;
-            } else {
-                jsSendSegmentParsingError(
-                    true,
-                    crate::bindings::SegmentParsingErrorCode::UnknownError,
-                    Some(MediaType::Video),
-                    "No probe segment was available to determine startup metadata",
-                );
-                dispatcher.stop_current_content();
-                return;
-            }
-        }
-        Err(err) => {
-            utils::handle_playlist_store_error(err);
-            dispatcher.stop_current_content();
-            return;
-        }
-    };
-
-    // Ensure there's at least one variant that is supported here
-    if playlist_store.playlist_kind() == PlaylistType::MultivariantPlaylist
-        && playlist_store.supported_variants().is_empty()
-    {
-        jsSendOtherError(
-            true,
-            crate::bindings::OtherErrorCode::NoSupportedVariant,
-            "Error while parsing MultivariantPlaylist: no compatible variant found.",
-        );
-        dispatcher.stop_current_content();
-        return;
-    }
 
     // Start fetching initial media playlists if needed
     for mt in [MediaType::Video, MediaType::Audio] {
@@ -155,10 +119,48 @@ fn advance_awaiting_playlist_info_state(dispatcher: &mut Dispatcher) {
     jsAnnounceVariantUpdate(curr_variant);
     jsAnnounceTrackUpdate(MediaType::Audio, curr_audio_track, is_selected);
 
-    if playlist_store.are_playlists_ready() {
-        dispatcher.ready_state = PlayerReadyState::AwaitingMediaSource { starting_position };
-        dispatcher.recheck_player_state();
+    if !playlist_store.are_playlists_ready() {
+        return;
     }
+
+    match playlist_store.startup_status(wanted_position) {
+        Ok(StartupStatus::Ready) => {}
+        Ok(StartupStatus::AwaitingSupportCheck) => return,
+        Ok(StartupStatus::NeedsProbes(probe_requests)) => {
+            if start_probe_segment_requests(dispatcher, probe_requests) {
+                return;
+            } else {
+                jsSendSegmentParsingError(
+                    true,
+                    crate::bindings::SegmentParsingErrorCode::UnknownError,
+                    Some(MediaType::Video),
+                    "No probe segment was available to determine startup metadata",
+                );
+                dispatcher.stop_current_content();
+                return;
+            }
+        }
+        Err(err) => {
+            utils::handle_playlist_store_error(err);
+            dispatcher.stop_current_content();
+            return;
+        }
+    };
+
+    if playlist_store.playlist_kind() == PlaylistType::MultivariantPlaylist
+        && playlist_store.supported_variants().is_empty()
+    {
+        jsSendOtherError(
+            true,
+            crate::bindings::OtherErrorCode::NoSupportedVariant,
+            "Error while parsing MultivariantPlaylist: no compatible variant found.",
+        );
+        dispatcher.stop_current_content();
+        return;
+    }
+
+    dispatcher.ready_state = PlayerReadyState::AwaitingMediaSource { starting_position };
+    dispatcher.recheck_player_state();
 }
 
 /// Try to progress `ready_state` when in the `AwaitingMediaSource` state
@@ -207,7 +209,7 @@ fn advance_awaiting_media_source_state(dispatcher: &mut Dispatcher) {
         return;
     }
     jsStartObservingPlayback();
-    consume_probe_segment(dispatcher);
+    consume_probe_segments(dispatcher);
 }
 
 /// Start a startup probe request if not already in progress.
@@ -219,26 +221,46 @@ fn advance_awaiting_media_source_state(dispatcher: &mut Dispatcher) {
 ///
 /// Returns `true` if the probe process has been started, or `false` if we
 /// cannot do that.
+fn start_probe_segment_requests(
+    dispatcher: &mut Dispatcher,
+    probe_requests: Vec<(ProbeSegmentMetadata, Option<MediaType>)>,
+) -> bool {
+    probe_requests
+        .into_iter()
+        .all(|probe_request| start_probe_segment_request(dispatcher, probe_request))
+}
+
 fn start_probe_segment_request(
     dispatcher: &mut Dispatcher,
-    probe_segment: ProbeSegmentMetadata,
+    probe_request: (ProbeSegmentMetadata, Option<MediaType>),
 ) -> bool {
-    if dispatcher.ready_probe_segment.is_some()
-        || dispatcher.segment_request_contexts.has(|a| a.is_probe())
+    let (probe_segment, requested_media_type) = probe_request;
+    if requested_media_type.is_some_and(|mt| dispatcher.ready_probe_segments.get(mt).is_some())
+        || dispatcher.segment_request_contexts.has(|context| {
+            matches!(
+                context,
+                PendingSegmentRequest::Probe {
+                    requested_media_type: context_media_type,
+                    ..
+                } if *context_media_type == requested_media_type
+            )
+        })
     {
-        return true; // probe already going on
+        return true;
     }
 
+    let lane_tag = requested_media_type
+        .map(RequestLaneTag::from_media_type)
+        .unwrap_or(RequestLaneTag::Probe);
     let req_id = dispatcher
         .segment_request_contexts
         .insert(PendingSegmentRequest::Probe {
-            // TODO: cloning here may be unnecessary if we're smart about it? Though
-            // it may be not worth it.
             probe_segment: probe_segment.clone(),
+            requested_media_type,
         });
     match &probe_segment.context {
         ProbeSegmentContext::Init { .. } => dispatcher.requester.request_segment_immediately(
-            RequestLaneTag::Probe,
+            lane_tag,
             &probe_segment.url,
             probe_segment.byte_range.as_ref(),
             None,
@@ -246,7 +268,7 @@ fn start_probe_segment_request(
         ),
         ProbeSegmentContext::Media { time_info, .. } => {
             dispatcher.requester.request_segment_immediately(
-                RequestLaneTag::Probe,
+                lane_tag,
                 &probe_segment.url,
                 probe_segment.byte_range.as_ref(),
                 Some(time_info.clone()),
@@ -277,58 +299,55 @@ fn init_source_buffer(
 ///
 /// As it is usable data and should anyway correspond to the initial segment to load, this
 /// method allows to both reset that state and to push it to the buffers.
-fn consume_probe_segment(dispatcher: &mut Dispatcher) {
-    let Some(ReadyProbeSegment { request, data }) = dispatcher.ready_probe_segment.take() else {
-        return; // No stored probe segment
-    };
-    let Some(media_type) = utils::has_playlist_store_media_type(dispatcher.playlist_store.as_ref())
-    else {
-        jsSendOtherError(
-            true,
-            OtherErrorCode::Unknown,
-            "No direct-media type could be resolved after probing",
-        );
-        dispatcher.stop_current_content();
-        return;
-    };
+fn consume_probe_segments(dispatcher: &mut Dispatcher) {
+    for media_type in [MediaType::Audio, MediaType::Video] {
+        let Some(ReadyProbeSegment {
+            request,
+            media_type,
+            data,
+        }) = dispatcher.ready_probe_segments.take(media_type)
+        else {
+            continue;
+        };
 
-    match request.context {
-        ProbeSegmentContext::Init { id } => {
-            dispatcher.on_init_segment_loaded(data, media_type, id);
-        }
-        ProbeSegmentContext::Media {
-            sequence,
-            discontinuity_sequence,
-            time_info,
-        } => {
-            let Some((segment_list, context)) = dispatcher
-                .playlist_store
-                .as_ref()
-                .and_then(|store| store.curr_media_playlist_segment_info(media_type))
-            else {
-                jsSendOtherError(
-                    true,
-                    OtherErrorCode::Unknown,
-                    "No direct-media context could be resolved after probing",
-                );
-                dispatcher.stop_current_content();
-                return;
-            };
-            let init_segment_id = segment_list
-                .media()
-                .iter()
-                .find(|seg| seg.sequence() == sequence)
-                .and_then(|seg| segment_list.init_for(seg))
-                .map(|init| init.id());
-            dispatcher.on_media_segment_loaded(SegmentPushMetadata {
-                data,
-                media_type,
-                time_info,
-                context,
-                init_segment_id,
-                sequence_number: sequence,
+        match request.context {
+            ProbeSegmentContext::Init { id } => {
+                dispatcher.on_init_segment_loaded(data, media_type, id);
+            }
+            ProbeSegmentContext::Media {
+                sequence,
                 discontinuity_sequence,
-            });
+                time_info,
+            } => {
+                let Some((segment_list, context)) = dispatcher
+                    .playlist_store
+                    .as_ref()
+                    .and_then(|store| store.curr_media_playlist_segment_info(media_type))
+                else {
+                    jsSendOtherError(
+                        true,
+                        OtherErrorCode::Unknown,
+                        "No media context could be resolved after probing",
+                    );
+                    dispatcher.stop_current_content();
+                    return;
+                };
+                let init_segment_id = segment_list
+                    .media()
+                    .iter()
+                    .find(|seg| seg.sequence() == sequence)
+                    .and_then(|seg| segment_list.init_for(seg))
+                    .map(|init| init.id());
+                dispatcher.on_media_segment_loaded(SegmentPushMetadata {
+                    data,
+                    media_type,
+                    time_info,
+                    context,
+                    init_segment_id,
+                    sequence_number: sequence,
+                    discontinuity_sequence,
+                });
+            }
         }
     }
 }

--- a/src/rs-core/dispatcher/core/startup.rs
+++ b/src/rs-core/dispatcher/core/startup.rs
@@ -38,19 +38,11 @@ impl Dispatcher {
     }
 
     pub(super) fn ready_to_load_segments(&mut self) -> bool {
-        if self
-            .playlist_store
-            .as_ref()
-            .is_some_and(|pl_store| !pl_store.are_playlists_ready())
-        {
-            false // Playlist(s) not yet fetched
-        } else {
-            ensure_ready_playlist_store(self, self.media_element_ref.wanted_position())
-        }
+        ensure_ready_playlists(self, self.media_element_ref.wanted_position())
     }
 }
 
-fn ensure_ready_playlist_store(dispatcher: &mut Dispatcher, wanted_position: f64) -> bool {
+fn ensure_ready_playlists(dispatcher: &mut Dispatcher, wanted_position: f64) -> bool {
     let Some(playlist_store) = dispatcher.playlist_store.as_mut() else {
         return false;
     };
@@ -65,6 +57,7 @@ fn ensure_ready_playlist_store(dispatcher: &mut Dispatcher, wanted_position: f64
 
     match status {
         StartupStatus::Ready => true,
+        StartupStatus::AwaitingPlaylists => false,
         StartupStatus::AwaitingSupportCheck => false,
         StartupStatus::VariantSwitchNeeded { variant_id } => {
             jsAnnounceVariantUpdate(Some(variant_id));
@@ -106,88 +99,79 @@ fn advance_awaiting_playlist_info_state(dispatcher: &mut Dispatcher) {
         _ => return,
     };
 
-    let (wanted_position, are_playlists_ready) = {
-        let Some(playlist_store) = dispatcher.playlist_store.as_mut() else {
-            return;
-        };
-        let wanted_position = utils::get_initial_position(playlist_store, starting_position);
-
-        // Start fetching initial media playlists if needed
-        for mt in [MediaType::Video, MediaType::Audio] {
-            if playlist_store.curr_media_playlist(mt).is_some() {
-                continue; // Already fetched
-            }
-            if let Some(id) = playlist_store.curr_media_playlist_id(mt) {
-                if let Some(url) = playlist_store.media_playlist_url(id) {
-                    let url = url.clone();
-                    dispatcher.requester.fetch_playlist(
-                        url,
-                        PlaylistFileType::MediaPlaylist {
-                            id: *id,
-                            media_type: mt,
-                        },
-                    );
-                }
-            }
-        }
-
-        // Now "Announce" lifecycle events if needed
-
-        // SAFETY: The following lines are unsafe because they may actually define raw pointers
-        // to point to Rust's heap memory and put it in the returned values.
-        //
-        // However, we're calling the JS binding function it is communicated to directly
-        // after and thus before the corresponding underlying data had a chance to be
-        // dropped.
-        //
-        // Because one of the rules of those bindings is to copy all pointed data
-        // synchronously on call, we should not encounter any issue.
-        let (variants_info, audio_tracks_info) =
-            if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist {
-                let has_audio_track = playlist_store.has_media_type(MediaType::Audio);
-                (
-                    unsafe { format_direct_media_variants_info_for_js() },
-                    unsafe { format_direct_media_audio_tracks_for_js(has_audio_track) },
-                )
-            } else {
-                (
-                    unsafe {
-                        format_variants_info_for_js(playlist_store.available_variants().as_slice())
-                    },
-                    unsafe { format_audio_tracks_for_js(playlist_store.audio_tracks()) },
-                )
-            };
-        let selected_audio_track = playlist_store.selected_audio_track_id();
-        let is_selected = selected_audio_track.is_some();
-        let curr_audio_track = if let Some(selected) = selected_audio_track {
-            Some(selected)
-        } else if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist
-            && playlist_store.has_media_type(MediaType::Audio)
-        {
-            Some(DIRECT_MEDIA_AUDIO_TRACK_ID)
-        } else {
-            playlist_store.curr_audio_track_id()
-        };
-        let curr_variant = if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist {
-            Some(DIRECT_MEDIA_VARIANT_ID)
-        } else {
-            playlist_store.curr_variant().map(|v| v.id())
-        };
-        let playlist_kind = playlist_store.playlist_kind();
-        let are_playlists_ready = playlist_store.are_playlists_ready();
-
-        jsAnnounceFetchedContent(playlist_kind, variants_info, audio_tracks_info);
-        jsAnnounceVariantUpdate(curr_variant);
-        jsAnnounceTrackUpdate(MediaType::Audio, curr_audio_track, is_selected);
-
-        (wanted_position, are_playlists_ready)
+    let Some(playlist_store) = dispatcher.playlist_store.as_mut() else {
+        return;
     };
 
-    if !are_playlists_ready {
-        return;
+    let wanted_position = utils::get_initial_position(playlist_store, starting_position);
+
+    // Start fetching initial media playlists if needed
+    for mt in [MediaType::Video, MediaType::Audio] {
+        if playlist_store.curr_media_playlist(mt).is_some() {
+            continue; // Already fetched
+        }
+        if let Some(id) = playlist_store.curr_media_playlist_id(mt) {
+            if let Some(url) = playlist_store.media_playlist_url(id) {
+                let url = url.clone();
+                dispatcher.requester.fetch_playlist(
+                    url,
+                    PlaylistFileType::MediaPlaylist {
+                        id: *id,
+                        media_type: mt,
+                    },
+                );
+            }
+        }
     }
 
-    if !ensure_ready_playlist_store(dispatcher, wanted_position) {
+    // Now "Announce" lifecycle events if needed
+
+    // SAFETY: The following lines are unsafe because they may actually define raw pointers
+    // to point to Rust's heap memory and put it in the returned values.
+    //
+    // However, we're calling the JS binding function it is communicated to directly
+    // after and thus before the corresponding underlying data had a chance to be
+    // dropped.
+    //
+    // Because one of the rules of those bindings is to copy all pointed data
+    // synchronously on call, we should not encounter any issue.
+    let (variants_info, audio_tracks_info) = if playlist_store.playlist_kind()
+        == PlaylistType::MediaPlaylist
+    {
+        let has_audio_track = playlist_store.has_media_type(MediaType::Audio);
+        (
+            unsafe { format_direct_media_variants_info_for_js() },
+            unsafe { format_direct_media_audio_tracks_for_js(has_audio_track) },
+        )
+    } else {
+        (
+            unsafe { format_variants_info_for_js(playlist_store.available_variants().as_slice()) },
+            unsafe { format_audio_tracks_for_js(playlist_store.audio_tracks()) },
+        )
+    };
+    let selected_audio_track = playlist_store.selected_audio_track_id();
+    let is_selected = selected_audio_track.is_some();
+    let curr_audio_track = if let Some(selected) = selected_audio_track {
+        Some(selected)
+    } else if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist
+        && playlist_store.has_media_type(MediaType::Audio)
+    {
+        Some(DIRECT_MEDIA_AUDIO_TRACK_ID)
+    } else {
+        playlist_store.curr_audio_track_id()
+    };
+    let curr_variant = if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist {
+        Some(DIRECT_MEDIA_VARIANT_ID)
+    } else {
+        playlist_store.curr_variant().map(|v| v.id())
+    };
+    let playlist_kind = playlist_store.playlist_kind();
+
+    jsAnnounceFetchedContent(playlist_kind, variants_info, audio_tracks_info);
+    jsAnnounceVariantUpdate(curr_variant);
+    jsAnnounceTrackUpdate(MediaType::Audio, curr_audio_track, is_selected);
+
+    if !ensure_ready_playlists(dispatcher, wanted_position) {
         return;
     }
 

--- a/src/rs-core/dispatcher/core/startup.rs
+++ b/src/rs-core/dispatcher/core/startup.rs
@@ -38,97 +38,63 @@ impl Dispatcher {
     }
 }
 
-/// Try to progress `ready_state` when in the `AwaitingPlaylistInfo` state
-fn advance_awaiting_playlist_info_state(dispatcher: &mut Dispatcher) {
-    let (starting_position, playlist_store) =
-        match (dispatcher.playlist_store.as_mut(), &dispatcher.ready_state) {
-            (
-                Some(playlist_store),
-                PlayerReadyState::AwaitingPlaylistInfo { starting_position },
-            ) => (*starting_position, playlist_store),
-            _ => {
-                return;
-            }
-        };
+pub(super) fn ensure_current_streams_ready(
+    dispatcher: &mut Dispatcher,
+    wanted_position: f64,
+) -> bool {
+    let Some(playlist_store) = dispatcher.playlist_store.as_mut() else {
+        return false;
+    };
+    let prev_variant_id = playlist_store.curr_variant().map(|v| v.id());
+    let prev_audio_id = playlist_store
+        .curr_media_playlist_id(MediaType::Audio)
+        .cloned();
+    let prev_video_id = playlist_store
+        .curr_media_playlist_id(MediaType::Video)
+        .cloned();
 
-    let wanted_position = utils::get_initial_position(playlist_store, starting_position);
+    let status = match playlist_store.startup_status(wanted_position) {
+        Ok(status) => status,
+        Err(err) => {
+            utils::handle_playlist_store_error(err);
+            dispatcher.stop_current_content();
+            return false;
+        }
+    };
 
-    // Start fetching initial media playlists if needed
-    for mt in [MediaType::Video, MediaType::Audio] {
-        if playlist_store.curr_media_playlist(mt).is_some() {
-            continue; // Already fetched
+    let Some(playlist_store) = dispatcher.playlist_store.as_ref() else {
+        return false;
+    };
+    let curr_variant_id = playlist_store.curr_variant().map(|v| v.id());
+    let curr_audio_id = playlist_store
+        .curr_media_playlist_id(MediaType::Audio)
+        .cloned();
+    let curr_video_id = playlist_store
+        .curr_media_playlist_id(MediaType::Video)
+        .cloned();
+    if curr_variant_id != prev_variant_id
+        || curr_audio_id != prev_audio_id
+        || curr_video_id != prev_video_id
+    {
+        let mut changed_media_types = vec![];
+        if curr_audio_id != prev_audio_id {
+            changed_media_types.push(MediaType::Audio);
         }
-        if let Some(id) = playlist_store.curr_media_playlist_id(mt) {
-            if let Some(url) = playlist_store.media_playlist_url(id) {
-                let id = id.clone();
-                let url = url.clone();
-                dispatcher
-                    .requester
-                    .fetch_playlist(url, PlaylistFileType::MediaPlaylist { id, media_type: mt });
-            }
+        if curr_video_id != prev_video_id {
+            changed_media_types.push(MediaType::Video);
         }
+
+        jsAnnounceVariantUpdate(curr_variant_id);
+        dispatcher.handle_media_playlist_update(&changed_media_types, false, false);
+        return false;
     }
 
-    // Now "Announce" lifecycle events if needed
-
-    // SAFETY: The following lines are unsafe because they may actually define raw pointers
-    // to point to Rust's heap memory and put it in the returned values.
-    //
-    // However, we're calling the JS binding function it is communicated to directly
-    // after and thus before the corresponding underlying data had a chance to be
-    // dropped.
-    //
-    // Because one of the rules of those bindings is to copy all pointed data
-    // synchronously on call, we should not encounter any issue.
-    let (variants_info, audio_tracks_info) = if playlist_store.playlist_kind()
-        == PlaylistType::MediaPlaylist
-    {
-        let has_audio_track = playlist_store.has_media_type(MediaType::Audio);
-        (
-            unsafe { format_direct_media_variants_info_for_js() },
-            unsafe { format_direct_media_audio_tracks_for_js(has_audio_track) },
-        )
-    } else {
-        (
-            unsafe { format_variants_info_for_js(playlist_store.supported_variants().as_slice()) },
-            unsafe { format_audio_tracks_for_js(playlist_store.audio_tracks()) },
-        )
-    };
-    let selected_audio_track = playlist_store.selected_audio_track_id();
-    let is_selected = selected_audio_track.is_some();
-    let curr_audio_track = if let Some(selected) = selected_audio_track {
-        Some(selected)
-    } else if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist
-        && playlist_store.has_media_type(MediaType::Audio)
-    {
-        Some(DIRECT_MEDIA_AUDIO_TRACK_ID)
-    } else {
-        playlist_store.curr_audio_track_id()
-    };
-    jsAnnounceFetchedContent(
-        playlist_store.playlist_kind(),
-        variants_info,
-        audio_tracks_info,
-    );
-
-    let curr_variant = if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist {
-        Some(DIRECT_MEDIA_VARIANT_ID)
-    } else {
-        playlist_store.curr_variant().map(|v| v.id())
-    };
-    jsAnnounceVariantUpdate(curr_variant);
-    jsAnnounceTrackUpdate(MediaType::Audio, curr_audio_track, is_selected);
-
-    if !playlist_store.are_playlists_ready() {
-        return;
-    }
-
-    match playlist_store.startup_status(wanted_position) {
-        Ok(StartupStatus::Ready) => {}
-        Ok(StartupStatus::AwaitingSupportCheck) => return,
-        Ok(StartupStatus::NeedsProbes(probe_requests)) => {
+    match status {
+        StartupStatus::Ready => true,
+        StartupStatus::AwaitingSupportCheck => false,
+        StartupStatus::NeedsProbes(probe_requests) => {
             if start_probe_segment_requests(dispatcher, probe_requests) {
-                return;
+                false
             } else {
                 jsSendSegmentParsingError(
                     true,
@@ -137,14 +103,104 @@ fn advance_awaiting_playlist_info_state(dispatcher: &mut Dispatcher) {
                     "No probe segment was available to determine startup metadata",
                 );
                 dispatcher.stop_current_content();
-                return;
+                false
             }
         }
-        Err(err) => {
-            utils::handle_playlist_store_error(err);
-            dispatcher.stop_current_content();
+    }
+}
+
+/// Try to progress `ready_state` when in the `AwaitingPlaylistInfo` state
+fn advance_awaiting_playlist_info_state(dispatcher: &mut Dispatcher) {
+    let starting_position = match &dispatcher.ready_state {
+        PlayerReadyState::AwaitingPlaylistInfo { starting_position } => *starting_position,
+        _ => return,
+    };
+
+    let (wanted_position, are_playlists_ready) = {
+        let Some(playlist_store) = dispatcher.playlist_store.as_mut() else {
             return;
+        };
+        let wanted_position = utils::get_initial_position(playlist_store, starting_position);
+
+        // Start fetching initial media playlists if needed
+        for mt in [MediaType::Video, MediaType::Audio] {
+            if playlist_store.curr_media_playlist(mt).is_some() {
+                continue; // Already fetched
+            }
+            if let Some(id) = playlist_store.curr_media_playlist_id(mt) {
+                if let Some(url) = playlist_store.media_playlist_url(id) {
+                    let id = id.clone();
+                    let url = url.clone();
+                    dispatcher.requester.fetch_playlist(
+                        url,
+                        PlaylistFileType::MediaPlaylist { id, media_type: mt },
+                    );
+                }
+            }
         }
+
+        // Now "Announce" lifecycle events if needed
+
+        // SAFETY: The following lines are unsafe because they may actually define raw pointers
+        // to point to Rust's heap memory and put it in the returned values.
+        //
+        // However, we're calling the JS binding function it is communicated to directly
+        // after and thus before the corresponding underlying data had a chance to be
+        // dropped.
+        //
+        // Because one of the rules of those bindings is to copy all pointed data
+        // synchronously on call, we should not encounter any issue.
+        let (variants_info, audio_tracks_info) =
+            if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist {
+                let has_audio_track = playlist_store.has_media_type(MediaType::Audio);
+                (
+                    unsafe { format_direct_media_variants_info_for_js() },
+                    unsafe { format_direct_media_audio_tracks_for_js(has_audio_track) },
+                )
+            } else {
+                (
+                    unsafe {
+                        format_variants_info_for_js(playlist_store.available_variants().as_slice())
+                    },
+                    unsafe { format_audio_tracks_for_js(playlist_store.audio_tracks()) },
+                )
+            };
+        let selected_audio_track = playlist_store.selected_audio_track_id();
+        let is_selected = selected_audio_track.is_some();
+        let curr_audio_track = if let Some(selected) = selected_audio_track {
+            Some(selected)
+        } else if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist
+            && playlist_store.has_media_type(MediaType::Audio)
+        {
+            Some(DIRECT_MEDIA_AUDIO_TRACK_ID)
+        } else {
+            playlist_store.curr_audio_track_id()
+        };
+        let curr_variant = if playlist_store.playlist_kind() == PlaylistType::MediaPlaylist {
+            Some(DIRECT_MEDIA_VARIANT_ID)
+        } else {
+            playlist_store.curr_variant().map(|v| v.id())
+        };
+        let playlist_kind = playlist_store.playlist_kind();
+        let are_playlists_ready = playlist_store.are_playlists_ready();
+
+        jsAnnounceFetchedContent(playlist_kind, variants_info, audio_tracks_info);
+        jsAnnounceVariantUpdate(curr_variant);
+        jsAnnounceTrackUpdate(MediaType::Audio, curr_audio_track, is_selected);
+
+        (wanted_position, are_playlists_ready)
+    };
+
+    if !are_playlists_ready {
+        return;
+    }
+
+    if !ensure_current_streams_ready(dispatcher, wanted_position) {
+        return;
+    }
+
+    let Some(playlist_store) = dispatcher.playlist_store.as_ref() else {
+        return;
     };
 
     if playlist_store.playlist_kind() == PlaylistType::MultivariantPlaylist

--- a/src/rs-core/dispatcher/mod.rs
+++ b/src/rs-core/dispatcher/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    bindings::MediaType,
     adaptive::AdaptiveQualitySelector,
+    bindings::MediaType,
     dispatcher::playlist_refresh_timers::PlaylistRefreshTimers,
     media_element::MediaElementReference,
     playlist_store::{PlaylistStore, ProbeSegmentMetadata},

--- a/src/rs-core/dispatcher/mod.rs
+++ b/src/rs-core/dispatcher/mod.rs
@@ -1,4 +1,5 @@
 use crate::{
+    bindings::MediaType,
     adaptive::AdaptiveQualitySelector,
     dispatcher::playlist_refresh_timers::PlaylistRefreshTimers,
     media_element::MediaElementReference,
@@ -66,9 +67,9 @@ pub struct Dispatcher {
     /// Allowing to retreive them once finished.
     segment_request_contexts: SegmentRequestContexts,
 
-    /// A startup probe segment that has already been fetched and inspected and now only waits for
+    /// Startup probe segments that have already been fetched and inspected and now only wait for
     /// the regular buffering pipeline to be ready before being pushed.
-    ready_probe_segment: Option<ReadyProbeSegment>,
+    ready_probe_segments: ReadyProbeSegments,
 }
 
 /// Identify the playback-related state the `Dispatcher` is in.
@@ -119,5 +120,47 @@ impl StartingPosition {
 #[derive(Debug)]
 struct ReadyProbeSegment {
     request: ProbeSegmentMetadata,
+    media_type: MediaType,
     data: event_listeners::JsMemoryBlob,
+}
+
+#[derive(Default)]
+struct ReadyProbeSegments {
+    audio: Option<ReadyProbeSegment>,
+    video: Option<ReadyProbeSegment>,
+}
+
+impl ReadyProbeSegments {
+    fn get(&self, media_type: MediaType) -> Option<&ReadyProbeSegment> {
+        match media_type {
+            MediaType::Audio => self.audio.as_ref(),
+            MediaType::Video => self.video.as_ref(),
+        }
+    }
+
+    fn insert(&mut self, probe: ReadyProbeSegment) {
+        match probe.media_type {
+            MediaType::Audio => self.audio = Some(probe),
+            MediaType::Video => self.video = Some(probe),
+        }
+    }
+
+    fn take(&mut self, media_type: MediaType) -> Option<ReadyProbeSegment> {
+        match media_type {
+            MediaType::Audio => self.audio.take(),
+            MediaType::Video => self.video.take(),
+        }
+    }
+
+    fn clear_media_type(&mut self, media_type: MediaType) {
+        match media_type {
+            MediaType::Audio => self.audio = None,
+            MediaType::Video => self.video = None,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.audio = None;
+        self.video = None;
+    }
 }

--- a/src/rs-core/dispatcher/segment_request_contexts.rs
+++ b/src/rs-core/dispatcher/segment_request_contexts.rs
@@ -100,7 +100,10 @@ pub(crate) enum PendingSegmentRequest {
     },
     /// This request concerns a "probe" request: we're loading a segment to know about a media's
     /// characteristics
-    Probe { probe_segment: ProbeSegmentMetadata },
+    Probe {
+        probe_segment: ProbeSegmentMetadata,
+        requested_media_type: Option<MediaType>,
+    },
 }
 
 impl PendingSegmentRequest {
@@ -112,5 +115,15 @@ impl PendingSegmentRequest {
     }
     pub(crate) fn is_init(&self) -> bool {
         matches!(self, Self::Init { .. })
+    }
+
+    pub(crate) fn requested_media_type(&self) -> Option<MediaType> {
+        match self {
+            Self::Init { media_type, .. } | Self::Media { media_type, .. } => Some(*media_type),
+            Self::Probe {
+                requested_media_type,
+                ..
+            } => *requested_media_type,
+        }
     }
 }

--- a/src/rs-core/dispatcher/utils.rs
+++ b/src/rs-core/dispatcher/utils.rs
@@ -78,15 +78,20 @@ pub(super) fn is_stale_segment_request_context(
             .is_some_and(|playlist| !playlist.contains_sequence(*sequence_number)),
 
         PendingSegmentRequest::Probe {
+            requested_media_type,
             probe_segment:
                 ProbeSegmentMetadata {
                     context: ProbeSegmentContext::Media { sequence, .. },
                     ..
                 },
-        } => playlist_store
-            .as_ref()
-            .and_then(|pl_store| pl_store.direct_media_playlist())
-            .is_some_and(|(_, playlist)| !playlist.contains_sequence(*sequence)),
+        } => match requested_media_type {
+            Some(media_type) => playlist_store
+                .and_then(|pl_store| pl_store.curr_media_playlist(*media_type))
+                .is_some_and(|playlist| !playlist.contains_sequence(*sequence)),
+            None => playlist_store
+                .and_then(|pl_store| pl_store.direct_media_playlist())
+                .is_some_and(|(_, playlist)| !playlist.contains_sequence(*sequence)),
+        },
         _ => false,
     }
 }
@@ -107,9 +112,6 @@ pub(super) fn handle_playlist_store_error(err: PlaylistStoreError) {
             Some(MediaType::Video),
             &err.to_string(),
         ),
-        PlaylistStoreError::MissingSelectedStreamMetadata => {
-            jsSendOtherError(true, OtherErrorCode::Unknown, &err.to_string())
-        }
         PlaylistStoreError::UnsupportedStartupStream => {
             jsSendOtherError(true, OtherErrorCode::NoSupportedVariant, &err.to_string())
         }

--- a/src/rs-core/dispatcher/utils.rs
+++ b/src/rs-core/dispatcher/utils.rs
@@ -109,7 +109,7 @@ pub(super) fn handle_playlist_store_error(err: PlaylistStoreError) {
         PlaylistStoreError::NoProbeSegment => jsSendSegmentParsingError(
             true,
             crate::bindings::SegmentParsingErrorCode::UnknownError,
-            Some(MediaType::Video),
+            None,
             &err.to_string(),
         ),
         PlaylistStoreError::UnsupportedStartupStream => {

--- a/src/rs-core/parser/media_playlist.rs
+++ b/src/rs-core/parser/media_playlist.rs
@@ -1,6 +1,6 @@
 use super::{
     multi_variant_playlist::MediaPlaylistContext,
-    top_level_playlist::DirectMediaInfo,
+    top_level_playlist::ExternalMediaInfo,
     value_parsers::{
         parse_byte_range, parse_decimal_floating_point, parse_decimal_integer,
         parse_start_attribute, ByteRange,
@@ -278,7 +278,7 @@ pub struct MediaPlaylist {
     /// URL at which this Media Playlist may be updated.
     url: Url,
     /// Metadata inferred from one of this playlist's segments when HLS signaling is incomplete.
-    external_media_info: Option<DirectMediaInfo>,
+    external_media_info: Option<ExternalMediaInfo>,
     // TODO
     // pub server_control: ServerControl,
     // pub part_inf: Option<f64>,
@@ -710,11 +710,11 @@ impl MediaPlaylist {
         &self.url
     }
 
-    pub(crate) fn external_media_info(&self) -> Option<&DirectMediaInfo> {
+    pub(crate) fn external_media_info(&self) -> Option<&ExternalMediaInfo> {
         self.external_media_info.as_ref()
     }
 
-    pub(crate) fn set_external_media_info(&mut self, media_info: DirectMediaInfo) {
+    pub(crate) fn set_external_media_info(&mut self, media_info: ExternalMediaInfo) {
         self.external_media_info = Some(media_info);
     }
 

--- a/src/rs-core/parser/media_playlist.rs
+++ b/src/rs-core/parser/media_playlist.rs
@@ -1,5 +1,6 @@
 use super::{
     multi_variant_playlist::MediaPlaylistContext,
+    top_level_playlist::DirectMediaInfo,
     value_parsers::{
         parse_byte_range, parse_decimal_floating_point, parse_decimal_integer,
         parse_start_attribute, ByteRange,
@@ -276,12 +277,11 @@ pub struct MediaPlaylist {
     segment_list: SegmentList,
     /// URL at which this Media Playlist may be updated.
     url: Url,
+    /// Metadata inferred from one of this playlist's segments when HLS signaling is incomplete.
+    external_media_info: Option<DirectMediaInfo>,
     // TODO
     // pub server_control: ServerControl,
     // pub part_inf: Option<f64>,
-
-    // ignored
-    // pub discontinuity_sequence: Option<u32>;
 }
 
 impl MediaPlaylist {
@@ -547,6 +547,7 @@ impl MediaPlaylist {
             i_frames_only,
             segment_list: SegmentList::new(maps_info, media_segments),
             url,
+            external_media_info: prev_playlist.and_then(|p| p.external_media_info.clone()),
             // TODO
             // server_control,
             // part_inf,
@@ -707,6 +708,14 @@ impl MediaPlaylist {
     /// Returns the URL at which this Media Playlist may be requested.
     pub(super) fn url(&self) -> &Url {
         &self.url
+    }
+
+    pub(crate) fn external_media_info(&self) -> Option<&DirectMediaInfo> {
+        self.external_media_info.as_ref()
+    }
+
+    pub(crate) fn set_external_media_info(&mut self, media_info: DirectMediaInfo) {
+        self.external_media_info = Some(media_info);
     }
 
     /// Returns the "extension" part of the media segments referenced in this Media Playlist (e.g.

--- a/src/rs-core/parser/media_tag.rs
+++ b/src/rs-core/parser/media_tag.rs
@@ -322,6 +322,10 @@ impl MediaTag {
         self.media_playlist.as_ref()
     }
 
+    pub(super) fn media_playlist_mut(&mut self) -> Option<&mut MediaPlaylist> {
+        self.media_playlist.as_mut()
+    }
+
     pub(crate) fn update(
         &mut self,
         playlist: impl BufRead,

--- a/src/rs-core/parser/mod.rs
+++ b/src/rs-core/parser/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use multi_variant_playlist::{
     MediaPlaylistPermanentId, MediaPlaylistUpdateError, MultivariantPlaylistParsingError,
 };
 pub(crate) use top_level_playlist::{
-    DirectMediaInfo, TopLevelPlaylist, TopLevelPlaylistParsingError,
+    ExternalMediaInfo, TopLevelPlaylist, TopLevelPlaylistParsingError,
 };
 pub(crate) use value_parsers::ByteRange;
 pub(crate) use variant_stream::{VariantStream, VideoResolution};

--- a/src/rs-core/parser/multi_variant_playlist.rs
+++ b/src/rs-core/parser/multi_variant_playlist.rs
@@ -669,7 +669,7 @@ impl From<MediaPlaylistParsingError> for MediaPlaylistUpdateError {
 }
 
 /// Identifier allowing to identify a given MediaPlaylist
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct MediaPlaylistPermanentId {
     location: MediaPlaylistUrlLocation,
     id: u32,

--- a/src/rs-core/parser/multi_variant_playlist.rs
+++ b/src/rs-core/parser/multi_variant_playlist.rs
@@ -197,25 +197,6 @@ impl MultivariantPlaylist {
     // }
 
     /// Returns information on all known variants linked to this `MultivariantPlaylist`, ordered by
-    /// `bandwidth` ascending, for which all codecs are known to be supported.
-    pub(crate) fn supported_variants(&self) -> Vec<&VariantStream> {
-        self.variants
-            .iter()
-            .filter(|v| v.supported().unwrap_or(false))
-            .collect()
-    }
-
-    /// Returns information on all known variants linked to this `MultivariantPlaylist`, ordered by
-    /// `bandwidth` ascending, for which all codecs are known to be supported and which are linked
-    /// to the given track_id
-    pub(crate) fn supported_variants_for_audio(&self, track_id: u32) -> Vec<&VariantStream> {
-        self.variants_for_audio(track_id)
-            .into_iter()
-            .filter(|v| v.supported().unwrap_or(false))
-            .collect()
-    }
-
-    /// Returns information on all known variants linked to this `MultivariantPlaylist`, ordered by
     /// `bandwidth` ascending, which are linked to the given track_id.
     pub(crate) fn variants_for_audio(&self, track_id: u32) -> Vec<&VariantStream> {
         let group_ids = self.audio_tracks.groups_for_track_id(track_id);

--- a/src/rs-core/parser/multi_variant_playlist.rs
+++ b/src/rs-core/parser/multi_variant_playlist.rs
@@ -669,7 +669,7 @@ impl From<MediaPlaylistParsingError> for MediaPlaylistUpdateError {
 }
 
 /// Identifier allowing to identify a given MediaPlaylist
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct MediaPlaylistPermanentId {
     location: MediaPlaylistUrlLocation,
     id: u32,
@@ -693,7 +693,7 @@ impl MediaPlaylistPermanentId {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub(crate) enum MediaPlaylistUrlLocation {
     /// This Media Playlist's URL is defined by a variant in the `MultivariantPlaylist` object.
     Variant,

--- a/src/rs-core/parser/multi_variant_playlist.rs
+++ b/src/rs-core/parser/multi_variant_playlist.rs
@@ -209,12 +209,21 @@ impl MultivariantPlaylist {
     /// `bandwidth` ascending, for which all codecs are known to be supported and which are linked
     /// to the given track_id
     pub(crate) fn supported_variants_for_audio(&self, track_id: u32) -> Vec<&VariantStream> {
+        self.variants_for_audio(track_id)
+            .into_iter()
+            .filter(|v| v.supported().unwrap_or(false))
+            .collect()
+    }
+
+    /// Returns information on all known variants linked to this `MultivariantPlaylist`, ordered by
+    /// `bandwidth` ascending, which are linked to the given track_id.
+    pub(crate) fn variants_for_audio(&self, track_id: u32) -> Vec<&VariantStream> {
         let group_ids = self.audio_tracks.groups_for_track_id(track_id);
         self.variants
             .iter()
             .filter(|v| {
                 if let Some(group) = v.audio_group() {
-                    group_ids.contains(&group) && v.supported().unwrap_or(false)
+                    group_ids.contains(&group)
                 } else {
                     false
                 }

--- a/src/rs-core/parser/multi_variant_playlist.rs
+++ b/src/rs-core/parser/multi_variant_playlist.rs
@@ -420,6 +420,29 @@ impl MultivariantPlaylist {
         }
     }
 
+    pub(crate) fn media_playlist_mut(
+        &mut self,
+        wanted_id: &MediaPlaylistPermanentId,
+    ) -> Option<&mut MediaPlaylist> {
+        match wanted_id.location() {
+            MediaPlaylistUrlLocation::Variant => self
+                .variants
+                .iter_mut()
+                .find(|v| v.id() == wanted_id.id())
+                .and_then(|v| v.media_playlist_mut()),
+            MediaPlaylistUrlLocation::AudioTrack => self
+                .audio_tracks
+                .media_tag_mut(wanted_id.id())
+                .and_then(|m| m.media_playlist_mut()),
+            MediaPlaylistUrlLocation::OtherMedia => self
+                .other_media
+                .iter_mut()
+                .find(|m| m.id() == wanted_id.id())
+                .and_then(|m| m.media_playlist_mut()),
+            MediaPlaylistUrlLocation::Direct => None,
+        }
+    }
+
     pub(crate) fn update_media_playlist(
         &mut self,
         id: &MediaPlaylistPermanentId,

--- a/src/rs-core/parser/top_level_playlist.rs
+++ b/src/rs-core/parser/top_level_playlist.rs
@@ -22,14 +22,9 @@ pub(crate) struct DirectMediaPlaylist {
     url: Url,
     /// The `MediaPlaylist` itself
     playlist: MediaPlaylist,
-    /// Known metadata for the segments of that media playlist.
-    ///
-    /// Can rely on the loading of a "probe segment" in which case it is first set to
-    /// `None` and only set to an actual value when known.
-    media_info: Option<DirectMediaInfo>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct DirectMediaInfo {
     pub(crate) mime_type: String,
     pub(crate) media_type: crate::bindings::MediaType,
@@ -75,7 +70,6 @@ impl DirectMediaPlaylist {
             id: MediaPlaylistPermanentId::new(MediaPlaylistUrlLocation::Direct, 0),
             url,
             playlist,
-            media_info: None,
         })
     }
 
@@ -91,12 +85,16 @@ impl DirectMediaPlaylist {
         &self.playlist
     }
 
-    pub(crate) fn media_info(&self) -> Option<&DirectMediaInfo> {
-        self.media_info.as_ref()
+    pub(crate) fn playlist_mut(&mut self) -> &mut MediaPlaylist {
+        &mut self.playlist
     }
 
-    pub(crate) fn set_media_info(&mut self, media_info: DirectMediaInfo) {
-        self.media_info = Some(media_info);
+    pub(crate) fn external_media_info(&self) -> Option<&DirectMediaInfo> {
+        self.playlist.external_media_info()
+    }
+
+    pub(crate) fn set_external_media_info(&mut self, external_media_info: DirectMediaInfo) {
+        self.playlist.set_external_media_info(external_media_info);
     }
 
     pub(crate) fn media_playlist_url(&self, wanted_id: &MediaPlaylistPermanentId) -> Option<&Url> {

--- a/src/rs-core/parser/top_level_playlist.rs
+++ b/src/rs-core/parser/top_level_playlist.rs
@@ -25,7 +25,7 @@ pub(crate) struct DirectMediaPlaylist {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct DirectMediaInfo {
+pub(crate) struct ExternalMediaInfo {
     pub(crate) mime_type: String,
     pub(crate) media_type: crate::bindings::MediaType,
     pub(crate) codec: String,
@@ -89,11 +89,11 @@ impl DirectMediaPlaylist {
         &mut self.playlist
     }
 
-    pub(crate) fn external_media_info(&self) -> Option<&DirectMediaInfo> {
+    pub(crate) fn external_media_info(&self) -> Option<&ExternalMediaInfo> {
         self.playlist.external_media_info()
     }
 
-    pub(crate) fn set_external_media_info(&mut self, external_media_info: DirectMediaInfo) {
+    pub(crate) fn set_external_media_info(&mut self, external_media_info: ExternalMediaInfo) {
         self.playlist.set_external_media_info(external_media_info);
     }
 

--- a/src/rs-core/parser/variant_stream.rs
+++ b/src/rs-core/parser/variant_stream.rs
@@ -176,8 +176,6 @@ pub struct VariantStream {
     /// Pathway.
     pathway_id: Option<String>,
 
-    supported: Option<bool>,
-
     context: Option<MediaPlaylistContext>,
     // TODO
     // ALLOWED-CPC
@@ -231,18 +229,6 @@ pub enum VariantParsingError {
 }
 
 impl VariantStream {
-    pub(crate) fn supported(&self) -> Option<bool> {
-        self.supported
-    }
-
-    pub(crate) fn update_support(&mut self, supported: bool) {
-        self.supported = Some(supported);
-    }
-
-    pub(crate) fn clear_support(&mut self) {
-        self.supported = None;
-    }
-
     pub(crate) fn has_type(&self, media_type: MediaType) -> bool {
         if self.codecs.len() == 0 {
             // No codec listed => Assume there's video for now
@@ -540,7 +526,6 @@ impl VariantStream {
                 video,
                 video_range,
                 context: None,
-                supported: None,
             })
         } else {
             Err(VariantParsingError::MissingBandwidth)

--- a/src/rs-core/parser/variant_stream.rs
+++ b/src/rs-core/parser/variant_stream.rs
@@ -230,7 +230,7 @@ pub enum VariantParsingError {
 
 impl VariantStream {
     pub(crate) fn has_type(&self, media_type: MediaType) -> bool {
-        if self.codecs.len() == 0 {
+        if self.codecs.is_empty() {
             // No codec listed => Assume there's video for now
             media_type == MediaType::Video
         } else {

--- a/src/rs-core/parser/variant_stream.rs
+++ b/src/rs-core/parser/variant_stream.rs
@@ -239,6 +239,10 @@ impl VariantStream {
         self.supported = Some(supported);
     }
 
+    pub(crate) fn clear_support(&mut self) {
+        self.supported = None;
+    }
+
     pub(crate) fn has_type(&self, media_type: MediaType) -> bool {
         if self.codecs.len() == 0 {
             // No codec listed => Assume there's video for now

--- a/src/rs-core/parser/variant_stream.rs
+++ b/src/rs-core/parser/variant_stream.rs
@@ -299,6 +299,10 @@ impl VariantStream {
         self.media_playlist.as_ref()
     }
 
+    pub(super) fn media_playlist_mut(&mut self) -> Option<&mut MediaPlaylist> {
+        self.media_playlist.as_mut()
+    }
+
     pub(super) fn update_media_playlist(
         &mut self,
         playlist: impl BufRead,

--- a/src/rs-core/parser/variant_stream.rs
+++ b/src/rs-core/parser/variant_stream.rs
@@ -240,9 +240,14 @@ impl VariantStream {
     }
 
     pub(crate) fn has_type(&self, media_type: MediaType) -> bool {
-        self.codecs
-            .iter()
-            .any(|c| matches!(c.0, Some(x) if x == media_type))
+        if self.codecs.len() == 0 {
+            // No codec listed => Assume there's video for now
+            media_type == MediaType::Video
+        } else {
+            self.codecs
+                .iter()
+                .any(|c| matches!(c.0, Some(x) if x == media_type))
+        }
     }
 
     pub(crate) fn codecs(&self, media_type: MediaType) -> Option<String> {

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -157,11 +157,11 @@ impl PlaylistStore {
                     return Err(PlaylistStoreError::NoInitialVariant);
                 };
 
-                (
-                    Some(initial_variant.id()),
+                let (curr_audio_id, curr_video_id) = Self::normalize_selected_media_ids(
                     playlist.audio_media_playlist_id_for(initial_variant, None),
                     playlist.video_media_playlist_id_for(initial_variant),
-                )
+                );
+                (Some(initial_variant.id()), curr_audio_id, curr_video_id)
             }
             TopLevelPlaylist::DirectMedia(_) => (None, None, None),
         };
@@ -414,10 +414,14 @@ impl PlaylistStore {
 
     pub(crate) fn current_codec(&self, media_type: MediaType) -> Option<String> {
         match &self.playlist {
-            TopLevelPlaylist::Multivariant(_) => self
-                .curr_multivariant_media_info(media_type)
-                .map(|info| info.codec.clone())
-                .or_else(|| self.curr_variant()?.codecs(media_type)),
+            TopLevelPlaylist::Multivariant(_) => {
+                if !self.has_media_type(media_type) {
+                    return None;
+                }
+                self.curr_multivariant_media_info(media_type)
+                    .map(|info| info.codec.clone())
+                    .or_else(|| self.curr_variant()?.codecs(media_type))
+            }
             TopLevelPlaylist::DirectMedia(playlist) => playlist
                 .external_media_info()
                 .filter(|info| info.media_type == media_type)
@@ -427,13 +431,17 @@ impl PlaylistStore {
 
     pub(crate) fn current_mime_type(&self, media_type: MediaType) -> Option<String> {
         match &self.playlist {
-            TopLevelPlaylist::Multivariant(_) => self
-                .curr_multivariant_media_info(media_type)
-                .map(|info| info.mime_type.clone())
-                .or_else(|| {
-                    self.curr_media_playlist(media_type)
-                        .map(|playlist| playlist.mime_type(media_type).unwrap_or("").to_string())
-                }),
+            TopLevelPlaylist::Multivariant(_) => {
+                if !self.has_media_type(media_type) {
+                    return None;
+                }
+                self.curr_multivariant_media_info(media_type)
+                    .map(|info| info.mime_type.clone())
+                    .or_else(|| {
+                        self.curr_media_playlist(media_type)
+                            .map(|playlist| playlist.mime_type(media_type).unwrap_or("").to_string())
+                    })
+            }
             TopLevelPlaylist::DirectMedia(playlist) => playlist
                 .external_media_info()
                 .filter(|info| info.media_type == media_type)
@@ -970,12 +978,14 @@ impl PlaylistStore {
         self.clear_variant_supports();
 
         if let Some(variant) = self.curr_variant() {
-            let new_audio_id = match &self.playlist {
+            let raw_new_audio_id = match &self.playlist {
                 TopLevelPlaylist::Multivariant(playlist) => {
                     playlist.audio_media_playlist_id_for(variant, self.curr_audio_track)
                 }
                 TopLevelPlaylist::DirectMedia(_) => None,
             };
+            let (new_audio_id, _) =
+                Self::normalize_selected_media_ids(raw_new_audio_id, self.curr_video_id);
 
             if new_audio_id.is_none() && self.curr_audio_id.is_some() {
                 // We may be in a case where the choosen track is not available in the
@@ -1056,8 +1066,12 @@ impl PlaylistStore {
         };
         let variant = playlist.variant(variant_id).unwrap();
         self.curr_variant_id = Some(variant_id);
-        self.curr_video_id = playlist.video_media_playlist_id_for(variant);
-        self.curr_audio_id = playlist.audio_media_playlist_id_for(variant, self.curr_audio_track);
+        let (curr_audio_id, curr_video_id) = Self::normalize_selected_media_ids(
+            playlist.audio_media_playlist_id_for(variant, self.curr_audio_track),
+            playlist.video_media_playlist_id_for(variant),
+        );
+        self.curr_video_id = curr_video_id;
+        self.curr_audio_id = curr_audio_id;
         self.multivariant_support_resolved = false;
     }
 
@@ -1101,6 +1115,20 @@ impl PlaylistStore {
 
     fn set_variant_support(&mut self, variant_id: u32, supported: bool) {
         self.variant_support.insert(variant_id, supported);
+    }
+
+    fn normalize_selected_media_ids(
+        audio_id: Option<MediaPlaylistPermanentId>,
+        video_id: Option<MediaPlaylistPermanentId>,
+    ) -> (
+        Option<MediaPlaylistPermanentId>,
+        Option<MediaPlaylistPermanentId>,
+    ) {
+        if audio_id.is_some() && audio_id == video_id {
+            (None, video_id)
+        } else {
+            (audio_id, video_id)
+        }
     }
 
     fn curr_multivariant_media_info(&self, media_type: MediaType) -> Option<&DirectMediaInfo> {
@@ -1241,7 +1269,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_multivariant_playlist_reuses_probe_metadata_for_both_media_types() {
+    fn shared_multivariant_playlist_is_selected_as_video_only() {
         let multivariant = r#"#EXTM3U
 #EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aud",NAME="Main",DEFAULT=YES,AUTOSELECT=YES
 #EXT-X-STREAM-INF:BANDWIDTH=1000,AUDIO="aud"
@@ -1259,10 +1287,8 @@ seg.ts
         )
         .unwrap();
         let mut store = PlaylistStore::try_new(playlist, 10_000.).unwrap();
-        let shared_id = store
-            .curr_media_playlist_id(MediaType::Audio)
-            .cloned()
-            .unwrap();
+        assert_eq!(store.curr_media_playlist_id(MediaType::Audio), None);
+        let shared_id = *store.curr_media_playlist_id(MediaType::Video).unwrap();
         store
             .update_media_playlist(
                 &shared_id,
@@ -1272,21 +1298,18 @@ seg.ts
             .unwrap();
 
         store.set_multivariant_media_info(
-            MediaType::Audio,
+            MediaType::Video,
             DirectMediaInfo {
-                mime_type: "audio/mp4".to_string(),
-                media_type: MediaType::Audio,
-                codec: "mp4a.40.2".to_string(),
+                mime_type: "video/mp4".to_string(),
+                media_type: MediaType::Video,
+                codec: "avc1.4d401e,mp4a.40.2".to_string(),
             },
         );
 
-        assert_eq!(
-            store.current_codec(MediaType::Audio).as_deref(),
-            Some("mp4a.40.2")
-        );
+        assert_eq!(store.current_codec(MediaType::Audio), None);
         assert_eq!(
             store.current_codec(MediaType::Video).as_deref(),
-            Some("mp4a.40.2")
+            Some("avc1.4d401e,mp4a.40.2")
         );
     }
 }

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -509,7 +509,7 @@ impl PlaylistStore {
     pub(crate) fn set_direct_media_info(&mut self, media_info: DirectMediaInfo) {
         match &mut self.playlist {
             TopLevelPlaylist::DirectMedia(playlist) => {
-                let direct_media_id = playlist.id().clone();
+                let direct_media_id = *playlist.id();
                 match media_info.media_type {
                     MediaType::Audio => {
                         self.curr_audio_id = Some(direct_media_id);
@@ -540,10 +540,7 @@ impl PlaylistStore {
         let Some(wanted_id) = wanted_id else {
             return;
         };
-        let entry = self
-            .multivariant_media_info
-            .entry(wanted_id.clone())
-            .or_default();
+        let entry = self.multivariant_media_info.entry(*wanted_id).or_default();
         match media_type {
             MediaType::Audio => entry.audio = Some(media_info),
             MediaType::Video => entry.video = Some(media_info),
@@ -1036,8 +1033,8 @@ impl PlaylistStore {
         if Some(new_id) != self.curr_variant_id {
             let prev_bandwidth = self.curr_variant().map(|v| v.bandwidth());
             let new_bandwidth = playlist.variant(new_id).map(|v| v.bandwidth());
-            let prev_audio_id = self.curr_audio_id.clone();
-            let prev_video_id = self.curr_video_id.clone();
+            let prev_audio_id = self.curr_audio_id;
+            let prev_video_id = self.curr_video_id;
             self.set_curr_variant_and_media_id(new_id.to_owned());
 
             let mut updates = vec![];
@@ -1082,8 +1079,8 @@ impl PlaylistStore {
     }
 
     pub(crate) fn switch_startup_variant(&mut self, variant_id: u32) -> Vec<MediaType> {
-        let prev_audio_id = self.curr_audio_id.clone();
-        let prev_video_id = self.curr_video_id.clone();
+        let prev_audio_id = self.curr_audio_id;
+        let prev_video_id = self.curr_video_id;
         self.set_curr_variant_and_media_id(variant_id);
 
         let mut changed_media_types = Vec::new();
@@ -1296,7 +1293,10 @@ seg.ts
             },
         );
 
-        assert_eq!(store.current_codec(MediaType::Audio).as_deref(), Some("mp4a.40.2"));
+        assert_eq!(
+            store.current_codec(MediaType::Audio).as_deref(),
+            Some("mp4a.40.2")
+        );
         assert_eq!(store.current_codec(MediaType::Video), None);
         match store.startup_status(0.).unwrap() {
             StartupStatus::NeedsProbes(probes) => {

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -46,6 +46,12 @@ pub(crate) enum ProbeSegmentContext {
 /// playlists are supported, which can necessitate a segment request and other async API
 /// calls.
 pub(crate) enum StartupStatus {
+    /// The currently selected startup variant is unsupported and another one should be selected.
+    VariantSwitchNeeded { variant_id: u32 },
+    /// The currently-selected media playlists are not all loaded yet.
+    /// TODO: Allow segment fetching for already loaded playlists even if the other one
+    /// is still pending?
+    AwaitingPlaylists,
     /// A "probe segment" must be loaded and inspected for supplementary
     /// playlist information before playback can start.
     ///
@@ -60,12 +66,11 @@ pub(crate) enum StartupStatus {
     /// - `None` if the `MediaType` isn't known or is not important (e.g. Direct Media
     ///   Playlist cases)
     NeedsProbes(Vec<(ProbeSegmentMetadata, Option<MediaType>)>),
-    /// Codecs are currently in their way to be checked by the platform.
+    /// Codecs linked to the contents are known but are currently in their way to be
+    /// checked by the platform.
     ///
     /// Once known, it should be communicated back to the `PlaylistStore`.
     AwaitingSupportCheck,
-    /// The currently selected startup variant is unsupported and another one should be selected.
-    VariantSwitchNeeded { variant_id: u32 },
     /// The top level playlist can now be fully exploited for playback.
     Ready,
 }
@@ -379,13 +384,6 @@ impl PlaylistStore {
         self.curr_media_playlist(media_type).is_some()
     }
 
-    /// Returns `true` only if all media playlists currently selected have been loaded.
-    pub(crate) fn are_playlists_ready(&self) -> bool {
-        [MediaType::Audio, MediaType::Video]
-            .into_iter()
-            .all(|t| !self.has_media_type(t) || self.is_media_playlist_ready(t))
-    }
-
     /// Returns true if a MediaPlaylist for the given `MediaType` has been selected, regardless if
     /// that playlist has been loaded or not.
     pub(crate) fn has_media_type(&self, media_type: MediaType) -> bool {
@@ -471,6 +469,15 @@ impl PlaylistStore {
                 }
             }
             TopLevelPlaylist::Multivariant(_) => {
+                if [MediaType::Audio, MediaType::Video]
+                    .into_iter()
+                    .any(|media_type| {
+                        self.has_media_type(media_type)
+                            && self.curr_media_playlist(media_type).is_none()
+                    })
+                {
+                    return Ok(StartupStatus::AwaitingPlaylists);
+                }
                 let probe_requests = [MediaType::Audio, MediaType::Video]
                     .into_iter()
                     .filter(|media_type| {
@@ -1117,6 +1124,7 @@ impl PlaylistStore {
         self.variant_support.insert(variant_id, supported);
     }
 
+    // TODO: This method is kind of ugly. Better handle muxed Audio/Video identifiers
     fn normalize_selected_media_ids(
         audio_id: Option<MediaPlaylistPermanentId>,
         video_id: Option<MediaPlaylistPermanentId>,
@@ -1250,14 +1258,13 @@ pub(crate) enum PlaylistStoreError {
     NoInitialVariant,
     #[error("No probe segment was available to determine startup metadata")]
     NoProbeSegment,
-    // XXX TODO: We deleted MissingSelectedStreamMetadata. See if that broke the API contract
     #[error("No supported startup stream was found for the current content")]
     UnsupportedStartupStream,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::PlaylistStore;
+    use super::{PlaylistStore, PlaylistStoreError, StartupStatus};
     use crate::{
         bindings::MediaType,
         parser::{ExternalMediaInfo, TopLevelPlaylist},
@@ -1311,5 +1318,59 @@ seg.ts
             store.current_codec(MediaType::Video).as_deref(),
             Some("avc1.4d401e,mp4a.40.2")
         );
+    }
+
+    #[test]
+    fn startup_status_waits_for_selected_multivariant_playlists_to_load() {
+        let multivariant = r#"#EXTM3U
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aud",NAME="Main",DEFAULT=YES,AUTOSELECT=YES,URI="audio.m3u8"
+#EXT-X-STREAM-INF:BANDWIDTH=1000,AUDIO="aud"
+video.m3u8
+"#;
+
+        let playlist = TopLevelPlaylist::parse(
+            multivariant.as_bytes(),
+            parse_url("https://example.com/master.m3u8"),
+        )
+        .unwrap();
+        let mut store = PlaylistStore::try_new(playlist, 10_000.).unwrap();
+
+        assert!(store.curr_media_playlist_id(MediaType::Audio).is_some());
+        assert!(store.curr_media_playlist_id(MediaType::Video).is_some());
+        assert!(matches!(
+            store.startup_status(0.),
+            Ok(StartupStatus::AwaitingPlaylists)
+        ));
+    }
+
+    #[test]
+    fn startup_status_errors_when_loaded_multivariant_playlist_has_no_probe_segment() {
+        let multivariant = r#"#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=1000
+video.m3u8
+"#;
+        let empty_media = r#"#EXTM3U
+#EXT-X-TARGETDURATION:4
+"#;
+
+        let playlist = TopLevelPlaylist::parse(
+            multivariant.as_bytes(),
+            parse_url("https://example.com/master.m3u8"),
+        )
+        .unwrap();
+        let mut store = PlaylistStore::try_new(playlist, 10_000.).unwrap();
+        let video_id = *store.curr_media_playlist_id(MediaType::Video).unwrap();
+        store
+            .update_media_playlist(
+                &video_id,
+                empty_media.as_bytes(),
+                parse_url("https://example.com/video.m3u8"),
+            )
+            .unwrap();
+
+        assert!(matches!(
+            store.startup_status(0.),
+            Err(PlaylistStoreError::NoProbeSegment)
+        ));
     }
 }

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -51,7 +51,15 @@ pub(crate) enum StartupStatus {
     ///
     /// Once the supplementary information is extracted, is should be communicated to the
     /// `PlaylistStore` (e.g. through `set_direct_media_info`).
-    NeedsProbe(ProbeSegmentMetadata),
+    ///
+    /// The second value of that tuple is either:
+    ///
+    /// - `Some(media_type)` where `media_type` is the corresponding known media type of
+    ///   the corresponding active playlist.
+    ///
+    /// - `None` if the `MediaType` isn't known or is not important (e.g. Direct Media
+    ///   Playlist cases)
+    NeedsProbes(Vec<(ProbeSegmentMetadata, Option<MediaType>)>),
     /// Codecs are currently in their way to be checked by the platform.
     ///
     /// Once known, it should be communicated back to the `PlaylistStore`.
@@ -186,30 +194,91 @@ impl PlaylistStore {
             return Ok(true);
         }
 
-        let playlist = match &mut self.playlist {
+        let playlist = match &self.playlist {
             TopLevelPlaylist::Multivariant(playlist) => playlist,
             TopLevelPlaylist::DirectMedia(_) => {
                 return Ok(true);
             }
         };
 
-        let mut is_multivariant_support_resolved = true;
-        playlist.variants_mut().iter_mut().for_each(|v| {
-            if v.supported().is_some() {
-                return;
-            }
-            [MediaType::Video, MediaType::Audio]
-                .into_iter()
-                .for_each(|mt| {
-                    if let Some(codec) = v.codecs(mt) {
-                        if let Some(is_supported) = jsIsTypeSupported(mt, &codec) {
-                            v.update_support(is_supported);
+        let curr_variant_id = self.curr_variant_id;
+        let inferred_audio_codec = self
+            .curr_media_playlist(MediaType::Audio)
+            .and_then(|p| p.external_media_info())
+            .map(|i| i.codec.clone());
+        let inferred_video_codec = self
+            .curr_media_playlist(MediaType::Video)
+            .and_then(|p| p.external_media_info())
+            .map(|i| i.codec.clone());
+
+        // For each variant, in order:
+        // - Some(true) -> Codec is known to be supported
+        // - Some(false) -> Codec is known to be unsupported
+        // - None -> We don't know yet
+        let variants_support: Vec<Option<bool>> = playlist
+            .all_variants()
+            .iter()
+            .map(|v| -> Result<Option<bool>, PlaylistStoreError> {
+                // If support was already determined for this variant, reuse it.
+                if let Some(supported) = v.supported() {
+                    return Ok(Some(supported));
+                }
+
+                let mut variant_is_supported = false;
+                for mt in [MediaType::Video, MediaType::Audio] {
+                    // Try to get the codec from the variant directly, falling back to
+                    // the inferred codec if this is the current variant.
+                    let codec = v.codecs(mt).or_else(|| {
+                        if Some(v.id()) == curr_variant_id {
+                            match mt {
+                                MediaType::Audio => inferred_audio_codec.clone(),
+                                MediaType::Video => inferred_video_codec.clone(),
+                            }
                         } else {
-                            is_multivariant_support_resolved = false;
+                            None
+                        }
+                    });
+
+                    if let Some(codec) = codec {
+                        match jsIsTypeSupported(mt, &codec) {
+                            // Codec is explicitly unsupported: the whole variant is out.
+                            Some(false) => return Ok(Some(false)),
+                            // Codec is supported: keep going.
+                            Some(true) => variant_is_supported = true,
+                            // Support cannot be determined yet: signal unresolved and bail.
+                            None => return Ok(None),
                         }
                     }
-                });
-        });
+                }
+
+                Ok(variant_is_supported.then_some(true)) // `None` if no codec is known
+            })
+            .collect::<Result<Vec<_>, PlaylistStoreError>>()?;
+
+        let playlist = match &mut self.playlist {
+            TopLevelPlaylist::Multivariant(playlist) => playlist,
+            TopLevelPlaylist::DirectMedia(_) => unreachable!(),
+        };
+
+        let is_multivariant_support_resolved = !variants_support.contains(&None);
+
+        // Re-iterate, now mutably
+        // NOTE: `all_variants()` and `variants_mut()` return variants in the same order;
+        // `zip` here relies on that invariant.
+        playlist
+            .variants_mut()
+            .iter_mut()
+            .zip(variants_support)
+            .for_each(|(v, support)| {
+                if v.supported().is_some() {
+                    return;
+                }
+                if let Some(support) = support {
+                    v.update_support(support);
+                }
+            });
+
+        // If any variant returned None, multi-variant support is not yet resolved.
         self.multivariant_support_resolved = is_multivariant_support_resolved;
 
         if is_multivariant_support_resolved {
@@ -323,9 +392,13 @@ impl PlaylistStore {
 
     pub(crate) fn current_codec(&self, media_type: MediaType) -> Option<String> {
         match &self.playlist {
-            TopLevelPlaylist::Multivariant(_) => self.curr_variant()?.codecs(media_type),
+            TopLevelPlaylist::Multivariant(_) => self
+                .curr_media_playlist(media_type)
+                .and_then(|playlist| playlist.external_media_info())
+                .map(|info| info.codec.clone())
+                .or_else(|| self.curr_variant()?.codecs(media_type)),
             TopLevelPlaylist::DirectMedia(playlist) => playlist
-                .media_info()
+                .external_media_info()
                 .filter(|info| info.media_type == media_type)
                 .map(|info| info.codec.clone()),
         }
@@ -335,9 +408,14 @@ impl PlaylistStore {
         match &self.playlist {
             TopLevelPlaylist::Multivariant(_) => self
                 .curr_media_playlist(media_type)
-                .map(|playlist| playlist.mime_type(media_type).unwrap_or("").to_string()),
+                .and_then(|playlist| playlist.external_media_info())
+                .map(|info| info.mime_type.clone())
+                .or_else(|| {
+                    self.curr_media_playlist(media_type)
+                        .map(|playlist| playlist.mime_type(media_type).unwrap_or("").to_string())
+                }),
             TopLevelPlaylist::DirectMedia(playlist) => playlist
-                .media_info()
+                .external_media_info()
                 .filter(|info| info.media_type == media_type)
                 .map(|info| info.mime_type.clone()),
         }
@@ -354,28 +432,37 @@ impl PlaylistStore {
     ) -> Result<StartupStatus, PlaylistStoreError> {
         match &self.playlist {
             TopLevelPlaylist::DirectMedia(playlist) => {
-                if playlist.media_info().is_none() {
+                if playlist.external_media_info().is_none() {
                     return self
                         .next_direct_media_probe(wanted_position)
-                        .map(StartupStatus::NeedsProbe)
+                        .map(|probe_segment| {
+                            StartupStatus::NeedsProbes(vec![(probe_segment, None)])
+                        })
                         .ok_or(PlaylistStoreError::NoProbeSegment);
                 }
             }
             TopLevelPlaylist::Multivariant(_) => {
-                if [MediaType::Audio, MediaType::Video]
+                let probe_requests = [MediaType::Audio, MediaType::Video]
                     .into_iter()
-                    .any(|media_type| {
-                        self.has_media_type(media_type) && self.current_codec(media_type).is_none()
+                    .filter(|media_type| {
+                        self.has_media_type(*media_type)
+                            && self.current_codec(*media_type).is_none()
                     })
-                {
-                    return Err(PlaylistStoreError::MissingSelectedStreamMetadata);
+                    .map(|media_type| {
+                        self.next_media_playlist_probe(media_type, wanted_position)
+                            .map(|probe_segment| (probe_segment, Some(media_type)))
+                    })
+                    .collect::<Option<Vec<_>>>()
+                    .ok_or(PlaylistStoreError::NoProbeSegment)?;
+                if !probe_requests.is_empty() {
+                    return Ok(StartupStatus::NeedsProbes(probe_requests));
                 }
             }
         }
 
         match &self.playlist {
             TopLevelPlaylist::DirectMedia(playlist) => {
-                let media_info = playlist.media_info().unwrap();
+                let media_info = playlist.external_media_info().unwrap();
                 match jsIsTypeSupported(media_info.media_type, &media_info.codec) {
                     Some(true) => Ok(StartupStatus::Ready),
                     Some(false) => Err(PlaylistStoreError::UnsupportedStartupStream),
@@ -403,24 +490,64 @@ impl PlaylistStore {
                         self.curr_video_id = Some(direct_media_id);
                     }
                 }
-                playlist.set_media_info(media_info);
+                playlist.set_external_media_info(media_info);
             }
             TopLevelPlaylist::Multivariant(_) => {}
         }
     }
 
-    /// Returns probe segment metadata associated to the `wanted_position` if it exists.
+    // XXX TODO: Maybe this can be merged with the direct media one? We have enough
+    // context here
+    pub(crate) fn set_multivariant_media_info(
+        &mut self,
+        media_type: MediaType,
+        media_info: DirectMediaInfo,
+    ) {
+        let wanted_id = match media_type {
+            MediaType::Audio => self.curr_audio_id.as_ref(),
+            MediaType::Video => self.curr_video_id.as_ref(),
+        };
+        let (Some(wanted_id), TopLevelPlaylist::Multivariant(playlist)) =
+            (wanted_id, &mut self.playlist)
+        else {
+            return;
+        };
+        if let Some(media_playlist) = playlist.media_playlist_mut(wanted_id) {
+            media_playlist.set_external_media_info(media_info);
+        }
+    }
+
+    /// Returns probe segment metadata for a direct Media Playlist associated to
+    /// the `wanted_position` if it exists.
     fn next_direct_media_probe(&self, wanted_position: f64) -> Option<ProbeSegmentMetadata> {
         let playlist = match &self.playlist {
-            TopLevelPlaylist::DirectMedia(playlist) => playlist,
+            TopLevelPlaylist::DirectMedia(playlist) => playlist.playlist(),
             TopLevelPlaylist::Multivariant(_) => return None,
         };
+        Self::probe_for_media_playlist(playlist, wanted_position)
+    }
+
+    /// Returns probe segment metadata for a non-direct Media Playlist associated to
+    /// the `wanted_position` if it exists.
+    fn next_media_playlist_probe(
+        &self,
+        media_type: MediaType,
+        wanted_position: f64,
+    ) -> Option<ProbeSegmentMetadata> {
+        let playlist = self.curr_media_playlist(media_type)?;
+        Self::probe_for_media_playlist(playlist, wanted_position)
+    }
+
+    /// Get probe segment for the given media playlist and preferred position.
+    fn probe_for_media_playlist(
+        playlist: &MediaPlaylist,
+        wanted_position: f64,
+    ) -> Option<ProbeSegmentMetadata> {
         let media_segment = playlist
-            .playlist()
             .segment_list()
             .segment_from_pos(wanted_position)
-            .or_else(|| playlist.playlist().segment_list().media().first())?;
-        if let Some(init_segment) = playlist.playlist().segment_list().init_for(media_segment) {
+            .or_else(|| playlist.segment_list().media().first())?;
+        if let Some(init_segment) = playlist.segment_list().init_for(media_segment) {
             Some(ProbeSegmentMetadata {
                 url: init_segment.url().clone(),
                 byte_range: init_segment.byte_range().cloned(),
@@ -992,8 +1119,7 @@ pub(crate) enum PlaylistStoreError {
     NoInitialVariant,
     #[error("No probe segment was available to determine startup metadata")]
     NoProbeSegment,
-    #[error("The selected startup streams lack enough metadata to resolve support")]
-    MissingSelectedStreamMetadata,
+    // XXX TODO: We deleted MissingSelectedStreamMetadata. See if that broke the API contract
     #[error("No supported startup stream was found for the current content")]
     UnsupportedStartupStream,
 }

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -128,9 +128,13 @@ pub(crate) struct PlaylistStore {
     multivariant_support_resolved: bool,
 
     /// Runtime support cache for variants in the current multivariant playlist.
+    /// Key is the variant id, bool is `true` if supported, `false` if not.
     variant_support: HashMap<u32, bool>,
 
     /// Probe metadata inferred for currently known multivariant media playlists.
+    /// XXX TODO: If it's per-media playlist, why would it be needed to separate audio and
+    /// video? Aren't both in the same segment anyway? In that case, isn't `isTypeSupported` and
+    /// `addSourceBuffer` supposed to accept both at once?
     multivariant_media_info: HashMap<MediaPlaylistPermanentId, ProbedMediaInfo>,
 }
 

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -109,8 +109,8 @@ pub(crate) struct PlaylistStore {
     /// Before actually playing a multivariant content, supported codecs need to be checked
     /// to avoid mistakenly choosing an unsupported variant.
     ///
-    /// This bool is set to `true` only once ALL variants in the
-    /// `MultivariantPlaylist` have had their support resolved.
+    /// This bool is set to `true` once the currently selected media has had its support
+    /// resolved.
     multivariant_support_resolved: bool,
 }
 
@@ -129,6 +129,7 @@ impl PlaylistStore {
         let (curr_variant_id, curr_audio_id, curr_video_id) = match &playlist {
             TopLevelPlaylist::Multivariant(playlist) => {
                 let variants = playlist.all_variants();
+
                 let initial_variant = if let Some(variant_id) =
                     best_variant_id(variants.iter(), initial_bandwidth)
                 {
@@ -140,6 +141,7 @@ impl PlaylistStore {
                     Logger::error("PS: Found no variant in the given MultivariantPlaylist");
                     return Err(PlaylistStoreError::NoInitialVariant);
                 };
+
                 (
                     Some(initial_variant.id()),
                     playlist.audio_media_playlist_id_for(initial_variant, None),
@@ -216,7 +218,7 @@ impl PlaylistStore {
             }
         };
 
-        let mut all_resolved = true;
+        let mut current_variant_resolved = true;
         'variant: for v in playlist.variants_mut().iter_mut() {
             // If support was already determined for this variant, reuse it.
             if v.supported().is_some() {
@@ -246,7 +248,7 @@ impl PlaylistStore {
                             MediaType::Video => curr_video_required,
                         };
                     if media_required {
-                        all_resolved = false;
+                        current_variant_resolved = false;
                         continue 'variant;
                     }
                     continue;
@@ -260,7 +262,9 @@ impl PlaylistStore {
                     }
                     Some(true) => variant_is_supported = true,
                     None => {
-                        all_resolved = false;
+                        if is_current_variant {
+                            current_variant_resolved = false;
+                        }
                         continue 'variant;
                     }
                 }
@@ -268,35 +272,38 @@ impl PlaylistStore {
 
             if variant_is_supported {
                 v.update_support(true);
-            } else if !saw_codec {
-                all_resolved = false;
+            } else if is_current_variant && !saw_codec {
+                current_variant_resolved = false;
             }
         }
 
-        // If any variant returned None, multi-variant support is not yet resolved.
-        is_multivariant_support_resolved = all_resolved;
+        let curr_variant_id = self.curr_variant_id.unwrap();
+        let curr_variant_support = playlist
+            .variant(curr_variant_id)
+            .and_then(|v| v.supported());
+
+        if curr_variant_support == Some(false) {
+            if let Some(variant_id) = self.next_best_variant_id() {
+                // XXX TODO: No variantUpdate event triggered when we do that here... We should
+                // probably return the issue to the dispatcher instead?
+                self.set_curr_variant_and_media_id(variant_id);
+                self.multivariant_support_resolved = false;
+                return Ok(false);
+            } else {
+                Logger::error("PS: No supported variant in the given MultivariantPlaylist");
+                return Err(PlaylistStoreError::NoSupportedVariant);
+            }
+        }
+
+        is_multivariant_support_resolved =
+            current_variant_resolved && curr_variant_support == Some(true);
 
         self.multivariant_support_resolved = is_multivariant_support_resolved;
 
         if is_multivariant_support_resolved {
-            Logger::info("PS: Support has been resolved for all multivariant variants");
-            let curr_variant_id = self.curr_variant_id.unwrap();
-            let curr_variant_still_here = playlist
-                .supported_variants()
-                .iter()
-                .any(|v| v.id() == curr_variant_id);
-
-            if !curr_variant_still_here {
-                let new_variant_id = playlist.supported_variants().first().map(|v| v.id());
-                if let Some(variant_id) = new_variant_id {
-                    self.set_curr_variant_and_media_id(variant_id);
-                } else {
-                    Logger::error("PS: No supported variant in the given MultivariantPlaylist");
-                    return Err(PlaylistStoreError::NoSupportedVariant);
-                }
-            }
+            Logger::info("PS: Support has been resolved for the current multivariant startup path");
         } else {
-            Logger::info("PS: Some multivariant variants still need asynchronous support checks");
+            Logger::info("PS: Current multivariant startup path still needs support resolution");
         }
         Ok(is_multivariant_support_resolved)
     }
@@ -565,6 +572,19 @@ impl PlaylistStore {
         }
     }
 
+    /// Returns vec describing all variant streams in the current `MultivariantPlaylist`,
+    /// excluding variants known to be unsupported.
+    pub(crate) fn available_variants(&self) -> Vec<&VariantStream> {
+        match &self.playlist {
+            TopLevelPlaylist::Multivariant(playlist) => playlist
+                .all_variants()
+                .iter()
+                .filter(|v| v.supported() != Some(false))
+                .collect(),
+            TopLevelPlaylist::DirectMedia(_) => vec![],
+        }
+    }
+
     /// Returns vec describing all available variant streams in the current MultivariantPlaylist.
     pub(crate) fn supported_variants(&self) -> Vec<&VariantStream> {
         match &self.playlist {
@@ -573,16 +593,31 @@ impl PlaylistStore {
         }
     }
 
-    /// Returns vec describing all available variant streams in the current MultivariantPlaylist.
-    pub(crate) fn variants_for_curr_track(&self) -> Vec<&VariantStream> {
+    /// Returns vec describing all non-rejected variants compatible with the current track choice.
+    fn selectable_variants_for_curr_track(&self) -> Vec<&VariantStream> {
         match &self.playlist {
             TopLevelPlaylist::Multivariant(playlist) => {
                 if let Some(track_id) = self.curr_audio_track {
-                    playlist.supported_variants_for_audio(track_id)
+                    // There's an explicitly set audio track id, get variants linked to it
+                    playlist
+                        .variants_for_audio(track_id)
+                        .into_iter()
+                        .filter(|v| v.supported() != Some(false))
+                        .collect()
                 } else if let Some(track_id) = self.curr_audio_track_id() {
-                    playlist.supported_variants_for_audio(track_id)
+                    // Else do in function of the current audio track
+                    playlist
+                        .variants_for_audio(track_id)
+                        .into_iter()
+                        .filter(|v| v.supported() != Some(false))
+                        .collect()
                 } else {
-                    playlist.supported_variants()
+                    // No current audio track: choose from anything
+                    playlist
+                        .all_variants()
+                        .iter()
+                        .filter(|v| v.supported() != Some(false))
+                        .collect()
                 }
             }
             TopLevelPlaylist::DirectMedia(_) => vec![],
@@ -695,7 +730,7 @@ impl PlaylistStore {
         if self.curr_variant_id.is_none() {
             return LockVariantResponse::NoVariantWithId;
         }
-        let variants = self.supported_variants();
+        let variants = self.selectable_variants_for_curr_track();
         let pos = variants.iter().find(|x| x.id() == variant_id);
 
         if pos.is_some() {
@@ -911,6 +946,7 @@ impl PlaylistStore {
             return SetAudioTrackResponse::NoUpdate;
         }
         self.curr_audio_track = track_id;
+        self.clear_variant_supports();
 
         if let Some(variant) = self.curr_variant() {
             let new_audio_id = match &self.playlist {
@@ -950,13 +986,14 @@ impl PlaylistStore {
         let new_id = if let Some(id) = variant_id {
             id
         } else {
-            let wanted_variants = self.variants_for_curr_track();
+            let wanted_variants = self.selectable_variants_for_curr_track();
             if let Some(id) = best_variant_id(wanted_variants.into_iter(), self.last_bandwidth) {
                 id
-            } else if let Some(id) = fallback_variant_id(self.variants_for_curr_track().into_iter())
+            } else if let Some(id) =
+                fallback_variant_id(self.selectable_variants_for_curr_track().into_iter())
             {
                 Logger::info(
-                    "PS: Found no bandwidth-compatible variant amongst supported variants",
+                    "PS: Found no bandwidth-compatible variant amongst selectable variants",
                 );
                 id
             } else {
@@ -1000,6 +1037,29 @@ impl PlaylistStore {
         self.curr_variant_id = Some(variant_id);
         self.curr_video_id = playlist.video_media_playlist_id_for(variant);
         self.curr_audio_id = playlist.audio_media_playlist_id_for(variant, self.curr_audio_track);
+        self.multivariant_support_resolved = false;
+    }
+
+    fn clear_variant_supports(&mut self) {
+        let TopLevelPlaylist::Multivariant(playlist) = &mut self.playlist else {
+            return;
+        };
+        playlist
+            .variants_mut()
+            .iter_mut()
+            .for_each(VariantStream::clear_support);
+        self.multivariant_support_resolved = false;
+    }
+
+    fn next_best_variant_id(&self) -> Option<u32> {
+        if let Some(id) = best_variant_id(
+            self.selectable_variants_for_curr_track().into_iter(),
+            self.last_bandwidth,
+        ) {
+            Some(id)
+        } else {
+            fallback_variant_id(self.selectable_variants_for_curr_track().into_iter())
+        }
     }
 }
 

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -76,12 +76,6 @@ enum MultivariantStartupStatus {
     Ready,
 }
 
-#[derive(Default)]
-struct ProbedMediaInfo {
-    audio: Option<DirectMediaInfo>,
-    video: Option<DirectMediaInfo>,
-}
-
 /// Stores information about the current loaded Multivariant Playlist and its sub-playlists:
 ///   - Information on the Multivariant Playlist itself.
 ///   - On the current variant selected.
@@ -132,10 +126,7 @@ pub(crate) struct PlaylistStore {
     variant_support: HashMap<u32, bool>,
 
     /// Probe metadata inferred for currently known multivariant media playlists.
-    /// XXX TODO: If it's per-media playlist, why would it be needed to separate audio and
-    /// video? Aren't both in the same segment anyway? In that case, isn't `isTypeSupported` and
-    /// `addSourceBuffer` supposed to accept both at once?
-    multivariant_media_info: HashMap<MediaPlaylistPermanentId, ProbedMediaInfo>,
+    multivariant_media_info: HashMap<MediaPlaylistPermanentId, DirectMediaInfo>,
 }
 
 impl PlaylistStore {
@@ -544,11 +535,7 @@ impl PlaylistStore {
         let Some(wanted_id) = wanted_id else {
             return;
         };
-        let entry = self.multivariant_media_info.entry(*wanted_id).or_default();
-        match media_type {
-            MediaType::Audio => entry.audio = Some(media_info),
-            MediaType::Video => entry.video = Some(media_info),
-        }
+        self.multivariant_media_info.insert(*wanted_id, media_info);
     }
 
     /// Returns probe segment metadata for a direct Media Playlist associated to
@@ -1118,11 +1105,7 @@ impl PlaylistStore {
 
     fn curr_multivariant_media_info(&self, media_type: MediaType) -> Option<&DirectMediaInfo> {
         let playlist_id = self.curr_media_playlist_id(media_type)?;
-        let info = self.multivariant_media_info.get(playlist_id)?;
-        match media_type {
-            MediaType::Audio => info.audio.as_ref(),
-            MediaType::Video => info.video.as_ref(),
-        }
+        self.multivariant_media_info.get(playlist_id)
     }
 }
 
@@ -1246,7 +1229,7 @@ pub(crate) enum PlaylistStoreError {
 
 #[cfg(test)]
 mod tests {
-    use super::{PlaylistStore, StartupStatus};
+    use super::PlaylistStore;
     use crate::{
         bindings::MediaType,
         parser::{DirectMediaInfo, TopLevelPlaylist},
@@ -1258,7 +1241,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_multivariant_playlist_keeps_probe_metadata_per_media_type() {
+    fn shared_multivariant_playlist_reuses_probe_metadata_for_both_media_types() {
         let multivariant = r#"#EXTM3U
 #EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aud",NAME="Main",DEFAULT=YES,AUTOSELECT=YES
 #EXT-X-STREAM-INF:BANDWIDTH=1000,AUDIO="aud"
@@ -1301,13 +1284,9 @@ seg.ts
             store.current_codec(MediaType::Audio).as_deref(),
             Some("mp4a.40.2")
         );
-        assert_eq!(store.current_codec(MediaType::Video), None);
-        match store.startup_status(0.).unwrap() {
-            StartupStatus::NeedsProbes(probes) => {
-                assert_eq!(probes.len(), 1);
-                assert_eq!(probes[0].1, Some(MediaType::Video));
-            }
-            _ => panic!("expected a remaining video probe"),
-        }
+        assert_eq!(
+            store.current_codec(MediaType::Video).as_deref(),
+            Some("mp4a.40.2")
+        );
     }
 }

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     utils::url::Url,
     Logger,
 };
-use std::{cmp::Ordering, io::BufRead};
+use std::{cmp::Ordering, collections::HashMap, io::BufRead};
 
 use crate::parser::ByteRange;
 pub(crate) use crate::parser::MediaPlaylistPermanentId;
@@ -112,6 +112,9 @@ pub(crate) struct PlaylistStore {
     /// This bool is set to `true` once the currently selected media has had its support
     /// resolved.
     multivariant_support_resolved: bool,
+
+    /// Runtime support cache for variants in the current multivariant playlist.
+    variant_support: HashMap<u32, bool>,
 }
 
 impl PlaylistStore {
@@ -160,6 +163,7 @@ impl PlaylistStore {
             is_variant_locked: false,
             last_bandwidth: 0.,
             multivariant_support_resolved: false,
+            variant_support: HashMap::new(),
         })
     }
 
@@ -210,8 +214,7 @@ impl PlaylistStore {
 
         let is_multivariant_support_resolved;
 
-        // Borrow playlist immutably first to get the mutable reference after
-        let playlist = match &mut self.playlist {
+        let playlist = match &self.playlist {
             TopLevelPlaylist::Multivariant(playlist) => playlist,
             TopLevelPlaylist::DirectMedia(_) => {
                 return Ok(true);
@@ -219,9 +222,10 @@ impl PlaylistStore {
         };
 
         let mut current_variant_resolved = true;
-        'variant: for v in playlist.variants_mut().iter_mut() {
+        let mut support_updates = Vec::new();
+        'variant: for v in playlist.all_variants() {
             // If support was already determined for this variant, reuse it.
-            if v.supported().is_some() {
+            if self.variant_support(v.id()).is_some() {
                 continue;
             }
 
@@ -257,7 +261,7 @@ impl PlaylistStore {
 
                 match jsIsTypeSupported(mt, &codec) {
                     Some(false) => {
-                        v.update_support(false);
+                        support_updates.push((v.id(), false));
                         continue 'variant;
                     }
                     Some(true) => variant_is_supported = true,
@@ -271,16 +275,18 @@ impl PlaylistStore {
             }
 
             if variant_is_supported {
-                v.update_support(true);
+                support_updates.push((v.id(), true));
             } else if is_current_variant && !saw_codec {
                 current_variant_resolved = false;
             }
         }
 
+        support_updates
+            .into_iter()
+            .for_each(|(variant_id, supported)| self.set_variant_support(variant_id, supported));
+
         let curr_variant_id = self.curr_variant_id.unwrap();
-        let curr_variant_support = playlist
-            .variant(curr_variant_id)
-            .and_then(|v| v.supported());
+        let curr_variant_support = self.variant_support(curr_variant_id);
 
         if curr_variant_support == Some(false) {
             if let Some(variant_id) = self.next_best_variant_id() {
@@ -579,7 +585,7 @@ impl PlaylistStore {
             TopLevelPlaylist::Multivariant(playlist) => playlist
                 .all_variants()
                 .iter()
-                .filter(|v| v.supported() != Some(false))
+                .filter(|v| self.variant_support(v.id()) != Some(false))
                 .collect(),
             TopLevelPlaylist::DirectMedia(_) => vec![],
         }
@@ -588,7 +594,11 @@ impl PlaylistStore {
     /// Returns vec describing all available variant streams in the current MultivariantPlaylist.
     pub(crate) fn supported_variants(&self) -> Vec<&VariantStream> {
         match &self.playlist {
-            TopLevelPlaylist::Multivariant(playlist) => playlist.supported_variants(),
+            TopLevelPlaylist::Multivariant(playlist) => playlist
+                .all_variants()
+                .iter()
+                .filter(|v| self.variant_support(v.id()) == Some(true))
+                .collect(),
             TopLevelPlaylist::DirectMedia(_) => vec![],
         }
     }
@@ -602,21 +612,21 @@ impl PlaylistStore {
                     playlist
                         .variants_for_audio(track_id)
                         .into_iter()
-                        .filter(|v| v.supported() != Some(false))
+                        .filter(|v| self.variant_support(v.id()) != Some(false))
                         .collect()
                 } else if let Some(track_id) = self.curr_audio_track_id() {
                     // Else do in function of the current audio track
                     playlist
                         .variants_for_audio(track_id)
                         .into_iter()
-                        .filter(|v| v.supported() != Some(false))
+                        .filter(|v| self.variant_support(v.id()) != Some(false))
                         .collect()
                 } else {
                     // No current audio track: choose from anything
                     playlist
                         .all_variants()
                         .iter()
-                        .filter(|v| v.supported() != Some(false))
+                        .filter(|v| self.variant_support(v.id()) != Some(false))
                         .collect()
                 }
             }
@@ -1041,13 +1051,10 @@ impl PlaylistStore {
     }
 
     fn clear_variant_supports(&mut self) {
-        let TopLevelPlaylist::Multivariant(playlist) = &mut self.playlist else {
+        let TopLevelPlaylist::Multivariant(_) = &self.playlist else {
             return;
         };
-        playlist
-            .variants_mut()
-            .iter_mut()
-            .for_each(VariantStream::clear_support);
+        self.variant_support.clear();
         self.multivariant_support_resolved = false;
     }
 
@@ -1060,6 +1067,14 @@ impl PlaylistStore {
         } else {
             fallback_variant_id(self.selectable_variants_for_curr_track().into_iter())
         }
+    }
+
+    fn variant_support(&self, variant_id: u32) -> Option<bool> {
+        self.variant_support.get(&variant_id).copied()
+    }
+
+    fn set_variant_support(&mut self, variant_id: u32, supported: bool) {
+        self.variant_support.insert(variant_id, supported);
     }
 }
 

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     bindings::{jsIsTypeSupported, MediaType, PlaylistNature},
     media_element::SegmentQualityContext,
     parser::{
-        AudioTrack, DirectMediaInfo, MediaPlaylist, MediaPlaylistUpdateError, SegmentList,
+        AudioTrack, ExternalMediaInfo, MediaPlaylist, MediaPlaylistUpdateError, SegmentList,
         SegmentTimeInfo, TopLevelPlaylist, VariantStream,
     },
     utils::url::Url,
@@ -50,7 +50,7 @@ pub(crate) enum StartupStatus {
     /// playlist information before playback can start.
     ///
     /// Once the supplementary information is extracted, is should be communicated to the
-    /// `PlaylistStore` (e.g. through `set_direct_media_info`).
+    /// `PlaylistStore` (e.g. through `set_external_media_info`).
     ///
     /// The second value of that tuple is either:
     ///
@@ -126,7 +126,7 @@ pub(crate) struct PlaylistStore {
     variant_support: HashMap<u32, bool>,
 
     /// Probe metadata inferred for currently known multivariant media playlists.
-    multivariant_media_info: HashMap<MediaPlaylistPermanentId, DirectMediaInfo>,
+    multivariant_media_info: HashMap<MediaPlaylistPermanentId, ExternalMediaInfo>,
 }
 
 impl PlaylistStore {
@@ -438,8 +438,9 @@ impl PlaylistStore {
                 self.curr_multivariant_media_info(media_type)
                     .map(|info| info.mime_type.clone())
                     .or_else(|| {
-                        self.curr_media_playlist(media_type)
-                            .map(|playlist| playlist.mime_type(media_type).unwrap_or("").to_string())
+                        self.curr_media_playlist(media_type).map(|playlist| {
+                            playlist.mime_type(media_type).unwrap_or("").to_string()
+                        })
                     })
             }
             TopLevelPlaylist::DirectMedia(playlist) => playlist
@@ -509,11 +510,17 @@ impl PlaylistStore {
         }
     }
 
-    pub(crate) fn set_direct_media_info(&mut self, media_info: DirectMediaInfo) {
+    /// Communicate back precise information probed from a probe segment alongside the `MediaType`
+    /// concerned.
+    pub(crate) fn set_external_media_info(
+        &mut self,
+        media_info: ExternalMediaInfo,
+        media_type: MediaType,
+    ) {
         match &mut self.playlist {
             TopLevelPlaylist::DirectMedia(playlist) => {
                 let direct_media_id = *playlist.id();
-                match media_info.media_type {
+                match media_type {
                     MediaType::Audio => {
                         self.curr_audio_id = Some(direct_media_id);
                         self.curr_video_id = None;
@@ -525,25 +532,18 @@ impl PlaylistStore {
                 }
                 playlist.set_external_media_info(media_info);
             }
-            TopLevelPlaylist::Multivariant(_) => {}
-        }
-    }
+            TopLevelPlaylist::Multivariant(_) => {
+                let wanted_id = match media_type {
+                    MediaType::Audio => self.curr_audio_id.as_ref(),
+                    MediaType::Video => self.curr_video_id.as_ref(),
+                };
 
-    // XXX TODO: Maybe this can be merged with the direct media one? We have enough
-    // context here
-    pub(crate) fn set_multivariant_media_info(
-        &mut self,
-        media_type: MediaType,
-        media_info: DirectMediaInfo,
-    ) {
-        let wanted_id = match media_type {
-            MediaType::Audio => self.curr_audio_id.as_ref(),
-            MediaType::Video => self.curr_video_id.as_ref(),
-        };
-        let Some(wanted_id) = wanted_id else {
-            return;
-        };
-        self.multivariant_media_info.insert(*wanted_id, media_info);
+                let Some(wanted_id) = wanted_id else {
+                    return; // There's no track choosen for that type
+                };
+                self.multivariant_media_info.insert(*wanted_id, media_info);
+            }
+        }
     }
 
     /// Returns probe segment metadata for a direct Media Playlist associated to
@@ -1131,7 +1131,7 @@ impl PlaylistStore {
         }
     }
 
-    fn curr_multivariant_media_info(&self, media_type: MediaType) -> Option<&DirectMediaInfo> {
+    fn curr_multivariant_media_info(&self, media_type: MediaType) -> Option<&ExternalMediaInfo> {
         let playlist_id = self.curr_media_playlist_id(media_type)?;
         self.multivariant_media_info.get(playlist_id)
     }
@@ -1260,7 +1260,7 @@ mod tests {
     use super::PlaylistStore;
     use crate::{
         bindings::MediaType,
-        parser::{DirectMediaInfo, TopLevelPlaylist},
+        parser::{ExternalMediaInfo, TopLevelPlaylist},
         utils::url::Url,
     };
 
@@ -1297,13 +1297,13 @@ seg.ts
             )
             .unwrap();
 
-        store.set_multivariant_media_info(
-            MediaType::Video,
-            DirectMediaInfo {
+        store.set_external_media_info(
+            ExternalMediaInfo {
                 mime_type: "video/mp4".to_string(),
                 media_type: MediaType::Video,
                 codec: "avc1.4d401e,mp4a.40.2".to_string(),
             },
+            MediaType::Video,
         );
 
         assert_eq!(store.current_codec(MediaType::Audio), None);

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -64,8 +64,22 @@ pub(crate) enum StartupStatus {
     ///
     /// Once known, it should be communicated back to the `PlaylistStore`.
     AwaitingSupportCheck,
+    /// The currently selected startup variant is unsupported and another one should be selected.
+    VariantSwitchNeeded { variant_id: u32 },
     /// The top level playlist can now be fully exploited for playback.
     Ready,
+}
+
+enum MultivariantStartupStatus {
+    AwaitingSupportCheck,
+    VariantSwitchNeeded { variant_id: u32 },
+    Ready,
+}
+
+#[derive(Default)]
+struct ProbedMediaInfo {
+    audio: Option<DirectMediaInfo>,
+    video: Option<DirectMediaInfo>,
 }
 
 /// Stores information about the current loaded Multivariant Playlist and its sub-playlists:
@@ -115,6 +129,9 @@ pub(crate) struct PlaylistStore {
 
     /// Runtime support cache for variants in the current multivariant playlist.
     variant_support: HashMap<u32, bool>,
+
+    /// Probe metadata inferred for currently known multivariant media playlists.
+    multivariant_media_info: HashMap<MediaPlaylistPermanentId, ProbedMediaInfo>,
 }
 
 impl PlaylistStore {
@@ -164,6 +181,7 @@ impl PlaylistStore {
             last_bandwidth: 0.,
             multivariant_support_resolved: false,
             variant_support: HashMap::new(),
+            multivariant_media_info: HashMap::new(),
         })
     }
 
@@ -195,29 +213,27 @@ impl PlaylistStore {
     ///
     /// Once that event listener has been called, `resolve_multivariant_support` can be called
     /// again, until it returns `true`.
-    fn resolve_multivariant_support(&mut self) -> Result<bool, PlaylistStoreError> {
+    fn resolve_multivariant_support(
+        &mut self,
+    ) -> Result<MultivariantStartupStatus, PlaylistStoreError> {
         if self.multivariant_support_resolved {
-            return Ok(true);
+            return Ok(MultivariantStartupStatus::Ready);
         }
 
         let curr_variant_id = self.curr_variant_id;
         let curr_audio_required = self.curr_audio_id.is_some();
         let curr_video_required = self.curr_video_id.is_some();
         let inferred_audio_codec = self
-            .curr_media_playlist(MediaType::Audio)
-            .and_then(|p| p.external_media_info())
+            .curr_multivariant_media_info(MediaType::Audio)
             .map(|i| i.codec.clone());
         let inferred_video_codec = self
-            .curr_media_playlist(MediaType::Video)
-            .and_then(|p| p.external_media_info())
+            .curr_multivariant_media_info(MediaType::Video)
             .map(|i| i.codec.clone());
-
-        let is_multivariant_support_resolved;
 
         let playlist = match &self.playlist {
             TopLevelPlaylist::Multivariant(playlist) => playlist,
             TopLevelPlaylist::DirectMedia(_) => {
-                return Ok(true);
+                return Ok(MultivariantStartupStatus::Ready);
             }
         };
 
@@ -290,18 +306,15 @@ impl PlaylistStore {
 
         if curr_variant_support == Some(false) {
             if let Some(variant_id) = self.next_best_variant_id() {
-                // XXX TODO: No variantUpdate event triggered when we do that here... We should
-                // probably return the issue to the dispatcher instead?
-                self.set_curr_variant_and_media_id(variant_id);
                 self.multivariant_support_resolved = false;
-                return Ok(false);
+                return Ok(MultivariantStartupStatus::VariantSwitchNeeded { variant_id });
             } else {
                 Logger::error("PS: No supported variant in the given MultivariantPlaylist");
                 return Err(PlaylistStoreError::NoSupportedVariant);
             }
         }
 
-        is_multivariant_support_resolved =
+        let is_multivariant_support_resolved =
             current_variant_resolved && curr_variant_support == Some(true);
 
         self.multivariant_support_resolved = is_multivariant_support_resolved;
@@ -311,7 +324,11 @@ impl PlaylistStore {
         } else {
             Logger::info("PS: Current multivariant startup path still needs support resolution");
         }
-        Ok(is_multivariant_support_resolved)
+        if is_multivariant_support_resolved {
+            Ok(MultivariantStartupStatus::Ready)
+        } else {
+            Ok(MultivariantStartupStatus::AwaitingSupportCheck)
+        }
     }
 
     /// Returns the list of tuples listing loaded media playlists.
@@ -403,8 +420,7 @@ impl PlaylistStore {
     pub(crate) fn current_codec(&self, media_type: MediaType) -> Option<String> {
         match &self.playlist {
             TopLevelPlaylist::Multivariant(_) => self
-                .curr_media_playlist(media_type)
-                .and_then(|playlist| playlist.external_media_info())
+                .curr_multivariant_media_info(media_type)
                 .map(|info| info.codec.clone())
                 .or_else(|| self.curr_variant()?.codecs(media_type)),
             TopLevelPlaylist::DirectMedia(playlist) => playlist
@@ -417,8 +433,7 @@ impl PlaylistStore {
     pub(crate) fn current_mime_type(&self, media_type: MediaType) -> Option<String> {
         match &self.playlist {
             TopLevelPlaylist::Multivariant(_) => self
-                .curr_media_playlist(media_type)
-                .and_then(|playlist| playlist.external_media_info())
+                .curr_multivariant_media_info(media_type)
                 .map(|info| info.mime_type.clone())
                 .or_else(|| {
                     self.curr_media_playlist(media_type)
@@ -480,8 +495,13 @@ impl PlaylistStore {
                 }
             }
             TopLevelPlaylist::Multivariant(_) => match self.resolve_multivariant_support()? {
-                true => Ok(StartupStatus::Ready),
-                false => Ok(StartupStatus::AwaitingSupportCheck),
+                MultivariantStartupStatus::Ready => Ok(StartupStatus::Ready),
+                MultivariantStartupStatus::AwaitingSupportCheck => {
+                    Ok(StartupStatus::AwaitingSupportCheck)
+                }
+                MultivariantStartupStatus::VariantSwitchNeeded { variant_id } => {
+                    Ok(StartupStatus::VariantSwitchNeeded { variant_id })
+                }
             },
         }
     }
@@ -517,13 +537,16 @@ impl PlaylistStore {
             MediaType::Audio => self.curr_audio_id.as_ref(),
             MediaType::Video => self.curr_video_id.as_ref(),
         };
-        let (Some(wanted_id), TopLevelPlaylist::Multivariant(playlist)) =
-            (wanted_id, &mut self.playlist)
-        else {
+        let Some(wanted_id) = wanted_id else {
             return;
         };
-        if let Some(media_playlist) = playlist.media_playlist_mut(wanted_id) {
-            media_playlist.set_external_media_info(media_info);
+        let entry = self
+            .multivariant_media_info
+            .entry(wanted_id.clone())
+            .or_default();
+        match media_type {
+            MediaType::Audio => entry.audio = Some(media_info),
+            MediaType::Video => entry.video = Some(media_info),
         }
     }
 
@@ -1058,6 +1081,21 @@ impl PlaylistStore {
         self.multivariant_support_resolved = false;
     }
 
+    pub(crate) fn switch_startup_variant(&mut self, variant_id: u32) -> Vec<MediaType> {
+        let prev_audio_id = self.curr_audio_id.clone();
+        let prev_video_id = self.curr_video_id.clone();
+        self.set_curr_variant_and_media_id(variant_id);
+
+        let mut changed_media_types = Vec::new();
+        if self.curr_audio_id != prev_audio_id {
+            changed_media_types.push(MediaType::Audio);
+        }
+        if self.curr_video_id != prev_video_id {
+            changed_media_types.push(MediaType::Video);
+        }
+        changed_media_types
+    }
+
     fn next_best_variant_id(&self) -> Option<u32> {
         if let Some(id) = best_variant_id(
             self.selectable_variants_for_curr_track().into_iter(),
@@ -1075,6 +1113,15 @@ impl PlaylistStore {
 
     fn set_variant_support(&mut self, variant_id: u32, supported: bool) {
         self.variant_support.insert(variant_id, supported);
+    }
+
+    fn curr_multivariant_media_info(&self, media_type: MediaType) -> Option<&DirectMediaInfo> {
+        let playlist_id = self.curr_media_playlist_id(media_type)?;
+        let info = self.multivariant_media_info.get(playlist_id)?;
+        match media_type {
+            MediaType::Audio => info.audio.as_ref(),
+            MediaType::Video => info.video.as_ref(),
+        }
     }
 }
 
@@ -1194,4 +1241,69 @@ pub(crate) enum PlaylistStoreError {
     // XXX TODO: We deleted MissingSelectedStreamMetadata. See if that broke the API contract
     #[error("No supported startup stream was found for the current content")]
     UnsupportedStartupStream,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PlaylistStore, StartupStatus};
+    use crate::{
+        bindings::MediaType,
+        parser::{DirectMediaInfo, TopLevelPlaylist},
+        utils::url::Url,
+    };
+
+    fn parse_url(url: &str) -> Url {
+        Url::new(url.to_string())
+    }
+
+    #[test]
+    fn shared_multivariant_playlist_keeps_probe_metadata_per_media_type() {
+        let multivariant = r#"#EXTM3U
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aud",NAME="Main",DEFAULT=YES,AUTOSELECT=YES
+#EXT-X-STREAM-INF:BANDWIDTH=1000,AUDIO="aud"
+https://example.com/media.m3u8
+"#;
+        let media = r#"#EXTM3U
+#EXT-X-TARGETDURATION:4
+#EXTINF:4,
+seg.ts
+"#;
+
+        let playlist = TopLevelPlaylist::parse(
+            multivariant.as_bytes(),
+            parse_url("https://example.com/master.m3u8"),
+        )
+        .unwrap();
+        let mut store = PlaylistStore::try_new(playlist, 10_000.).unwrap();
+        let shared_id = store
+            .curr_media_playlist_id(MediaType::Audio)
+            .cloned()
+            .unwrap();
+        store
+            .update_media_playlist(
+                &shared_id,
+                media.as_bytes(),
+                parse_url("https://example.com/media.m3u8"),
+            )
+            .unwrap();
+
+        store.set_multivariant_media_info(
+            MediaType::Audio,
+            DirectMediaInfo {
+                mime_type: "audio/mp4".to_string(),
+                media_type: MediaType::Audio,
+                codec: "mp4a.40.2".to_string(),
+            },
+        );
+
+        assert_eq!(store.current_codec(MediaType::Audio).as_deref(), Some("mp4a.40.2"));
+        assert_eq!(store.current_codec(MediaType::Video), None);
+        match store.startup_status(0.).unwrap() {
+            StartupStatus::NeedsProbes(probes) => {
+                assert_eq!(probes.len(), 1);
+                assert_eq!(probes[0].1, Some(MediaType::Video));
+            }
+            _ => panic!("expected a remaining video probe"),
+        }
+    }
 }

--- a/src/rs-core/playlist_store/mod.rs
+++ b/src/rs-core/playlist_store/mod.rs
@@ -194,14 +194,9 @@ impl PlaylistStore {
             return Ok(true);
         }
 
-        let playlist = match &self.playlist {
-            TopLevelPlaylist::Multivariant(playlist) => playlist,
-            TopLevelPlaylist::DirectMedia(_) => {
-                return Ok(true);
-            }
-        };
-
         let curr_variant_id = self.curr_variant_id;
+        let curr_audio_required = self.curr_audio_id.is_some();
+        let curr_video_required = self.curr_video_id.is_some();
         let inferred_audio_codec = self
             .curr_media_playlist(MediaType::Audio)
             .and_then(|p| p.external_media_info())
@@ -211,74 +206,76 @@ impl PlaylistStore {
             .and_then(|p| p.external_media_info())
             .map(|i| i.codec.clone());
 
-        // For each variant, in order:
-        // - Some(true) -> Codec is known to be supported
-        // - Some(false) -> Codec is known to be unsupported
-        // - None -> We don't know yet
-        let variants_support: Vec<Option<bool>> = playlist
-            .all_variants()
-            .iter()
-            .map(|v| -> Result<Option<bool>, PlaylistStoreError> {
-                // If support was already determined for this variant, reuse it.
-                if let Some(supported) = v.supported() {
-                    return Ok(Some(supported));
-                }
+        let is_multivariant_support_resolved;
 
-                let mut variant_is_supported = false;
-                for mt in [MediaType::Video, MediaType::Audio] {
-                    // Try to get the codec from the variant directly, falling back to
-                    // the inferred codec if this is the current variant.
-                    let codec = v.codecs(mt).or_else(|| {
-                        if Some(v.id()) == curr_variant_id {
-                            match mt {
-                                MediaType::Audio => inferred_audio_codec.clone(),
-                                MediaType::Video => inferred_video_codec.clone(),
-                            }
-                        } else {
-                            None
-                        }
-                    });
-
-                    if let Some(codec) = codec {
-                        match jsIsTypeSupported(mt, &codec) {
-                            // Codec is explicitly unsupported: the whole variant is out.
-                            Some(false) => return Ok(Some(false)),
-                            // Codec is supported: keep going.
-                            Some(true) => variant_is_supported = true,
-                            // Support cannot be determined yet: signal unresolved and bail.
-                            None => return Ok(None),
-                        }
-                    }
-                }
-
-                Ok(variant_is_supported.then_some(true)) // `None` if no codec is known
-            })
-            .collect::<Result<Vec<_>, PlaylistStoreError>>()?;
-
+        // Borrow playlist immutably first to get the mutable reference after
         let playlist = match &mut self.playlist {
             TopLevelPlaylist::Multivariant(playlist) => playlist,
-            TopLevelPlaylist::DirectMedia(_) => unreachable!(),
+            TopLevelPlaylist::DirectMedia(_) => {
+                return Ok(true);
+            }
         };
 
-        let is_multivariant_support_resolved = !variants_support.contains(&None);
+        let mut all_resolved = true;
+        'variant: for v in playlist.variants_mut().iter_mut() {
+            // If support was already determined for this variant, reuse it.
+            if v.supported().is_some() {
+                continue;
+            }
 
-        // Re-iterate, now mutably
-        // NOTE: `all_variants()` and `variants_mut()` return variants in the same order;
-        // `zip` here relies on that invariant.
-        playlist
-            .variants_mut()
-            .iter_mut()
-            .zip(variants_support)
-            .for_each(|(v, support)| {
-                if v.supported().is_some() {
-                    return;
+            let mut variant_is_supported = false;
+            let is_current_variant = Some(v.id()) == curr_variant_id;
+            let mut saw_codec = false;
+
+            for mt in [MediaType::Video, MediaType::Audio] {
+                let codec = v.codecs(mt).or_else(|| {
+                    if is_current_variant {
+                        match mt {
+                            MediaType::Audio => inferred_audio_codec.clone(),
+                            MediaType::Video => inferred_video_codec.clone(),
+                        }
+                    } else {
+                        None
+                    }
+                });
+
+                let Some(codec) = codec else {
+                    let media_required = is_current_variant
+                        && match mt {
+                            MediaType::Audio => curr_audio_required,
+                            MediaType::Video => curr_video_required,
+                        };
+                    if media_required {
+                        all_resolved = false;
+                        continue 'variant;
+                    }
+                    continue;
+                };
+                saw_codec = true;
+
+                match jsIsTypeSupported(mt, &codec) {
+                    Some(false) => {
+                        v.update_support(false);
+                        continue 'variant;
+                    }
+                    Some(true) => variant_is_supported = true,
+                    None => {
+                        all_resolved = false;
+                        continue 'variant;
+                    }
                 }
-                if let Some(support) = support {
-                    v.update_support(support);
-                }
-            });
+            }
+
+            if variant_is_supported {
+                v.update_support(true);
+            } else if !saw_codec {
+                all_resolved = false;
+            }
+        }
 
         // If any variant returned None, multi-variant support is not yet resolved.
+        is_multivariant_support_resolved = all_resolved;
+
         self.multivariant_support_resolved = is_multivariant_support_resolved;
 
         if is_multivariant_support_resolved {

--- a/src/rs-core/requester/mod.rs
+++ b/src/rs-core/requester/mod.rs
@@ -23,7 +23,7 @@ pub(crate) enum RequestLaneTag {
 }
 
 impl RequestLaneTag {
-    fn from_media_type(media_type: MediaType) -> Self {
+    pub(crate) fn from_media_type(media_type: MediaType) -> Self {
         match media_type {
             MediaType::Audio => Self::Audio,
             MediaType::Video => Self::Video,

--- a/src/rs-core/requester/mod.rs
+++ b/src/rs-core/requester/mod.rs
@@ -509,12 +509,18 @@ impl Requester {
         self.request_segment_now(url, byte_range, lane_tag, time_info, caller_id);
     }
 
+    /// Prevent new requests from being started until `unlock_segment_requests` is called.
+    ///
+    /// This allows to schedule multiple segment request at once, then allowing the `Requester`'s
+    /// priorization algorithm take care of which request to do first, instead of just doing
+    /// immediately the first one that is scheduled.
     pub(crate) fn lock_segment_requests(&mut self) -> bool {
         let was_locked = self.segment_request_locked;
         self.segment_request_locked = true;
         was_locked
     }
 
+    /// Allow new requests to be started again (after having called `lock_segment_requests`).
     pub(crate) fn unlock_segment_requests(&mut self) {
         self.segment_request_locked = false;
         self.check_segment_queue();


### PR DESCRIPTION
I recently added support for direct-media playlist (e.g. playing an HLS content by directly giving its media playlist URL and not going through the multivariant playlist).

One of the main complexities there was that we do not know in advance the codec, container or media type of such media.

This lead to the necessity to load the initial segment to "probe" its metadata, whereas media streaming players generally prefer to test support before beginning to load the corresponding content (thus preventing the unnecessary load of a segment we could already have known is not supported).

---

Anyway now that this was done, I thought that the same "probe" logic could be used for even multivariant playlists who do not announce their codecs, which is legal as per the HLS spec (it's only a SHOULD, not a MUST).

It does seem relatively rare (thankfully), but some example stream online show that behavior, like: https://test-streams.mux.dev/test_001/stream.m3u8

---

There are many supplementary complexities there though:

- unlike direct media, we may have to test multiple media playlist at once, e.g. one for video and one for audio
- Depending on the probe result, we may need to automatically decide to switch to the next variant (if the first was found out to be unsupported)
- Unlike media playlist, we probably don't want to do that only on startup. It is preferable to probe "lazily" as the variant is first selected as a candidate.
- Many other consideration changes because the model is not the same with variants: we may have a audio track change, a variant lock etc.